### PR TITLE
Level Export feature

### DIFF
--- a/LibReplanetizer/Level Objects/Engine/TerrainFragment.cs
+++ b/LibReplanetizer/Level Objects/Engine/TerrainFragment.cs
@@ -48,6 +48,9 @@ namespace LibReplanetizer.LevelObjects
             off_2C = ReadUint(tfragBlock, offset + 0x2C);
 
             model = new TerrainModel(fs, head, tfragBlock, num);
+
+            modelID = model.id;
+
             modelMatrix = Matrix4.Identity;
         }
 

--- a/LibReplanetizer/Models/TerrainModel.cs
+++ b/LibReplanetizer/Models/TerrainModel.cs
@@ -16,6 +16,7 @@ namespace LibReplanetizer.Models
         public TerrainModel(FileStream fs, TerrainHead head, byte[] tfragBlock, int num)
         {
             id = getIDAssigned();
+            size = 1.0f;
 
             int offset = num * 0x30;
             int texturePointer = ReadInt(tfragBlock, offset + 0x10);

--- a/LibReplanetizer/Models/TerrainModel.cs
+++ b/LibReplanetizer/Models/TerrainModel.cs
@@ -8,10 +8,15 @@ namespace LibReplanetizer.Models
 {
     public class TerrainModel : Model
     {
+        // Don't use this directly, call getIDAssigned() instead to retrieve an ID
+        private static short STATIC_ID = 0;
+
         public List<uint> off_0C = new List<uint>();    // Something to do with lighting
         int faceCount;
         public TerrainModel(FileStream fs, TerrainHead head, byte[] tfragBlock, int num)
         {
+            id = getIDAssigned();
+
             int offset = num * 0x30;
             int texturePointer = ReadInt(tfragBlock, offset + 0x10);
             int textureCount = ReadInt(tfragBlock, offset + 0x14);
@@ -57,6 +62,11 @@ namespace LibReplanetizer.Models
             }
 
             return outBytes;
+        }
+
+        private static short getIDAssigned()
+        {
+            return STATIC_ID++;
         }
 
     }

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -751,6 +751,13 @@ namespace LibReplanetizer
             }
         }
 
