### PR TITLE
Skybox and Transparent Mobies

### DIFF
--- a/Replanetizer/CustomControls/CustomGLControl.cs
+++ b/Replanetizer/CustomControls/CustomGLControl.cs
@@ -60,6 +60,8 @@ namespace RatchetEdit
         private List<int> collisionIbo = new List<int>();
         private bool[] selectedChunks;
 
+        private bool allowTransparency = false;
+
         public CustomGLControl()
         {
             bufferTable = new ConditionalWeakTable<IRenderable, BufferContainer>();
@@ -723,7 +725,11 @@ namespace RatchetEdit
                 GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
                 GL.UseProgram(shaderID);
             }
+        }
 
+        public void setTransparency(bool value)
+        {
+            allowTransparency = value;
         }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -735,7 +741,6 @@ namespace RatchetEdit
             worldView = view * projection;
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
-
             GL.EnableVertexAttribArray(0);
             GL.EnableVertexAttribArray(1);
 
@@ -743,35 +748,52 @@ namespace RatchetEdit
 
             GL.UseProgram(shaderID);
 
-            if (enableMoby)
-            {
-                hook.UpdateMobys(level.mobs, level.mobyModels);
-
-                foreach (Moby mob in level.mobs)
-                {
-                    RenderModelObject(mob, mob == selectedObject);
-                }
-            }
-
-
-            if (enableTie)
-                foreach (Tie tie in level.ties)
-                    RenderModelObject(tie, tie == selectedObject);
-
-            if (enableShrub)
-                foreach (Shrub shrub in level.shrubs)
-                    RenderModelObject(shrub, shrub == selectedObject);
-
-            if (enableTerrain)
-                foreach (TerrainFragment tFrag in terrains)
-                    RenderModelObject(tFrag, tFrag == selectedObject);
-
             if (enableSkybox)
+            {
+                GL.Disable(EnableCap.DepthTest);
+                Matrix4 mvp = view.ClearTranslation() * projection;
+                GL.UniformMatrix4(matrixID, false, ref mvp);
+                ActivateBuffersForModel(level.skybox);
+                GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, sizeof(float) * 8, 0);
+                GL.VertexAttribPointer(1, 2, VertexAttribPointerType.Float, false, sizeof(float) * 8, sizeof(float) * 6);
                 foreach (TextureConfig conf in level.skybox.textureConfig)
                 {
                     GL.BindTexture(TextureTarget.Texture2D, (conf.ID > 0) ? textureIds[level.textures[conf.ID]] : 0);
                     GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
                 }
+                GL.Enable(EnableCap.DepthTest);
+            }
+
+            if (enableTerrain)
+                foreach (TerrainFragment tFrag in terrains)
+                    RenderModelObject(tFrag, tFrag == selectedObject);
+
+            if (enableShrub)
+                foreach (Shrub shrub in level.shrubs)
+                    RenderModelObject(shrub, shrub == selectedObject);
+
+            if (enableTie)
+                foreach (Tie tie in level.ties)
+                    RenderModelObject(tie, tie == selectedObject);
+
+
+            if (enableMoby)
+            {
+                hook.UpdateMobys(level.mobs, level.mobyModels);
+
+                if (allowTransparency)
+                {
+                    GL.Enable(EnableCap.Blend);
+                    GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+                }
+
+                foreach (Moby mob in level.mobs)
+                {
+                    RenderModelObject(mob, mob == selectedObject);
+                }
+
+                GL.Disable(EnableCap.Blend);
+            }
 
             GL.UseProgram(colorShaderID);
 

--- a/Replanetizer/CustomControls/CustomGLControl.cs
+++ b/Replanetizer/CustomControls/CustomGLControl.cs
@@ -619,7 +619,6 @@ namespace RatchetEdit
             {
                 tfragOffset = offset;
                 FakeDrawObjects(terrains.Cast<ModelObject>().ToList(), tfragOffset);
-                offset += level.cuboids.Count;
             }
 
             RenderTool();