+        /*
+         * Different Modes for Level Export:
+         * - Separate: Exports every ModelObject as is
+         * - Combined: Combines all ModelObjects into one mesh
+         * - Typewise: Combines all ModelObjects of the same type (Tie, Shrubs etc.) into one mesh
+         * - Materialwise: Combines all faces using the same material/texture into one mesh
+         */
         public enum WriterLevelMode{
             Separate,
             Combined,

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -216,7 +216,7 @@ namespace LibReplanetizer
         {
             for (int i = 0; i < model.textureConfig.Count; i++)
             {
-                int modelTextureID = model.textureConfig[0].ID;
+                int modelTextureID = model.textureConfig[i].ID;
                 if (!usedMtls.Contains(modelTextureID))
                 {
                     MTLfs.WriteLine("newmtl mtl_" + modelTextureID);
@@ -319,7 +319,7 @@ namespace LibReplanetizer
                 foreach (TerrainFragment t in terrain)
                 {
                     OBJfs.WriteLine("o Object_" + t.model.id.ToString("X4"));
-                    if (t.model.textureConfig != null)
+                    if (t.model.textureConfig != null && settings.exportMTLFile)
                         OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
                     faceOffset += writeObjectData(OBJfs, t.model, faceOffset, Vector3.Zero, Vector3.One, Quaternion.Identity);
                     if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
@@ -330,7 +330,7 @@ namespace LibReplanetizer
                     foreach (Tie t in level.ties)
                     {
                         OBJfs.WriteLine("o Object_" + t.model.id.ToString("X4"));
-                        if (t.model.textureConfig != null)
+                        if (t.model.textureConfig != null && settings.exportMTLFile)
                             OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
                         faceOffset += writeObjectData(OBJfs, t.model, faceOffset, t.position, t.scale, t.rotation);
                         if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
@@ -342,7 +342,7 @@ namespace LibReplanetizer
                     foreach (Shrub t in level.shrubs)
                     {
                         OBJfs.WriteLine("o Object_" + t.model.id.ToString("X4"));
-                        if (t.model.textureConfig != null)
+                        if (t.model.textureConfig != null && settings.exportMTLFile)
                             OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
                         faceOffset += writeObjectData(OBJfs, t.model, faceOffset, t.position, t.scale, t.rotation);
                         if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
@@ -354,7 +354,7 @@ namespace LibReplanetizer
                     foreach (Moby t in level.mobs)
                     {
                         OBJfs.WriteLine("o Object_" + t.model.id.ToString("X4"));
-                        if (t.model.textureConfig != null)
+                        if (t.model.textureConfig != null && settings.exportMTLFile)
                             OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
                         faceOffset += writeObjectData(OBJfs, t.model, faceOffset, t.position, t.scale, t.rotation);
                         if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
@@ -392,6 +392,8 @@ namespace LibReplanetizer
                 OBJfs.WriteLine("o Object_CombinedLevel");
                 foreach (TerrainFragment t in terrain)
                 {
+                    if (t.model.textureConfig != null && settings.exportMTLFile)
+                        OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
                     faceOffset += writeObjectData(OBJfs, t.model, faceOffset, Vector3.Zero, Vector3.One, Quaternion.Identity);
                     if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
                 }
@@ -400,6 +402,8 @@ namespace LibReplanetizer
                 {
                     foreach (Tie t in level.ties)
                     {
+                        if (t.model.textureConfig != null && settings.exportMTLFile)
+                            OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
                         faceOffset += writeObjectData(OBJfs, t.model, faceOffset, t.position, t.scale, t.rotation);
                         if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
                     }
@@ -409,6 +413,8 @@ namespace LibReplanetizer
                 {
                     foreach (Shrub t in level.shrubs)
                     {
+                        if (t.model.textureConfig != null && settings.exportMTLFile)
+                            OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
                         faceOffset += writeObjectData(OBJfs, t.model, faceOffset, t.position, t.scale, t.rotation);
                         if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
                     }
@@ -418,6 +424,8 @@ namespace LibReplanetizer
                 {
                     foreach (Moby t in level.mobs)
                     {
+                        if (t.model.textureConfig != null && settings.exportMTLFile)
+                            OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
                         faceOffset += writeObjectData(OBJfs, t.model, faceOffset, t.position, t.scale, t.rotation);
                         if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
                     }
@@ -429,8 +437,6 @@ namespace LibReplanetizer
 
         private static void WriteObjTypewise(string fileName, Level level, WriterLevelSettings settings)
         {
-            throw new NotImplementedException();
-
             string pathName = Path.GetDirectoryName(fileName);
             string fileNameNoExtension = Path.GetFileNameWithoutExtension(fileName);
 
@@ -443,12 +449,131 @@ namespace LibReplanetizer
                     terrain.AddRange(level.terrainChunks[i]);
                 }
             }
+
+            StreamWriter MTLfs = null;
+
+            if (settings.exportMTLFile) MTLfs = new StreamWriter(pathName + "\\" + fileNameNoExtension + ".mtl");
+
+            using (StreamWriter OBJfs = new StreamWriter(fileName))
+            {
+                int faceOffset = 0;
+                List<int> usedMtls = new List<int>();
+
+                if (terrain.Count != 0)
+                {
+                    OBJfs.WriteLine("o Object_Terrain");
+                }
+
+                foreach (TerrainFragment t in terrain)
+                {
+                    if (t.model.textureConfig != null && settings.exportMTLFile)
+                        OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
+                    faceOffset += writeObjectData(OBJfs, t.model, faceOffset, Vector3.Zero, Vector3.One, Quaternion.Identity);
+                    if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
+                }
+
+                if (settings.writeTies)
+                {
+                    OBJfs.WriteLine("o Object_Ties");
+
+                    foreach (Tie t in level.ties)
+                    {
+                        if (t.model.textureConfig != null && settings.exportMTLFile)
+                            OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
+                        faceOffset += writeObjectData(OBJfs, t.model, faceOffset, t.position, t.scale, t.rotation);
+                        if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
+                    }
+                }
+
+                if (settings.writeShrubs)
+                {
+                    OBJfs.WriteLine("o Object_Shrubs");
+
+                    foreach (Shrub t in level.shrubs)
+                    {
+                        if (t.model.textureConfig != null && settings.exportMTLFile)
+                            OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
+                        faceOffset += writeObjectData(OBJfs, t.model, faceOffset, t.position, t.scale, t.rotation);
+                        if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
+                    }
+                }
+
+                if (settings.writeMobies)
+                {
+                    OBJfs.WriteLine("o Object_Mobies");
+
+                    foreach (Moby t in level.mobs)
+                    {
+                        if (t.model.textureConfig != null && settings.exportMTLFile)
+                            OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
+                        faceOffset += writeObjectData(OBJfs, t.model, faceOffset, t.position, t.scale, t.rotation);
+                        if (settings.exportMTLFile) writeObjectMaterial(MTLfs, t.model, usedMtls);
+                    }
+                }
+            }
+
+            if (settings.exportMTLFile) MTLfs.Dispose();
+        }
+
+        private static int SeparateModelObjectByMaterial(ModelObject t, List<Tuple<int, int, int>>[] faces, List<Vector3> vertices, List<Vector3> normals, List<Vector2> uvs, int faceOffset)
+        {
+            Model model = t.model;
+
+            int vertexCount = model.vertexBuffer.Length / 8;
+
+            for (int x = 0; x < vertexCount; x++)
+            {
+                Vector3 v = new Vector3(
+                    model.size * t.scale.X * model.vertexBuffer[(x * 0x08) + 0x0],
+                    model.size * t.scale.Y * model.vertexBuffer[(x * 0x08) + 0x1],
+                    model.size * t.scale.Z * model.vertexBuffer[(x * 0x08) + 0x2]);
+                v = rotate(t.rotation, v);
+                v += t.position;
+
+                vertices.Add(v);
+
+                normals.Add(new Vector3(
+                    model.vertexBuffer[(x * 0x08) + 0x3],
+                    model.vertexBuffer[(x * 0x08) + 0x4],
+                    model.vertexBuffer[(x * 0x08) + 0x5]));
+
+                uvs.Add(new Vector2(
+                    model.vertexBuffer[(x * 0x08) + 0x6],
+                    1f - model.vertexBuffer[(x * 0x08) + 0x7]));
+            }
+
+            int textureNum = 0;
+            for (int i = 0; i < model.indexBuffer.Length / 3; i++)
+            {
+                int triIndex = i * 3;
+                int materialID = 0;
+
+                if ((model.textureConfig != null) && (textureNum < model.textureConfig.Count))
+                {
+                    if ((textureNum + 1 < model.textureConfig.Count) && (triIndex >= model.textureConfig[textureNum + 1].start))
+                    {
+                        textureNum++;
+                    }
+
+                    materialID = model.textureConfig[textureNum].ID;
+                }
+
+                if (materialID >= faces.Length || materialID < 0)
+                {
+                    materialID = 0;
+                }
+
+                faces[materialID].Add(new Tuple<int, int, int>(
+                    model.indexBuffer[triIndex + 0] + 1 + faceOffset,
+                    model.indexBuffer[triIndex + 1] + 1 + faceOffset,
+                    model.indexBuffer[triIndex + 2] + 1 + faceOffset));
+            }
+
+            return vertexCount;
         }
 
         private static void WriteObjMaterialwise(string fileName, Level level, WriterLevelSettings settings)
         {
-            throw new NotImplementedException();
-
             string pathName = Path.GetDirectoryName(fileName);
             string fileNameNoExtension = Path.GetFileNameWithoutExtension(fileName);
 
@@ -459,6 +584,150 @@ namespace LibReplanetizer
                 if (settings.chunksSelected[i])
                 {
                     terrain.AddRange(level.terrainChunks[i]);
+                }
+            }
+
+            int materialCount = level.textures.Count;
+
+            List<Tuple<int,int,int>>[] faces = new List<Tuple<int,int,int>>[materialCount];
+
+            for (int i = 0; i < materialCount; i++)
+            {
+                faces[i] = new List<Tuple<int,int,int>>();
+            }
+
+            List<Vector3> vertices = new List<Vector3>();
+            List<Vector3> normals = new List<Vector3>();
+            List<Vector2> uvs = new List<Vector2>();
+
+            int faceOffset = 0;
+
+            foreach (TerrainFragment t in terrain)
+            {
+                Model model = t.model;
+
+                int vertexCount = model.vertexBuffer.Length / 8;
+
+                for (int x = 0; x < vertexCount; x++)
+                {
+                    vertices.Add(new Vector3(
+                        model.vertexBuffer[(x * 0x08) + 0x0],
+                        model.vertexBuffer[(x * 0x08) + 0x1],
+                        model.vertexBuffer[(x * 0x08) + 0x2]));
+
+                    normals.Add(new Vector3(
+                        model.vertexBuffer[(x * 0x08) + 0x3],
+                        model.vertexBuffer[(x * 0x08) + 0x4],
+                        model.vertexBuffer[(x * 0x08) + 0x5]));
+
+                    uvs.Add(new Vector2(
+                        model.vertexBuffer[(x * 0x08) + 0x6],
+                        1f - model.vertexBuffer[(x * 0x08) + 0x7]));
+                }
+
+                int textureNum = 0;
+                for (int i = 0; i < model.indexBuffer.Length / 3; i++)
+                {
+                    int triIndex = i * 3;
+                    int materialID = 0;
+
+                    if ((model.textureConfig != null) && (textureNum < model.textureConfig.Count))
+                    {
+                        if ((textureNum + 1 < model.textureConfig.Count) && (triIndex >= model.textureConfig[textureNum + 1].start))
+                        {
+                            textureNum++;
+                        }
+
+                        materialID = model.textureConfig[textureNum].ID;
+                    }
+
+                    faces[materialID].Add(new Tuple<int, int, int>(
+                        model.indexBuffer[triIndex + 0] + 1 + faceOffset,
+                        model.indexBuffer[triIndex + 1] + 1 + faceOffset,
+                        model.indexBuffer[triIndex + 2] + 1 + faceOffset));
+                }
+
+                faceOffset += vertexCount;
+            }
+
+            if (settings.writeTies)
+            {
+                foreach (Tie t in level.ties)
+                {
+                    faceOffset += SeparateModelObjectByMaterial(t, faces, vertices, normals, uvs, faceOffset);
+                }
+            }
+
+            if (settings.writeShrubs)
+            {
+                foreach (Shrub t in level.shrubs)
+                {
+                    faceOffset += SeparateModelObjectByMaterial(t, faces, vertices, normals, uvs, faceOffset);
+                }
+            }
+
+            if (settings.writeMobies)
+            {
+                foreach (Moby t in level.mobs)
+                {
+                    faceOffset += SeparateModelObjectByMaterial(t, faces, vertices, normals, uvs, faceOffset);
+                }
+            }
+
+            if (settings.exportMTLFile)
+            {
+                using (StreamWriter MTLfs = new StreamWriter(pathName + "\\" + fileNameNoExtension + ".mtl"))
+                {
+                    for (int i = 0; i < materialCount; i++)
+                    {
+                        if (faces[i].Count != 0)
+                        {
+                            MTLfs.WriteLine("newmtl mtl_" + i);
+                            MTLfs.WriteLine("Ns 1000");
+                            MTLfs.WriteLine("Ka 1.000000 1.000000 1.000000");
+                            MTLfs.WriteLine("Kd 1.000000 1.000000 1.000000");
+                            MTLfs.WriteLine("Ni 1.000000");
+                            MTLfs.WriteLine("d 1.000000");
+                            MTLfs.WriteLine("illum 1");
+                            MTLfs.WriteLine("map_Kd tex_" + i + ".png");
+                        }
+                    }
+                }
+            }
+
+
+            using (StreamWriter OBJfs = new StreamWriter(fileName))
+            {
+                foreach (Vector3 v in vertices)
+                {
+                    OBJfs.WriteLine("v " + v.X.ToString("G") + " " + v.Y.ToString("G") + " " + v.Z.ToString("G"));
+                }
+
+                foreach (Vector3 vn in normals)
+                {
+                    OBJfs.WriteLine("vn " + vn.X.ToString("G") + " " + vn.Y.ToString("G") + " " + vn.Z.ToString("G"));
+                }
+
+                foreach (Vector2 vt in uvs)
+                {
+                    OBJfs.WriteLine("vt " + vt.X.ToString("G") + " " + vt.Y.ToString("G"));
+                }
+                
+                for (int i = 0; i < materialCount; i++) 
+                {
+                    List<Tuple<int, int, int>> list = faces[i];
+
+                    if (list.Count == 0) continue;
+
+                    OBJfs.WriteLine("o Object_Material_" + i);
+
+                    if (settings.exportMTLFile)
+                        OBJfs.WriteLine("mtllib " + fileNameNoExtension + ".mtl");
+
+                    foreach (Tuple<int,int,int> t in list)
+                    {
+                        OBJfs.WriteLine("f " + (t.Item1 + "/" + t.Item1 + "/" + t.Item1) + " " + (t.Item2 + "/" + t.Item2 + "/" + t.Item2) + " " + (t.Item3 + "/" + t.Item3 + "/" + t.Item3));
+                    }
                 }
             }
         }

--- a/Replanetizer/CustomControls/CustomGLControl.cs
+++ b/Replanetizer/CustomControls/CustomGLControl.cs
@@ -168,10 +168,6 @@ namespace RatchetEdit
             this.level = level;
             LoadLevelTextures();
             LoadCollisionBOs();
-            enableMoby = true;
-            enableTie = true;
-            enableShrub = true;
-            enableTerrain = true;
 
             Moby ratchet = level.mobs[0];
 

--- a/Replanetizer/Forms/LevelExportWindow.Designer.cs
+++ b/Replanetizer/Forms/LevelExportWindow.Designer.cs
@@ -43,10 +43,6 @@ namespace RatchetEdit.Forms
             this.shrubsCheckbox = new System.Windows.Forms.CheckBox();
             this.mobiesCheckbox = new System.Windows.Forms.CheckBox();
             this.label6 = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
-            this.label8 = new System.Windows.Forms.Label();
-            this.label9 = new System.Windows.Forms.Label();
-            this.label10 = new System.Windows.Forms.Label();
             this.chunk0Checkbox = new System.Windows.Forms.CheckBox();
             this.chunk1Checkbox = new System.Windows.Forms.CheckBox();
             this.chunk2Checkbox = new System.Windows.Forms.CheckBox();
@@ -57,12 +53,12 @@ namespace RatchetEdit.Forms
             // 
             // exportButton
             // 
-            this.exportButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.exportButton.Location = new System.Drawing.Point(264, 625);
-            this.exportButton.MaximumSize = new System.Drawing.Size(200, 39);
-            this.exportButton.MinimumSize = new System.Drawing.Size(200, 39);
+            this.exportButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.exportButton.Location = new System.Drawing.Point(214, 365);
+            this.exportButton.MaximumSize = new System.Drawing.Size(150, 28);
+            this.exportButton.MinimumSize = new System.Drawing.Size(150, 28);
             this.exportButton.Name = "exportButton";
-            this.exportButton.Size = new System.Drawing.Size(200, 39);
+            this.exportButton.Size = new System.Drawing.Size(150, 28);
             this.exportButton.TabIndex = 2;
             this.exportButton.Text = "Export";
             this.exportButton.UseVisualStyleBackColor = true;
@@ -76,30 +72,30 @@ namespace RatchetEdit.Forms
             // meshModeCombobox
             // 
             this.meshModeCombobox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.meshModeCombobox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.meshModeCombobox.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
             this.meshModeCombobox.FormattingEnabled = true;
             this.meshModeCombobox.Items.AddRange(new object[] {
             "Separated",
             "Combined",
             "Typewise",
             "Materialwise"});
-            this.meshModeCombobox.Location = new System.Drawing.Point(264, 39);
+            this.meshModeCombobox.Location = new System.Drawing.Point(214, 25);
             this.meshModeCombobox.Margin = new System.Windows.Forms.Padding(0);
-            this.meshModeCombobox.MaximumSize = new System.Drawing.Size(200, 0);
-            this.meshModeCombobox.MinimumSize = new System.Drawing.Size(200, 0);
+            this.meshModeCombobox.MaximumSize = new System.Drawing.Size(150, 0);
+            this.meshModeCombobox.MinimumSize = new System.Drawing.Size(150, 0);
             this.meshModeCombobox.Name = "meshModeCombobox";
-            this.meshModeCombobox.Size = new System.Drawing.Size(200, 39);
+            this.meshModeCombobox.Size = new System.Drawing.Size(150, 28);
             this.meshModeCombobox.TabIndex = 3;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(25, 39);
-            this.label1.MaximumSize = new System.Drawing.Size(200, 39);
-            this.label1.MinimumSize = new System.Drawing.Size(200, 39);
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(25, 25);
+            this.label1.MaximumSize = new System.Drawing.Size(150, 28);
+            this.label1.MinimumSize = new System.Drawing.Size(150, 28);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(200, 39);
+            this.label1.Size = new System.Drawing.Size(150, 28);
             this.label1.TabIndex = 4;
             this.label1.Text = "Mesh Mode";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -107,12 +103,12 @@ namespace RatchetEdit.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(25, 97);
-            this.label2.MaximumSize = new System.Drawing.Size(200, 39);
-            this.label2.MinimumSize = new System.Drawing.Size(200, 39);
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(25, 73);
+            this.label2.MaximumSize = new System.Drawing.Size(150, 28);
+            this.label2.MinimumSize = new System.Drawing.Size(150, 28);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(200, 39);
+            this.label2.Size = new System.Drawing.Size(150, 28);
             this.label2.TabIndex = 5;
             this.label2.Text = "Include Ties";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -120,12 +116,12 @@ namespace RatchetEdit.Forms
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(25, 155);
-            this.label3.MaximumSize = new System.Drawing.Size(200, 39);
-            this.label3.MinimumSize = new System.Drawing.Size(200, 39);
+            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.label3.Location = new System.Drawing.Point(25, 121);
+            this.label3.MaximumSize = new System.Drawing.Size(150, 28);
+            this.label3.MinimumSize = new System.Drawing.Size(150, 28);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(200, 39);
+            this.label3.Size = new System.Drawing.Size(150, 28);
             this.label3.TabIndex = 6;
             this.label3.Text = "Include Shrubs";
             this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -133,12 +129,12 @@ namespace RatchetEdit.Forms
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(25, 213);
-            this.label4.MaximumSize = new System.Drawing.Size(200, 39);
-            this.label4.MinimumSize = new System.Drawing.Size(200, 39);
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.label4.Location = new System.Drawing.Point(25, 169);
+            this.label4.MaximumSize = new System.Drawing.Size(150, 28);
+            this.label4.MinimumSize = new System.Drawing.Size(150, 28);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(200, 39);
+            this.label4.Size = new System.Drawing.Size(150, 28);
             this.label4.TabIndex = 7;
             this.label4.Text = "Include Mobies";
             this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -146,24 +142,24 @@ namespace RatchetEdit.Forms
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(25, 271);
-            this.label5.MaximumSize = new System.Drawing.Size(250, 39);
-            this.label5.MinimumSize = new System.Drawing.Size(250, 39);
+            this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.label5.Location = new System.Drawing.Point(25, 217);
+            this.label5.MaximumSize = new System.Drawing.Size(200, 28);
+            this.label5.MinimumSize = new System.Drawing.Size(200, 28);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(250, 39);
+            this.label5.Size = new System.Drawing.Size(200, 28);
             this.label5.TabIndex = 8;
-            this.label5.Text = "Include Chunk 0";
+            this.label5.Text = "Include Terrain Chunks";
             this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // exportProgressBar
             // 
             this.exportProgressBar.BackColor = System.Drawing.SystemColors.Control;
-            this.exportProgressBar.Location = new System.Drawing.Point(25, 625);
-            this.exportProgressBar.MaximumSize = new System.Drawing.Size(200, 39);
-            this.exportProgressBar.MinimumSize = new System.Drawing.Size(200, 39);
+            this.exportProgressBar.Location = new System.Drawing.Point(25, 365);
+            this.exportProgressBar.MaximumSize = new System.Drawing.Size(150, 28);
+            this.exportProgressBar.MinimumSize = new System.Drawing.Size(150, 28);
             this.exportProgressBar.Name = "exportProgressBar";
-            this.exportProgressBar.Size = new System.Drawing.Size(200, 39);
+            this.exportProgressBar.Size = new System.Drawing.Size(150, 28);
             this.exportProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             this.exportProgressBar.TabIndex = 9;
             // 
@@ -174,12 +170,12 @@ namespace RatchetEdit.Forms
             this.tiesCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.tiesCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.tiesCheckbox.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.tiesCheckbox.Location = new System.Drawing.Point(425, 97);
+            this.tiesCheckbox.Location = new System.Drawing.Point(336, 73);
             this.tiesCheckbox.Margin = new System.Windows.Forms.Padding(0);
-            this.tiesCheckbox.MaximumSize = new System.Drawing.Size(39, 39);
-            this.tiesCheckbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.tiesCheckbox.MaximumSize = new System.Drawing.Size(28, 28);
+            this.tiesCheckbox.MinimumSize = new System.Drawing.Size(28, 28);
             this.tiesCheckbox.Name = "tiesCheckbox";
-            this.tiesCheckbox.Size = new System.Drawing.Size(39, 39);
+            this.tiesCheckbox.Size = new System.Drawing.Size(28, 28);
             this.tiesCheckbox.TabIndex = 10;
             this.tiesCheckbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.tiesCheckbox.UseVisualStyleBackColor = false;
@@ -189,14 +185,14 @@ namespace RatchetEdit.Forms
             this.shrubsCheckbox.Appearance = System.Windows.Forms.Appearance.Button;
             this.shrubsCheckbox.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.shrubsCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.shrubsCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.shrubsCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
             this.shrubsCheckbox.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.shrubsCheckbox.Location = new System.Drawing.Point(425, 155);
+            this.shrubsCheckbox.Location = new System.Drawing.Point(336, 121);
             this.shrubsCheckbox.Margin = new System.Windows.Forms.Padding(0);
-            this.shrubsCheckbox.MaximumSize = new System.Drawing.Size(39, 39);
-            this.shrubsCheckbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.shrubsCheckbox.MaximumSize = new System.Drawing.Size(28, 28);
+            this.shrubsCheckbox.MinimumSize = new System.Drawing.Size(28, 28);
             this.shrubsCheckbox.Name = "shrubsCheckbox";
-            this.shrubsCheckbox.Size = new System.Drawing.Size(39, 39);
+            this.shrubsCheckbox.Size = new System.Drawing.Size(28, 28);
             this.shrubsCheckbox.TabIndex = 11;
             this.shrubsCheckbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.shrubsCheckbox.UseVisualStyleBackColor = false;
@@ -206,14 +202,14 @@ namespace RatchetEdit.Forms
             this.mobiesCheckbox.Appearance = System.Windows.Forms.Appearance.Button;
             this.mobiesCheckbox.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.mobiesCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.mobiesCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.mobiesCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
             this.mobiesCheckbox.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.mobiesCheckbox.Location = new System.Drawing.Point(425, 213);
+            this.mobiesCheckbox.Location = new System.Drawing.Point(336, 169);
             this.mobiesCheckbox.Margin = new System.Windows.Forms.Padding(0);
-            this.mobiesCheckbox.MaximumSize = new System.Drawing.Size(39, 39);
-            this.mobiesCheckbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.mobiesCheckbox.MaximumSize = new System.Drawing.Size(28, 28);
+            this.mobiesCheckbox.MinimumSize = new System.Drawing.Size(28, 28);
             this.mobiesCheckbox.Name = "mobiesCheckbox";
-            this.mobiesCheckbox.Size = new System.Drawing.Size(39, 39);
+            this.mobiesCheckbox.Size = new System.Drawing.Size(28, 28);
             this.mobiesCheckbox.TabIndex = 12;
             this.mobiesCheckbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.mobiesCheckbox.UseVisualStyleBackColor = false;
@@ -221,83 +217,32 @@ namespace RatchetEdit.Forms
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label6.Location = new System.Drawing.Point(25, 329);
-            this.label6.MaximumSize = new System.Drawing.Size(250, 39);
-            this.label6.MinimumSize = new System.Drawing.Size(250, 39);
+            this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.label6.Location = new System.Drawing.Point(25, 313);
+            this.label6.MaximumSize = new System.Drawing.Size(150, 28);
+            this.label6.MinimumSize = new System.Drawing.Size(150, 28);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(250, 39);
+            this.label6.Size = new System.Drawing.Size(150, 28);
             this.label6.TabIndex = 13;
-            this.label6.Text = "Include Chunk 1";
+            this.label6.Text = "Include MTL File";
             this.label6.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label7
-            // 
-            this.label7.AutoSize = true;
-            this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label7.Location = new System.Drawing.Point(25, 387);
-            this.label7.MaximumSize = new System.Drawing.Size(250, 39);
-            this.label7.MinimumSize = new System.Drawing.Size(250, 39);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(250, 39);
-            this.label7.TabIndex = 14;
-            this.label7.Text = "Include Chunk 2";
-            this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label8
-            // 
-            this.label8.AutoSize = true;
-            this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label8.Location = new System.Drawing.Point(25, 445);
-            this.label8.MaximumSize = new System.Drawing.Size(250, 39);
-            this.label8.MinimumSize = new System.Drawing.Size(250, 39);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(250, 39);
-            this.label8.TabIndex = 15;
-            this.label8.Text = "Include Chunk 3";
-            this.label8.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label9.Location = new System.Drawing.Point(25, 503);
-            this.label9.MaximumSize = new System.Drawing.Size(250, 39);
-            this.label9.MinimumSize = new System.Drawing.Size(250, 39);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(250, 39);
-            this.label9.TabIndex = 16;
-            this.label9.Text = "Include Chunk 4";
-            this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label10
-            // 
-            this.label10.AutoSize = true;
-            this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label10.Location = new System.Drawing.Point(25, 561);
-            this.label10.MaximumSize = new System.Drawing.Size(250, 39);
-            this.label10.MinimumSize = new System.Drawing.Size(250, 39);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(250, 39);
-            this.label10.TabIndex = 17;
-            this.label10.Text = "Include MTL File";
-            this.label10.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // chunk0Checkbox
             // 
             this.chunk0Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
             this.chunk0Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.chunk0Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chunk0Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk0Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
             this.chunk0Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.chunk0Checkbox.Location = new System.Drawing.Point(425, 271);
+            this.chunk0Checkbox.Location = new System.Drawing.Point(28, 265);
             this.chunk0Checkbox.Margin = new System.Windows.Forms.Padding(0);
-            this.chunk0Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
-            this.chunk0Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk0Checkbox.MaximumSize = new System.Drawing.Size(28, 28);
+            this.chunk0Checkbox.MinimumSize = new System.Drawing.Size(28, 28);
             this.chunk0Checkbox.Name = "chunk0Checkbox";
-            this.chunk0Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk0Checkbox.Size = new System.Drawing.Size(28, 28);
             this.chunk0Checkbox.TabIndex = 18;
-            this.chunk0Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk0Checkbox.Text = "0";
+            this.chunk0Checkbox.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.chunk0Checkbox.UseVisualStyleBackColor = false;
             // 
             // chunk1Checkbox
@@ -305,16 +250,17 @@ namespace RatchetEdit.Forms
             this.chunk1Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
             this.chunk1Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.chunk1Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chunk1Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk1Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
             this.chunk1Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.chunk1Checkbox.Location = new System.Drawing.Point(425, 329);
+            this.chunk1Checkbox.Location = new System.Drawing.Point(105, 265);
             this.chunk1Checkbox.Margin = new System.Windows.Forms.Padding(0);
-            this.chunk1Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
-            this.chunk1Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk1Checkbox.MaximumSize = new System.Drawing.Size(28, 28);
+            this.chunk1Checkbox.MinimumSize = new System.Drawing.Size(28, 28);
             this.chunk1Checkbox.Name = "chunk1Checkbox";
-            this.chunk1Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk1Checkbox.Size = new System.Drawing.Size(28, 28);
             this.chunk1Checkbox.TabIndex = 19;
-            this.chunk1Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk1Checkbox.Text = "1";
+            this.chunk1Checkbox.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.chunk1Checkbox.UseVisualStyleBackColor = false;
             // 
             // chunk2Checkbox
@@ -322,16 +268,17 @@ namespace RatchetEdit.Forms
             this.chunk2Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
             this.chunk2Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.chunk2Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chunk2Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk2Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
             this.chunk2Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.chunk2Checkbox.Location = new System.Drawing.Point(425, 387);
+            this.chunk2Checkbox.Location = new System.Drawing.Point(182, 265);
             this.chunk2Checkbox.Margin = new System.Windows.Forms.Padding(0);
-            this.chunk2Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
-            this.chunk2Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk2Checkbox.MaximumSize = new System.Drawing.Size(28, 28);
+            this.chunk2Checkbox.MinimumSize = new System.Drawing.Size(28, 28);
             this.chunk2Checkbox.Name = "chunk2Checkbox";
-            this.chunk2Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk2Checkbox.Size = new System.Drawing.Size(28, 28);
             this.chunk2Checkbox.TabIndex = 20;
-            this.chunk2Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk2Checkbox.Text = "2";
+            this.chunk2Checkbox.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.chunk2Checkbox.UseVisualStyleBackColor = false;
             // 
             // chunk3Checkbox
@@ -339,16 +286,17 @@ namespace RatchetEdit.Forms
             this.chunk3Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
             this.chunk3Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.chunk3Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chunk3Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk3Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
             this.chunk3Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.chunk3Checkbox.Location = new System.Drawing.Point(425, 445);
+            this.chunk3Checkbox.Location = new System.Drawing.Point(259, 265);
             this.chunk3Checkbox.Margin = new System.Windows.Forms.Padding(0);
-            this.chunk3Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
-            this.chunk3Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk3Checkbox.MaximumSize = new System.Drawing.Size(28, 28);
+            this.chunk3Checkbox.MinimumSize = new System.Drawing.Size(28, 28);
             this.chunk3Checkbox.Name = "chunk3Checkbox";
-            this.chunk3Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk3Checkbox.Size = new System.Drawing.Size(28, 28);
             this.chunk3Checkbox.TabIndex = 21;
-            this.chunk3Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk3Checkbox.Text = "3";
+            this.chunk3Checkbox.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.chunk3Checkbox.UseVisualStyleBackColor = false;
             // 
             // chunk4Checkbox
@@ -356,16 +304,17 @@ namespace RatchetEdit.Forms
             this.chunk4Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
             this.chunk4Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.chunk4Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chunk4Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk4Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
             this.chunk4Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.chunk4Checkbox.Location = new System.Drawing.Point(425, 503);
+            this.chunk4Checkbox.Location = new System.Drawing.Point(336, 265);
             this.chunk4Checkbox.Margin = new System.Windows.Forms.Padding(0);
-            this.chunk4Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
-            this.chunk4Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk4Checkbox.MaximumSize = new System.Drawing.Size(28, 28);
+            this.chunk4Checkbox.MinimumSize = new System.Drawing.Size(28, 28);
             this.chunk4Checkbox.Name = "chunk4Checkbox";
-            this.chunk4Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk4Checkbox.Size = new System.Drawing.Size(28, 28);
             this.chunk4Checkbox.TabIndex = 22;
-            this.chunk4Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk4Checkbox.Text = "4";
+            this.chunk4Checkbox.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.chunk4Checkbox.UseVisualStyleBackColor = false;
             // 
             // mtlCheckbox
@@ -375,12 +324,12 @@ namespace RatchetEdit.Forms
             this.mtlCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.mtlCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.mtlCheckbox.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.mtlCheckbox.Location = new System.Drawing.Point(425, 561);
+            this.mtlCheckbox.Location = new System.Drawing.Point(336, 313);
             this.mtlCheckbox.Margin = new System.Windows.Forms.Padding(0);
-            this.mtlCheckbox.MaximumSize = new System.Drawing.Size(39, 39);
-            this.mtlCheckbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.mtlCheckbox.MaximumSize = new System.Drawing.Size(28, 28);
+            this.mtlCheckbox.MinimumSize = new System.Drawing.Size(28, 28);
             this.mtlCheckbox.Name = "mtlCheckbox";
-            this.mtlCheckbox.Size = new System.Drawing.Size(39, 39);
+            this.mtlCheckbox.Size = new System.Drawing.Size(28, 28);
             this.mtlCheckbox.TabIndex = 23;
             this.mtlCheckbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.mtlCheckbox.UseVisualStyleBackColor = false;
@@ -389,17 +338,13 @@ namespace RatchetEdit.Forms
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(484, 681);
+            this.ClientSize = new System.Drawing.Size(384, 411);
             this.Controls.Add(this.mtlCheckbox);
             this.Controls.Add(this.chunk4Checkbox);
             this.Controls.Add(this.chunk3Checkbox);
             this.Controls.Add(this.chunk2Checkbox);
             this.Controls.Add(this.chunk1Checkbox);
             this.Controls.Add(this.chunk0Checkbox);
-            this.Controls.Add(this.label10);
-            this.Controls.Add(this.label9);
-            this.Controls.Add(this.label8);
-            this.Controls.Add(this.label7);
             this.Controls.Add(this.label6);
             this.Controls.Add(this.mobiesCheckbox);
             this.Controls.Add(this.shrubsCheckbox);
@@ -414,16 +359,15 @@ namespace RatchetEdit.Forms
             this.Controls.Add(this.exportButton);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(500, 720);
+            this.MaximumSize = new System.Drawing.Size(400, 450);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(500, 720);
+            this.MinimumSize = new System.Drawing.Size(400, 450);
             this.Name = "LevelExportWindow";
             this.Padding = new System.Windows.Forms.Padding(9);
             this.ShowIcon = false;
-            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Level Export Window";
-            this.FormClosing += new FormClosingEventHandler(enableMain);
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.enableMain);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -443,10 +387,6 @@ namespace RatchetEdit.Forms
         private System.Windows.Forms.CheckBox shrubsCheckbox;
         private System.Windows.Forms.CheckBox mobiesCheckbox;
         private System.Windows.Forms.Label label6;
-        private System.Windows.Forms.Label label7;
-        private System.Windows.Forms.Label label8;
-        private System.Windows.Forms.Label label9;
-        private System.Windows.Forms.Label label10;
         private System.Windows.Forms.CheckBox chunk0Checkbox;
         private System.Windows.Forms.CheckBox chunk1Checkbox;
         private System.Windows.Forms.CheckBox chunk2Checkbox;

--- a/Replanetizer/Forms/LevelExportWindow.Designer.cs
+++ b/Replanetizer/Forms/LevelExportWindow.Designer.cs
@@ -38,7 +38,6 @@ namespace RatchetEdit.Forms
             this.label3 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
-            this.exportProgressBar = new System.Windows.Forms.ProgressBar();
             this.tiesCheckbox = new System.Windows.Forms.CheckBox();
             this.shrubsCheckbox = new System.Windows.Forms.CheckBox();
             this.mobiesCheckbox = new System.Windows.Forms.CheckBox();
@@ -49,6 +48,7 @@ namespace RatchetEdit.Forms
             this.chunk3Checkbox = new System.Windows.Forms.CheckBox();
             this.chunk4Checkbox = new System.Windows.Forms.CheckBox();
             this.mtlCheckbox = new System.Windows.Forms.CheckBox();
+            this.exportProgressStatus = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // exportButton
@@ -151,17 +151,6 @@ namespace RatchetEdit.Forms
             this.label5.TabIndex = 8;
             this.label5.Text = "Include Terrain Chunks";
             this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // exportProgressBar
-            // 
-            this.exportProgressBar.BackColor = System.Drawing.SystemColors.Control;
-            this.exportProgressBar.Location = new System.Drawing.Point(25, 365);
-            this.exportProgressBar.MaximumSize = new System.Drawing.Size(150, 28);
-            this.exportProgressBar.MinimumSize = new System.Drawing.Size(150, 28);
-            this.exportProgressBar.Name = "exportProgressBar";
-            this.exportProgressBar.Size = new System.Drawing.Size(150, 28);
-            this.exportProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
-            this.exportProgressBar.TabIndex = 9;
             // 
             // tiesCheckbox
             // 
@@ -334,11 +323,23 @@ namespace RatchetEdit.Forms
             this.mtlCheckbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.mtlCheckbox.UseVisualStyleBackColor = false;
             // 
+            // exportProgressStatus
+            // 
+            this.exportProgressStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 16F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.exportProgressStatus.Location = new System.Drawing.Point(25, 365);
+            this.exportProgressStatus.MaximumSize = new System.Drawing.Size(150, 28);
+            this.exportProgressStatus.MinimumSize = new System.Drawing.Size(150, 28);
+            this.exportProgressStatus.Name = "exportProgressStatus";
+            this.exportProgressStatus.Size = new System.Drawing.Size(150, 28);
+            this.exportProgressStatus.TabIndex = 24;
+            this.exportProgressStatus.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
             // LevelExportWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(384, 411);
+            this.Controls.Add(this.exportProgressStatus);
             this.Controls.Add(this.mtlCheckbox);
             this.Controls.Add(this.chunk4Checkbox);
             this.Controls.Add(this.chunk3Checkbox);
@@ -349,7 +350,6 @@ namespace RatchetEdit.Forms
             this.Controls.Add(this.mobiesCheckbox);
             this.Controls.Add(this.shrubsCheckbox);
             this.Controls.Add(this.tiesCheckbox);
-            this.Controls.Add(this.exportProgressBar);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.label3);
@@ -382,7 +382,6 @@ namespace RatchetEdit.Forms
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.ProgressBar exportProgressBar;
         private System.Windows.Forms.CheckBox tiesCheckbox;
         private System.Windows.Forms.CheckBox shrubsCheckbox;
         private System.Windows.Forms.CheckBox mobiesCheckbox;
@@ -393,5 +392,6 @@ namespace RatchetEdit.Forms
         private System.Windows.Forms.CheckBox chunk3Checkbox;
         private System.Windows.Forms.CheckBox chunk4Checkbox;
         private System.Windows.Forms.CheckBox mtlCheckbox;
+        private Label exportProgressStatus;
     }
 }

--- a/Replanetizer/Forms/LevelExportWindow.Designer.cs
+++ b/Replanetizer/Forms/LevelExportWindow.Designer.cs
@@ -1,0 +1,94 @@
+﻿namespace RatchetEdit.Forms
+{
+    partial class LevelExportWindow
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.checkedListBox1 = new System.Windows.Forms.CheckedListBox();
+            this.button1 = new System.Windows.Forms.Button();
+            this.exportLevelDialog = new System.Windows.Forms.SaveFileDialog();
+            this.SuspendLayout();
+            // 
+            // checkedListBox1
+            // 
+            this.checkedListBox1.FormattingEnabled = true;
+            this.checkedListBox1.Items.AddRange(new object[] {
+            "Combine Meshes",
+            "Include Ties",
+            "Include Shrubs",
+            "Include Terrain of Chunk 0",
+            "Include Terrain of Chunk 1",
+            "Include Terrain of Chunk 2",
+            "Include Terrain of Chunk 3",
+            "Include Terrain of Chunk 4"});
+            this.checkedListBox1.Location = new System.Drawing.Point(1, 12);
+            this.checkedListBox1.Name = "checkedListBox1";
+            this.checkedListBox1.Size = new System.Drawing.Size(480, 499);
+            this.checkedListBox1.TabIndex = 1;
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(297, 615);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.TabIndex = 2;
+            this.button1.Text = "button1";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // exportLevelDialog
+            // 
+            this.exportLevelDialog.FileName = "Level.obj";
+            // 
+            // LevelExportWindow
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(484, 681);
+            this.Controls.Add(this.button1);
+            this.Controls.Add(this.checkedListBox1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MaximumSize = new System.Drawing.Size(500, 720);
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(500, 720);
+            this.Name = "LevelExportWindow";
+            this.Padding = new System.Windows.Forms.Padding(9);
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Level Export Window";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.CheckedListBox checkedListBox1;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.SaveFileDialog exportLevelDialog;
+    }
+}

--- a/Replanetizer/Forms/LevelExportWindow.Designer.cs
+++ b/Replanetizer/Forms/LevelExportWindow.Designer.cs
@@ -1,4 +1,7 @@
-﻿namespace RatchetEdit.Forms
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace RatchetEdit.Forms
 {
     partial class LevelExportWindow
     {
@@ -27,49 +30,388 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.checkedListBox1 = new System.Windows.Forms.CheckedListBox();
-            this.button1 = new System.Windows.Forms.Button();
+            this.exportButton = new System.Windows.Forms.Button();
             this.exportLevelDialog = new System.Windows.Forms.SaveFileDialog();
+            this.meshModeCombobox = new System.Windows.Forms.ComboBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.exportProgressBar = new System.Windows.Forms.ProgressBar();
+            this.tiesCheckbox = new System.Windows.Forms.CheckBox();
+            this.shrubsCheckbox = new System.Windows.Forms.CheckBox();
+            this.mobiesCheckbox = new System.Windows.Forms.CheckBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label8 = new System.Windows.Forms.Label();
+            this.label9 = new System.Windows.Forms.Label();
+            this.label10 = new System.Windows.Forms.Label();
+            this.chunk0Checkbox = new System.Windows.Forms.CheckBox();
+            this.chunk1Checkbox = new System.Windows.Forms.CheckBox();
+            this.chunk2Checkbox = new System.Windows.Forms.CheckBox();
+            this.chunk3Checkbox = new System.Windows.Forms.CheckBox();
+            this.chunk4Checkbox = new System.Windows.Forms.CheckBox();
+            this.mtlCheckbox = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
-            // checkedListBox1
+            // exportButton
             // 
-            this.checkedListBox1.FormattingEnabled = true;
-            this.checkedListBox1.Items.AddRange(new object[] {
-            "Combine Meshes",
-            "Include Ties",
-            "Include Shrubs",
-            "Include Terrain of Chunk 0",
-            "Include Terrain of Chunk 1",
-            "Include Terrain of Chunk 2",
-            "Include Terrain of Chunk 3",
-            "Include Terrain of Chunk 4"});
-            this.checkedListBox1.Location = new System.Drawing.Point(1, 12);
-            this.checkedListBox1.Name = "checkedListBox1";
-            this.checkedListBox1.Size = new System.Drawing.Size(480, 499);
-            this.checkedListBox1.TabIndex = 1;
-            // 
-            // button1
-            // 
-            this.button1.Location = new System.Drawing.Point(297, 615);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
-            this.button1.TabIndex = 2;
-            this.button1.Text = "button1";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.exportButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.exportButton.Location = new System.Drawing.Point(264, 625);
+            this.exportButton.MaximumSize = new System.Drawing.Size(200, 39);
+            this.exportButton.MinimumSize = new System.Drawing.Size(200, 39);
+            this.exportButton.Name = "exportButton";
+            this.exportButton.Size = new System.Drawing.Size(200, 39);
+            this.exportButton.TabIndex = 2;
+            this.exportButton.Text = "Export";
+            this.exportButton.UseVisualStyleBackColor = true;
+            this.exportButton.Click += new System.EventHandler(this.exportButton_Click);
             // 
             // exportLevelDialog
             // 
             this.exportLevelDialog.FileName = "Level.obj";
+            this.exportLevelDialog.Filter = "Wavefront OBJ file|*.obj";
+            // 
+            // meshModeCombobox
+            // 
+            this.meshModeCombobox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.meshModeCombobox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.meshModeCombobox.FormattingEnabled = true;
+            this.meshModeCombobox.Items.AddRange(new object[] {
+            "Separated",
+            "Combined",
+            "Typewise",
+            "Materialwise"});
+            this.meshModeCombobox.Location = new System.Drawing.Point(264, 39);
+            this.meshModeCombobox.Margin = new System.Windows.Forms.Padding(0);
+            this.meshModeCombobox.MaximumSize = new System.Drawing.Size(200, 0);
+            this.meshModeCombobox.MinimumSize = new System.Drawing.Size(200, 0);
+            this.meshModeCombobox.Name = "meshModeCombobox";
+            this.meshModeCombobox.Size = new System.Drawing.Size(200, 39);
+            this.meshModeCombobox.TabIndex = 3;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(25, 39);
+            this.label1.MaximumSize = new System.Drawing.Size(200, 39);
+            this.label1.MinimumSize = new System.Drawing.Size(200, 39);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(200, 39);
+            this.label1.TabIndex = 4;
+            this.label1.Text = "Mesh Mode";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(25, 97);
+            this.label2.MaximumSize = new System.Drawing.Size(200, 39);
+            this.label2.MinimumSize = new System.Drawing.Size(200, 39);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(200, 39);
+            this.label2.TabIndex = 5;
+            this.label2.Text = "Include Ties";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.Location = new System.Drawing.Point(25, 155);
+            this.label3.MaximumSize = new System.Drawing.Size(200, 39);
+            this.label3.MinimumSize = new System.Drawing.Size(200, 39);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(200, 39);
+            this.label3.TabIndex = 6;
+            this.label3.Text = "Include Shrubs";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.Location = new System.Drawing.Point(25, 213);
+            this.label4.MaximumSize = new System.Drawing.Size(200, 39);
+            this.label4.MinimumSize = new System.Drawing.Size(200, 39);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(200, 39);
+            this.label4.TabIndex = 7;
+            this.label4.Text = "Include Mobies";
+            this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label5.Location = new System.Drawing.Point(25, 271);
+            this.label5.MaximumSize = new System.Drawing.Size(250, 39);
+            this.label5.MinimumSize = new System.Drawing.Size(250, 39);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(250, 39);
+            this.label5.TabIndex = 8;
+            this.label5.Text = "Include Chunk 0";
+            this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // exportProgressBar
+            // 
+            this.exportProgressBar.BackColor = System.Drawing.SystemColors.Control;
+            this.exportProgressBar.Location = new System.Drawing.Point(25, 625);
+            this.exportProgressBar.MaximumSize = new System.Drawing.Size(200, 39);
+            this.exportProgressBar.MinimumSize = new System.Drawing.Size(200, 39);
+            this.exportProgressBar.Name = "exportProgressBar";
+            this.exportProgressBar.Size = new System.Drawing.Size(200, 39);
+            this.exportProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
+            this.exportProgressBar.TabIndex = 9;
+            // 
+            // tiesCheckbox
+            // 
+            this.tiesCheckbox.Appearance = System.Windows.Forms.Appearance.Button;
+            this.tiesCheckbox.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.tiesCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.tiesCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tiesCheckbox.ForeColor = System.Drawing.SystemColors.HighlightText;
+            this.tiesCheckbox.Location = new System.Drawing.Point(425, 97);
+            this.tiesCheckbox.Margin = new System.Windows.Forms.Padding(0);
+            this.tiesCheckbox.MaximumSize = new System.Drawing.Size(39, 39);
+            this.tiesCheckbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.tiesCheckbox.Name = "tiesCheckbox";
+            this.tiesCheckbox.Size = new System.Drawing.Size(39, 39);
+            this.tiesCheckbox.TabIndex = 10;
+            this.tiesCheckbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.tiesCheckbox.UseVisualStyleBackColor = false;
+            // 
+            // shrubsCheckbox
+            // 
+            this.shrubsCheckbox.Appearance = System.Windows.Forms.Appearance.Button;
+            this.shrubsCheckbox.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.shrubsCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.shrubsCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.shrubsCheckbox.ForeColor = System.Drawing.SystemColors.HighlightText;
+            this.shrubsCheckbox.Location = new System.Drawing.Point(425, 155);
+            this.shrubsCheckbox.Margin = new System.Windows.Forms.Padding(0);
+            this.shrubsCheckbox.MaximumSize = new System.Drawing.Size(39, 39);
+            this.shrubsCheckbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.shrubsCheckbox.Name = "shrubsCheckbox";
+            this.shrubsCheckbox.Size = new System.Drawing.Size(39, 39);
+            this.shrubsCheckbox.TabIndex = 11;
+            this.shrubsCheckbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.shrubsCheckbox.UseVisualStyleBackColor = false;
+            // 
+            // mobiesCheckbox
+            // 
+            this.mobiesCheckbox.Appearance = System.Windows.Forms.Appearance.Button;
+            this.mobiesCheckbox.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.mobiesCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.mobiesCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.mobiesCheckbox.ForeColor = System.Drawing.SystemColors.HighlightText;
+            this.mobiesCheckbox.Location = new System.Drawing.Point(425, 213);
+            this.mobiesCheckbox.Margin = new System.Windows.Forms.Padding(0);
+            this.mobiesCheckbox.MaximumSize = new System.Drawing.Size(39, 39);
+            this.mobiesCheckbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.mobiesCheckbox.Name = "mobiesCheckbox";
+            this.mobiesCheckbox.Size = new System.Drawing.Size(39, 39);
+            this.mobiesCheckbox.TabIndex = 12;
+            this.mobiesCheckbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.mobiesCheckbox.UseVisualStyleBackColor = false;
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label6.Location = new System.Drawing.Point(25, 329);
+            this.label6.MaximumSize = new System.Drawing.Size(250, 39);
+            this.label6.MinimumSize = new System.Drawing.Size(250, 39);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(250, 39);
+            this.label6.TabIndex = 13;
+            this.label6.Text = "Include Chunk 1";
+            this.label6.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label7.Location = new System.Drawing.Point(25, 387);
+            this.label7.MaximumSize = new System.Drawing.Size(250, 39);
+            this.label7.MinimumSize = new System.Drawing.Size(250, 39);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(250, 39);
+            this.label7.TabIndex = 14;
+            this.label7.Text = "Include Chunk 2";
+            this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label8.Location = new System.Drawing.Point(25, 445);
+            this.label8.MaximumSize = new System.Drawing.Size(250, 39);
+            this.label8.MinimumSize = new System.Drawing.Size(250, 39);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(250, 39);
+            this.label8.TabIndex = 15;
+            this.label8.Text = "Include Chunk 3";
+            this.label8.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label9.Location = new System.Drawing.Point(25, 503);
+            this.label9.MaximumSize = new System.Drawing.Size(250, 39);
+            this.label9.MinimumSize = new System.Drawing.Size(250, 39);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(250, 39);
+            this.label9.TabIndex = 16;
+            this.label9.Text = "Include Chunk 4";
+            this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label10.Location = new System.Drawing.Point(25, 561);
+            this.label10.MaximumSize = new System.Drawing.Size(250, 39);
+            this.label10.MinimumSize = new System.Drawing.Size(250, 39);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(250, 39);
+            this.label10.TabIndex = 17;
+            this.label10.Text = "Include MTL File";
+            this.label10.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // chunk0Checkbox
+            // 
+            this.chunk0Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
+            this.chunk0Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.chunk0Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.chunk0Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk0Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
+            this.chunk0Checkbox.Location = new System.Drawing.Point(425, 271);
+            this.chunk0Checkbox.Margin = new System.Windows.Forms.Padding(0);
+            this.chunk0Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
+            this.chunk0Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk0Checkbox.Name = "chunk0Checkbox";
+            this.chunk0Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk0Checkbox.TabIndex = 18;
+            this.chunk0Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk0Checkbox.UseVisualStyleBackColor = false;
+            // 
+            // chunk1Checkbox
+            // 
+            this.chunk1Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
+            this.chunk1Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.chunk1Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.chunk1Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk1Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
+            this.chunk1Checkbox.Location = new System.Drawing.Point(425, 329);
+            this.chunk1Checkbox.Margin = new System.Windows.Forms.Padding(0);
+            this.chunk1Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
+            this.chunk1Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk1Checkbox.Name = "chunk1Checkbox";
+            this.chunk1Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk1Checkbox.TabIndex = 19;
+            this.chunk1Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk1Checkbox.UseVisualStyleBackColor = false;
+            // 
+            // chunk2Checkbox
+            // 
+            this.chunk2Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
+            this.chunk2Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.chunk2Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.chunk2Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk2Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
+            this.chunk2Checkbox.Location = new System.Drawing.Point(425, 387);
+            this.chunk2Checkbox.Margin = new System.Windows.Forms.Padding(0);
+            this.chunk2Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
+            this.chunk2Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk2Checkbox.Name = "chunk2Checkbox";
+            this.chunk2Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk2Checkbox.TabIndex = 20;
+            this.chunk2Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk2Checkbox.UseVisualStyleBackColor = false;
+            // 
+            // chunk3Checkbox
+            // 
+            this.chunk3Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
+            this.chunk3Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.chunk3Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.chunk3Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk3Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
+            this.chunk3Checkbox.Location = new System.Drawing.Point(425, 445);
+            this.chunk3Checkbox.Margin = new System.Windows.Forms.Padding(0);
+            this.chunk3Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
+            this.chunk3Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk3Checkbox.Name = "chunk3Checkbox";
+            this.chunk3Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk3Checkbox.TabIndex = 21;
+            this.chunk3Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk3Checkbox.UseVisualStyleBackColor = false;
+            // 
+            // chunk4Checkbox
+            // 
+            this.chunk4Checkbox.Appearance = System.Windows.Forms.Appearance.Button;
+            this.chunk4Checkbox.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.chunk4Checkbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.chunk4Checkbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chunk4Checkbox.ForeColor = System.Drawing.SystemColors.HighlightText;
+            this.chunk4Checkbox.Location = new System.Drawing.Point(425, 503);
+            this.chunk4Checkbox.Margin = new System.Windows.Forms.Padding(0);
+            this.chunk4Checkbox.MaximumSize = new System.Drawing.Size(39, 39);
+            this.chunk4Checkbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.chunk4Checkbox.Name = "chunk4Checkbox";
+            this.chunk4Checkbox.Size = new System.Drawing.Size(39, 39);
+            this.chunk4Checkbox.TabIndex = 22;
+            this.chunk4Checkbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.chunk4Checkbox.UseVisualStyleBackColor = false;
+            // 
+            // mtlCheckbox
+            // 
+            this.mtlCheckbox.Appearance = System.Windows.Forms.Appearance.Button;
+            this.mtlCheckbox.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.mtlCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.mtlCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 20F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.mtlCheckbox.ForeColor = System.Drawing.SystemColors.HighlightText;
+            this.mtlCheckbox.Location = new System.Drawing.Point(425, 561);
+            this.mtlCheckbox.Margin = new System.Windows.Forms.Padding(0);
+            this.mtlCheckbox.MaximumSize = new System.Drawing.Size(39, 39);
+            this.mtlCheckbox.MinimumSize = new System.Drawing.Size(39, 39);
+            this.mtlCheckbox.Name = "mtlCheckbox";
+            this.mtlCheckbox.Size = new System.Drawing.Size(39, 39);
+            this.mtlCheckbox.TabIndex = 23;
+            this.mtlCheckbox.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.mtlCheckbox.UseVisualStyleBackColor = false;
             // 
             // LevelExportWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(484, 681);
-            this.Controls.Add(this.button1);
-            this.Controls.Add(this.checkedListBox1);
+            this.Controls.Add(this.mtlCheckbox);
+            this.Controls.Add(this.chunk4Checkbox);
+            this.Controls.Add(this.chunk3Checkbox);
+            this.Controls.Add(this.chunk2Checkbox);
+            this.Controls.Add(this.chunk1Checkbox);
+            this.Controls.Add(this.chunk0Checkbox);
+            this.Controls.Add(this.label10);
+            this.Controls.Add(this.label9);
+            this.Controls.Add(this.label8);
+            this.Controls.Add(this.label7);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.mobiesCheckbox);
+            this.Controls.Add(this.shrubsCheckbox);
+            this.Controls.Add(this.tiesCheckbox);
+            this.Controls.Add(this.exportProgressBar);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.meshModeCombobox);
+            this.Controls.Add(this.exportButton);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MaximumSize = new System.Drawing.Size(500, 720);
@@ -81,14 +423,35 @@
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Level Export Window";
+            this.FormClosing += new FormClosingEventHandler(enableMain);
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
-
-        private System.Windows.Forms.CheckedListBox checkedListBox1;
-        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button exportButton;
         private System.Windows.Forms.SaveFileDialog exportLevelDialog;
+        private System.Windows.Forms.ComboBox meshModeCombobox;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.ProgressBar exportProgressBar;
+        private System.Windows.Forms.CheckBox tiesCheckbox;
+        private System.Windows.Forms.CheckBox shrubsCheckbox;
+        private System.Windows.Forms.CheckBox mobiesCheckbox;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.CheckBox chunk0Checkbox;
+        private System.Windows.Forms.CheckBox chunk1Checkbox;
+        private System.Windows.Forms.CheckBox chunk2Checkbox;
+        private System.Windows.Forms.CheckBox chunk3Checkbox;
+        private System.Windows.Forms.CheckBox chunk4Checkbox;
+        private System.Windows.Forms.CheckBox mtlCheckbox;
     }
 }

--- a/Replanetizer/Forms/LevelExportWindow.cs
+++ b/Replanetizer/Forms/LevelExportWindow.cs
@@ -7,38 +7,89 @@ namespace RatchetEdit.Forms
 {
     public partial class LevelExportWindow : Form
     {
-        Main main;
+        private Level level;
+        private Main main;
+        private ModelWriter.WriterLevelSettings settings;
 
         public LevelExportWindow(Main main)
         {
             InitializeComponent();
 
+            level = main.level;
             this.main = main;
+            settings = new ModelWriter.WriterLevelSettings();
+
+            meshModeCombobox.SelectedIndex = (int)settings.mode;
+            tiesCheckbox.Checked = settings.writeTies;
+            shrubsCheckbox.Checked = settings.writeShrubs;
+            mobiesCheckbox.Checked = settings.writeMobies;
+            chunk0Checkbox.Checked = settings.chunksSelected[0];
+            chunk1Checkbox.Checked = settings.chunksSelected[1];
+            chunk2Checkbox.Checked = settings.chunksSelected[2];
+            chunk3Checkbox.Checked = settings.chunksSelected[3];
+            chunk4Checkbox.Checked = settings.chunksSelected[4];
+            mtlCheckbox.Checked = settings.exportMTLFile;
+
+            if (level.terrainChunks.Count < 5)
+            {
+                chunk4Checkbox.Enabled = false;
+                chunk4Checkbox.Checked = false;
+            }
+
+            if (level.terrainChunks.Count < 4)
+            {
+                chunk3Checkbox.Enabled = false;
+                chunk3Checkbox.Checked = false;
+            }
+
+            if (level.terrainChunks.Count < 3)
+            {
+                chunk2Checkbox.Enabled = false;
+                chunk2Checkbox.Checked = false;
+            }
+
+            if (level.terrainChunks.Count < 2)
+            {
+                chunk1Checkbox.Enabled = false;
+                chunk1Checkbox.Checked = false;
+            }
+
+            if (level.terrainChunks.Count < 1)
+            {
+                chunk0Checkbox.Enabled = false;
+                chunk0Checkbox.Checked = false;
+            }
+
         }
 
-        private void checkedListBox1_SelectedIndexChanged(object sender, EventArgs e)
-        {
-
-        }
-
-        private void button1_Click(object sender, EventArgs e)
+        private void exportLevel()
         {
             if (exportLevelDialog.ShowDialog() != DialogResult.OK) return;
 
             string fileName = exportLevelDialog.FileName;
 
-            ModelWriter.WriterLevelSettings settings = new ModelWriter.WriterLevelSettings();
+            settings.mode = (ModelWriter.WriterLevelMode)meshModeCombobox.SelectedIndex;
+            settings.writeTies = tiesCheckbox.Checked;
+            settings.writeShrubs = shrubsCheckbox.Checked;
+            settings.writeMobies = mobiesCheckbox.Checked;
+            settings.chunksSelected[0] = chunk0Checkbox.Checked;
+            settings.chunksSelected[1] = chunk1Checkbox.Checked;
+            settings.chunksSelected[2] = chunk2Checkbox.Checked;
+            settings.chunksSelected[3] = chunk3Checkbox.Checked;
+            settings.chunksSelected[4] = chunk4Checkbox.Checked;
+            settings.exportMTLFile = mtlCheckbox.Checked;
 
-            settings.chunksSelected = new bool[5];
-            settings.chunksSelected[0] = true;
-            settings.chunksSelected[1] = true;
-            settings.chunksSelected[2] = true;
-            settings.chunksSelected[3] = true;
-            settings.chunksSelected[4] = true;
+            ModelWriter.WriteObj(fileName, level, settings);
+        }
 
-            settings.combineMeshes = true;
+        private void exportButton_Click(object sender, EventArgs e)
+        {
+            exportLevel();
+        }
 
-            ModelWriter.WriteObj(fileName, main.level, settings);
+        private void enableMain(object sender, FormClosingEventArgs e)
+        {
+            main.Enabled = true;
         }
     }
 }

--- a/Replanetizer/Forms/LevelExportWindow.cs
+++ b/Replanetizer/Forms/LevelExportWindow.cs
@@ -1,0 +1,44 @@
+﻿using LibReplanetizer;
+using System;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace RatchetEdit.Forms
+{
+    public partial class LevelExportWindow : Form
+    {
+        Main main;
+
+        public LevelExportWindow(Main main)
+        {
+            InitializeComponent();
+
+            this.main = main;
+        }
+
+        private void checkedListBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+
+        }
+
+        private void button1_Click(object sender, EventArgs e)
+        {
+            if (exportLevelDialog.ShowDialog() != DialogResult.OK) return;
+
+            string fileName = exportLevelDialog.FileName;
+
+            ModelWriter.WriterLevelSettings settings = new ModelWriter.WriterLevelSettings();
+
+            settings.chunksSelected = new bool[5];
+            settings.chunksSelected[0] = true;
+            settings.chunksSelected[1] = true;
+            settings.chunksSelected[2] = true;
+            settings.chunksSelected[3] = true;
+            settings.chunksSelected[4] = true;
+
+            settings.combineMeshes = true;
+
+            ModelWriter.WriteObj(fileName, main.level, settings);
+        }
+    }
+}

--- a/Replanetizer/Forms/LevelExportWindow.cs
+++ b/Replanetizer/Forms/LevelExportWindow.cs
@@ -84,7 +84,22 @@ namespace RatchetEdit.Forms
 
         private void exportButton_Click(object sender, EventArgs e)
         {
-            exportLevel();
+            Application.UseWaitCursor = true;
+            exportProgressStatus.Text = "Export in Progress...";
+            Enabled = false;
+            Application.DoEvents();
+
+            try
+            {
+                exportLevel();
+            }
+            finally
+            {
+                Application.UseWaitCursor = false;
+                exportProgressStatus.Text = "";
+                Enabled = true;
+            }
+            
         }
 
         private void enableMain(object sender, FormClosingEventArgs e)

--- a/Replanetizer/Forms/LevelExportWindow.resx
+++ b/Replanetizer/Forms/LevelExportWindow.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="saveFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>185, 17</value>
+  </metadata>
+</root>

--- a/Replanetizer/Forms/LevelExportWindow.resx
+++ b/Replanetizer/Forms/LevelExportWindow.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="saveFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>185, 17</value>
+  <metadata name="exportLevelDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>

--- a/Replanetizer/Forms/Main.Designer.cs
+++ b/Replanetizer/Forms/Main.Designer.cs
@@ -69,6 +69,7 @@ namespace RatchetEdit
             this.levelVariablesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.languageDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.lightConfigurationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.levelExportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mapOpenDialog = new System.Windows.Forms.OpenFileDialog();
@@ -396,7 +397,8 @@ namespace RatchetEdit
             this.toolStripMenuItem14,
             this.levelVariablesToolStripMenuItem,
             this.languageDataToolStripMenuItem,
-            this.lightConfigurationToolStripMenuItem});
+            this.lightConfigurationToolStripMenuItem,
+            this.levelExportToolStripMenuItem});
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
             this.toolStripMenuItem2.Size = new System.Drawing.Size(63, 20);
             this.toolStripMenuItem2.Text = "Window";
@@ -470,6 +472,14 @@ namespace RatchetEdit
             this.lightConfigurationToolStripMenuItem.Enabled = false;
             this.lightConfigurationToolStripMenuItem.Text = "Light Configuration";
             this.lightConfigurationToolStripMenuItem.Click += new System.EventHandler(this.lightConfigurationToolStripMenuItem_Click);
+            // 
+            // levelExportToolStripMenuItem
+            // 
+            this.levelExportToolStripMenuItem.Name = "levelExportToolStripMenuItem";
+            this.levelExportToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.levelExportToolStripMenuItem.Enabled = false;
+            this.levelExportToolStripMenuItem.Text = "Level Export Window";
+            this.levelExportToolStripMenuItem.Click += new System.EventHandler(this.levelExportToolStripMenuItem_Click);
             // 
             // toolStripMenuItem3
             // 
@@ -851,6 +861,7 @@ namespace RatchetEdit
         private System.Windows.Forms.ToolStripMenuItem collisionToolStripMenuItem1;
         private System.Windows.Forms.OpenFileDialog collisionOpenDialog;
         private System.Windows.Forms.ToolStripMenuItem lightConfigurationToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem levelExportToolStripMenuItem;
         private CustomGLControl glControl;
         private System.Windows.Forms.ToolStripMenuItem levelVariablesToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem chunksToolStripMenuItem;