@@ -717,6 +716,11 @@ namespace RatchetEdit
 
             if (selected)
             {
+                bool switchBlends = allowTransparency && (modelObject is Moby);
+
+                if (switchBlends)
+                    GL.Disable(EnableCap.Blend);
+
                 GL.UseProgram(colorShaderID);
                 GL.Uniform4(colorID, new Vector4(1, 1, 1, 1));
                 GL.UniformMatrix4(matrixID, false, ref mvp);
@@ -724,6 +728,9 @@ namespace RatchetEdit
                 GL.DrawElements(PrimitiveType.Triangles, modelObject.model.indexBuffer.Length, DrawElementsType.UnsignedShort, 0);
                 GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
                 GL.UseProgram(shaderID);
+
+                if (switchBlends)
+                    GL.Enable(EnableCap.Blend);
             }
         }
 

--- a/Replanetizer/Forms/Main.Designer.cs
+++ b/Replanetizer/Forms/Main.Designer.cs
@@ -71,6 +71,7 @@ namespace RatchetEdit
             this.lightConfigurationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.levelExportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
+            this.transparencyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mapOpenDialog = new System.Windows.Forms.OpenFileDialog();
             this.tickTimer = new System.Windows.Forms.Timer(this.components);
@@ -484,16 +485,25 @@ namespace RatchetEdit
             // toolStripMenuItem3
             // 
             this.toolStripMenuItem3.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.transparencyToolStripMenuItem,
             this.settingsToolStripMenuItem});
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-            this.toolStripMenuItem3.Enabled = false;
             this.toolStripMenuItem3.Size = new System.Drawing.Size(80, 20);
             this.toolStripMenuItem3.Text = "Preferences";
+            // 
+            // transparencyToolStripMenuItem
+            // 
+            this.transparencyToolStripMenuItem.Name = "transparencyToolStripMenuItem";
+            this.transparencyToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
+            this.transparencyToolStripMenuItem.Text = "Transparent Mobies";
+            this.transparencyToolStripMenuItem.CheckOnClick = true;
+            this.transparencyToolStripMenuItem.CheckedChanged += new System.EventHandler(this.transparencyPreference_CheckedChanged);
             // 
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
             this.settingsToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
+            this.settingsToolStripMenuItem.Enabled = false;
             this.settingsToolStripMenuItem.Text = "Settings";
             // 
             // mapOpenDialog
@@ -820,6 +830,7 @@ namespace RatchetEdit
         private System.Windows.Forms.Label camXLabel;
         private System.Windows.Forms.Label camYLabel;
         private System.Windows.Forms.Label camZLabel;
+        private System.Windows.Forms.ToolStripMenuItem transparencyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;
         private System.Windows.Forms.OpenFileDialog mapOpenDialog;
         private System.Windows.Forms.Timer tickTimer;

--- a/Replanetizer/Forms/Main.cs
+++ b/Replanetizer/Forms/Main.cs
@@ -535,6 +535,12 @@ namespace RatchetEdit
             InvalidateView();
         }
 
+        private void transparencyPreference_CheckedChanged(object sender, EventArgs e)
+        {
+            glControl.setTransparency(transparencyToolStripMenuItem.Checked);
+            InvalidateView();
+        }
+
         private void changeChunkSelection(object sender, EventArgs e, int index)
         {
             chunksSelected[index] = !chunksSelected[index];


### PR DESCRIPTION
- Added drawing the skybox, it is always centered around the camera (if I am not wrong that is how the skybox worked in the game too) and is always drawn behind everything, some skyboxes are transparent multilayered, however, these do not look right yet since we have no transparency sorting
- Added the option to enable transparency for mobies, since there is no transparency sorting other mobies may be invisible behind it but it looks good as an optional thing

-----

I will keep this PR up for a bit and merge myself if no one has any suggestions.