@@ -858,7 +869,7 @@ namespace RatchetEdit
         private System.Windows.Forms.ToolStripMenuItem chunk1ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem chunk2ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem chunk3ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem chunk4ToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem chunk4ToolStripMenuItem;    
     }
 }
 

--- a/Replanetizer/Forms/Main.cs
+++ b/Replanetizer/Forms/Main.cs
@@ -73,6 +73,11 @@ namespace RatchetEdit
 
             glControl.LoadLevel(level);
 
+            mobiesVisible(true);
+            tiesVisible(true);
+            shrubsVisible(true);
+            terrainVisible(true);
+
             //Enable all the buttons in the view tab
             foreach (ToolStripMenuItem menuButton in ViewToolStipItem.DropDownItems)
             {
@@ -102,6 +107,30 @@ namespace RatchetEdit
 
             objectTree.UpdateEntries(level);
             UpdateProperties(null);
+        }
+
+        public void mobiesVisible(bool value)
+        {
+            mobyCheck.Checked = value;
+            glControl.enableMoby = value;
+        }
+
+        public void tiesVisible(bool value)
+        {
+            tieCheck.Checked = value;
+            glControl.enableTie = value;
+        }
+
+        public void shrubsVisible(bool value)
+        {
+            shrubCheck.Checked = value;
+            glControl.enableShrub = value;
+        }
+
+        public void terrainVisible(bool value)
+        {
+            terrainCheck.Checked = value;
+            glControl.enableTerrain = value;
         }
 
         private Dictionary<int, string> GetModelNames(string fileName)

--- a/Replanetizer/Forms/Main.cs
+++ b/Replanetizer/Forms/Main.cs
@@ -247,6 +247,8 @@ namespace RatchetEdit
             {
                 levelExportWindow.BringToFront();
             }
+
+            Enabled = false;
         }
         #endregion
 

--- a/Replanetizer/Forms/Main.cs
+++ b/Replanetizer/Forms/Main.cs
@@ -39,6 +39,7 @@ namespace RatchetEdit
         public LanguageViewer languageViewer;
         public LightConfigViewer lightConfigViewer;
         public LevelVariableViewer levelVariableViewer;
+        public LevelExportWindow levelExportWindow;
 
         private bool[] chunksSelected = new bool[5];
 
@@ -234,6 +235,19 @@ namespace RatchetEdit
                 levelVariableViewer.BringToFront();
             }
         }
+
+        private void OpenExportLevelWindow()
+        {
+            if (levelExportWindow == null || levelExportWindow.IsDisposed)
+            {
+                levelExportWindow = new LevelExportWindow(this);
+                levelExportWindow.Show();
+            }
+            else
+            {
+                levelExportWindow.BringToFront();
+            }
+        }
         #endregion
 
         #region MenuButtons
@@ -277,6 +291,11 @@ namespace RatchetEdit
         private void levelVariablesToolStripMenuItem_Click(object sender, EventArgs e)
         {
             OpenLevelVariableViewer();
+        }
+
+        private void levelExportToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            OpenExportLevelWindow();
         }
         #endregion MenuButtons
 

--- a/Replanetizer/Forms/TextureViewer.Designer.cs
+++ b/Replanetizer/Forms/TextureViewer.Designer.cs
@@ -39,6 +39,9 @@
             this.okBtn = new System.Windows.Forms.Button();
             this.cancelBtn = new System.Windows.Forms.Button();
             this.exportBtn = new System.Windows.Forms.Button();
+            this.exportAllButton = new System.Windows.Forms.Button();
+            this.exportFolderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
+            this.saveTextureFileDialog = new System.Windows.Forms.SaveFileDialog();
             ((System.ComponentModel.ISupportInitialize)(this.textureImage)).BeginInit();
             this.SuspendLayout();
             // 
@@ -61,7 +64,9 @@
             // 
             // openTextureDialog
             // 
-            this.openTextureDialog.Filter = "All supported image files|*.bmp;*.png;*.jpg;*.jpeg;*.dds|Bitmap Image File|*.bmp|Portable Network Graphics|*.png|JPEG Image File|*.jpg;*.jpeg|DirectDraw Surface|*.dds";
+            this.openTextureDialog.Filter = "All supported image files|*.bmp;*.png;*.jpg;*.jpeg;*.dds|Bitmap Image File|*.bmp|" +
+    "Portable Network Graphics|*.png|JPEG Image File|*.jpg;*.jpeg|DirectDraw Surface|" +
+    "*.dds";
             // 
             // texAmountLabel
             // 
@@ -96,6 +101,7 @@
             this.textureView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.textureView.HideSelection = false;
             this.textureView.LargeImageList = this.texImages;
             this.textureView.Location = new System.Drawing.Point(12, 287);
             this.textureView.Name = "textureView";
@@ -140,11 +146,27 @@
             this.exportBtn.UseVisualStyleBackColor = true;
             this.exportBtn.Click += new System.EventHandler(this.exportBtn_Click);
             // 
+            // exportAllButton
+            // 
+            this.exportAllButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.exportAllButton.Location = new System.Drawing.Point(258, 597);
+            this.exportAllButton.Name = "exportAllButton";
+            this.exportAllButton.Size = new System.Drawing.Size(117, 32);
+            this.exportAllButton.TabIndex = 17;
+            this.exportAllButton.Text = "Export All";
+            this.exportAllButton.UseVisualStyleBackColor = true;
+            this.exportAllButton.Click += new System.EventHandler(this.exportAllButton_Click);
+            // 
+            // saveTextureFileDialog
+            // 
+            this.saveTextureFileDialog.Filter = "Portable Network Graphics|*.png";
+            // 
             // TextureViewer
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(584, 641);
+            this.Controls.Add(this.exportAllButton);
             this.Controls.Add(this.exportBtn);
             this.Controls.Add(this.cancelBtn);
             this.Controls.Add(this.okBtn);
@@ -173,5 +195,8 @@
         private System.Windows.Forms.Button okBtn;
         private System.Windows.Forms.Button cancelBtn;
         private System.Windows.Forms.Button exportBtn;
+        private System.Windows.Forms.Button exportAllButton;
+        private System.Windows.Forms.FolderBrowserDialog exportFolderBrowserDialog;
+        private System.Windows.Forms.SaveFileDialog saveTextureFileDialog;
     }
 }

--- a/Replanetizer/Forms/TextureViewer.cs
+++ b/Replanetizer/Forms/TextureViewer.cs
@@ -176,10 +176,39 @@ namespace RatchetEdit
         {
             if (textureView.SelectedIndices.Count == 0) return;
 
+            if (saveTextureFileDialog.ShowDialog() != DialogResult.OK) return;
+
+            string fileName = saveTextureFileDialog.FileName;
+
             int index = textureView.SelectedIndices[0];
 
             Bitmap image = main.level.textures[index].getTextureImage();
-            image.Save(index.ToString() + ".png");
+            image.Save(fileName);
+        }
+
+        private void exportAllButton_Click(object sender, EventArgs e)
+        {
+            if (exportFolderBrowserDialog.ShowDialog() != DialogResult.OK) return;
+
+            Enabled = false;
+            Application.DoEvents();
+
+            try
+            {
+                string path = exportFolderBrowserDialog.SelectedPath;
+
+                for (int i = 0; i < main.level.textures.Count; i++)
+                {
+                    Bitmap image = main.level.textures[i].getTextureImage();
+                    image.Save(path + "/" + i.ToString() + ".png");
+                }
+            }
+            finally
+            {
+                Enabled = true;
+            }
+
+
         }
     }
 }

--- a/Replanetizer/Forms/TextureViewer.resx
+++ b/Replanetizer/Forms/TextureViewer.resx
@@ -126,4 +126,10 @@
   <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>275, 17</value>
   </metadata>
+  <metadata name="exportFolderBrowserDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>385, 17</value>
+  </metadata>
+  <metadata name="saveTextureFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>585, 17</value>
+  </metadata>
 </root>

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -55,6 +55,9 @@
     <Compile Update="CustomControls\CustomGLControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Update="Forms\LevelExportWindow.cs" >
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Update="Forms\AboutBox1.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
- Added exporting whole levels as an `*.obj` file with 4 different modes of how the objects are combined
- Added dialog to export texture so the user can specify a path
- Added export all textures button, useful in combination with exporting the whole level
- Fixed a bug where if you deactivated that ties, shrubs etc are visible and then loaded a new level, the fact that GLControl reactivated those visibilities was not reflected in the UI