### PR TITLE
Fixing Saving and Loading Levels

### DIFF
--- a/LibReplanetizer/Headers/ChunkHeader.cs
+++ b/LibReplanetizer/Headers/ChunkHeader.cs
@@ -20,5 +20,15 @@ namespace LibReplanetizer.Headers
             terrainPointer = ReadInt(chunkHeaderBytes, 0x00);
             collisionPointer = ReadInt(chunkHeaderBytes, 0x04);
         }
+
+        public byte[] Serialize()
+        {
+            byte[] bytes = new byte[0x10];
+
+            WriteInt(bytes, 0x00, terrainPointer);
+            WriteInt(bytes, 0x04, collisionPointer);
+
+            return bytes;
+        }
     }
 }

--- a/LibReplanetizer/Headers/GameplayHeader.cs
+++ b/LibReplanetizer/Headers/GameplayHeader.cs
@@ -169,7 +169,7 @@ namespace LibReplanetizer.Headers
             occlusionPointer = ReadInt(gameplayHeadBlock, 0x90);
         }
 
-        public byte[] Serialize()
+        public byte[] SerializeRC1()
         {
             byte[] bytes = new byte[GAMEPLAYSIZE];
 
@@ -217,6 +217,60 @@ namespace LibReplanetizer.Headers
             WriteInt(bytes, 0x84, unkPointer17);
             WriteInt(bytes, 0x88, type88Pointer);
             WriteInt(bytes, 0x8C, occlusionPointer);
+
+            return bytes;
+        }
+
+        public byte[] SerializeRC23()
+        {
+            byte[] bytes = new byte[GAMEPLAYSIZE];
+
+            WriteInt(bytes, 0x00, levelVarPointer);
+            WriteInt(bytes, 0x04, type04Pointer);
+            WriteInt(bytes, 0x08, cameraPointer);
+            WriteInt(bytes, 0x0C, type0CPointer);
+
+            WriteInt(bytes, 0x10, englishPointer);
+            WriteInt(bytes, 0x14, lang2Pointer);
+            WriteInt(bytes, 0x18, frenchPointer);
+            WriteInt(bytes, 0x1C, germanPointer);
+
+            WriteInt(bytes, 0x20, spanishPointer);
+            WriteInt(bytes, 0x24, italianPointer);
+            WriteInt(bytes, 0x28, lang7Pointer);
+            WriteInt(bytes, 0x2C, lang8Pointer);
+
+            WriteInt(bytes, 0x30, tieIdPointer);
+            //0x34
+            //0x38
+            WriteInt(bytes, 0x3C, shrubIdPointer);
+
+            WriteInt(bytes, 0x40, shrubPointer);
+            //0x44
+            WriteInt(bytes, 0x48, mobyIdPointer);
+            WriteInt(bytes, 0x4C, mobyPointer);
+
+            WriteInt(bytes, 0x50, unkPointer6);
+            WriteInt(bytes, 0x54, unkPointer7);
+            WriteInt(bytes, 0x58, type50Pointer);
+            WriteInt(bytes, 0x5C, pvarSizePointer);
+
+            WriteInt(bytes, 0x60, pvarPointer);
+            WriteInt(bytes, 0x64, type5CPointer);
+            WriteInt(bytes, 0x68, cuboidPointer);
+            WriteInt(bytes, 0x6C, type64Pointer);
+
+            WriteInt(bytes, 0x70, type68Pointer);
+            WriteInt(bytes, 0x74, unkPointer12);
+            WriteInt(bytes, 0x78, splinePointer);
+            WriteInt(bytes, 0x7C, unkPointer13);
+
+            //0x80
+            WriteInt(bytes, 0x84, type80Pointer);
+            WriteInt(bytes, 0x88, unkPointer17);
+            //0x8C
+
+            WriteInt(bytes, 0x90, occlusionPointer);
 
             return bytes;
         }

--- a/LibReplanetizer/Level Objects/GameType.cs
+++ b/LibReplanetizer/Level Objects/GameType.cs
@@ -3,7 +3,7 @@ namespace LibReplanetizer
 {
     public class GameType
     {
-        readonly int[] mobySizes = { 0x78, 0x88, 0x88, 0x70 };
+        public static readonly int[] mobySizes = { 0x78, 0x88, 0x88, 0x70 };
 
         public int num;
         public int mobyElemSize;

--- a/LibReplanetizer/Level Objects/Gameplay/Moby.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Moby.cs
@@ -1,5 +1,6 @@
 ﻿using LibReplanetizer.Models;
 using OpenTK;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -213,11 +214,17 @@ namespace LibReplanetizer.LevelObjects
 
         public override byte[] ToByteArray()
         {
+            //Mobies differ for each game, there is no universal method
+            throw new NotImplementedException();
+        }
+
+        public byte[] ToByteArrayRC1()
+        {
             Vector3 eulerAngles = ToEulerAngles(modelMatrix.ExtractRotation());
 
-            byte[] buffer = new byte[ELEMENTSIZE];
+            byte[] buffer = new byte[GameType.mobySizes[0]];
 
-            WriteInt(buffer, 0x00, ELEMENTSIZE);
+            WriteInt(buffer, 0x00, GameType.mobySizes[0]);
             WriteInt(buffer, 0x04, missionID);
             WriteInt(buffer, 0x08, unk1);
             WriteInt(buffer, 0x0C, dataval);
@@ -254,6 +261,58 @@ namespace LibReplanetizer.LevelObjects
 
             WriteInt(buffer, 0x70, light);
             WriteInt(buffer, 0x74, cutscene);
+
+            return buffer;
+        }
+
+        public byte[] ToByteArrayRC23()
+        {
+            Vector3 eulerAngles = ToEulerAngles(modelMatrix.ExtractRotation());
+
+            byte[] buffer = new byte[GameType.mobySizes[1]];
+
+            WriteInt(buffer, 0x00, GameType.mobySizes[1]);
+            WriteInt(buffer, 0x04, missionID);
+            WriteInt(buffer, 0x08, unk1);
+            WriteInt(buffer, 0x0C, dataval);
+
+            WriteInt(buffer, 0x10, unk2);
+            WriteInt(buffer, 0x14, drop);
+            WriteInt(buffer, 0x18, unk3);
+            WriteInt(buffer, 0x1C, unk4);
+
+            WriteInt(buffer, 0x20, unk5);
+            WriteInt(buffer, 0x24, unk6);
+            WriteInt(buffer, 0x28, modelID);
+            WriteFloat(buffer, 0x2C, scale.X);
+
+            WriteInt(buffer, 0x30, rend1);
+            WriteInt(buffer, 0x34, rend2);
+            WriteInt(buffer, 0x38, unk7);
+            WriteInt(buffer, 0x3C, unk8);
+
+            WriteFloat(buffer, 0x40, position.X);
+            WriteFloat(buffer, 0x44, position.Y);
+            WriteFloat(buffer, 0x48, position.Z);
+            WriteFloat(buffer, 0x4C, eulerAngles.X);
+
+            WriteFloat(buffer, 0x50, eulerAngles.Y);
+            WriteFloat(buffer, 0x54, eulerAngles.Z);
+            WriteInt(buffer, 0x58, unk9);
+            WriteInt(buffer, 0x5C, unk10);
+
+            WriteInt(buffer, 0x60, unk11);
+            WriteInt(buffer, 0x64, unk12);
+            WriteInt(buffer, 0x68, pvarIndex);
+            WriteInt(buffer, 0x6C, unk13);
+
+            WriteInt(buffer, 0x70, unk14);
+            WriteUint(buffer, 0x74, color.R);
+            WriteUint(buffer, 0x78, color.G);
+            WriteUint(buffer, 0x7C, color.B);
+
+            WriteInt(buffer, 0x80, light);
+            WriteInt(buffer, 0x84, cutscene);
 
             return buffer;
         }

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -32,6 +32,7 @@ namespace LibReplanetizer
 
         public byte[] renderDefBytes;
         public byte[] collBytes;
+        public List<byte[]> collBytesChunks;
         public byte[] billboardBytes;
         public byte[] soundConfigBytes;
 
@@ -107,6 +108,7 @@ namespace LibReplanetizer
 
             terrainChunks = new List<List<TerrainFragment>>();
             collisionChunks = new List<Model>();
+            collBytesChunks = new List<byte[]>();
 
             // Engine elements
             using (EngineParser engineParser = new EngineParser(enginePath))
@@ -242,6 +244,7 @@ namespace LibReplanetizer
 
                     terrainChunks.Add(chunkParser.GetTerrainModels());
                     collisionChunks.Add(chunkParser.GetCollisionModel());
+                    collBytesChunks.Add(chunkParser.GetCollBytes());
                 }
             }
 

--- a/LibReplanetizer/Parsers/ChunkParser.cs
+++ b/LibReplanetizer/Parsers/ChunkParser.cs
@@ -4,6 +4,7 @@ using LibReplanetizer.Models;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using static LibReplanetizer.DataFunctions;
 
 namespace LibReplanetizer.Parsers
 {
@@ -25,6 +26,22 @@ namespace LibReplanetizer.Parsers
         public Model GetCollisionModel()
         {
             return GetCollisionModel(chunkHeader.collisionPointer);
+        }
+
+        /*
+         * To point of this is so that we can save the collision data
+         * reconstructing this block of data from a collision model is tedious
+         * and at the moment since you cannot modify the collision anyway it is unnecessary
+         * This here costs a few megabytes of RAM at best so it is fine
+         */
+        public byte[] GetCollBytes()
+        {
+            byte[] headBlock = ReadBlock(fileStream, chunkHeader.collisionPointer, 8);
+            int collisionStart = chunkHeader.collisionPointer + ReadInt(headBlock, 0);
+            int collisionLength = ReadInt(headBlock, 4);
+            int totalLength = collisionStart + collisionLength - chunkHeader.collisionPointer;
+
+            return ReadArbBytes(chunkHeader.collisionPointer, totalLength);
         }
 
         public void Dispose()

--- a/LibReplanetizer/Parsers/EngineParser.cs
+++ b/LibReplanetizer/Parsers/EngineParser.cs
@@ -4,6 +4,7 @@ using LibReplanetizer.Models;
 using LibReplanetizer.Models.Animations;
 using System;
 using System.Collections.Generic;
+using static LibReplanetizer.DataFunctions;
 
 namespace LibReplanetizer.Parsers
 {
@@ -107,7 +108,12 @@ namespace LibReplanetizer.Parsers
         {
             if (engineHead.collisionPointer > 0)
             {
-                return ReadArbBytes(engineHead.collisionPointer, engineHead.mobyModelPointer - engineHead.collisionPointer);
+                byte[] headBlock = ReadBlock(fileStream, engineHead.collisionPointer, 8);
+                int collisionStart = engineHead.collisionPointer + ReadInt(headBlock, 0);
+                int collisionLength = ReadInt(headBlock, 4);
+                int totalLength = collisionStart + collisionLength - engineHead.collisionPointer;
+
+                return ReadArbBytes(engineHead.collisionPointer, totalLength);
             }
             else
             {

--- a/LibReplanetizer/Serializers/ChunkSerializer.cs
+++ b/LibReplanetizer/Serializers/ChunkSerializer.cs
@@ -1,0 +1,167 @@
+﻿using LibReplanetizer.Headers;
+using LibReplanetizer.LevelObjects;
+using LibReplanetizer.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using static LibReplanetizer.DataFunctions;
+
+namespace LibReplanetizer.Serializers
+{
+    public class ChunkSerializer
+    {
+        public string pathName;
+
+        public void Save(Level level, string pathName, int chunk)
+        {
+            if (chunk >= level.terrainChunks.Count)
+                throw new IndexOutOfRangeException("Chunk does not exist!");
+
+            this.pathName = pathName;
+            FileStream fs = File.Open(pathName + "/chunk" + chunk +".ps3", FileMode.Create);
+
+            // Seek past the header
+            fs.Seek(0x10, SeekOrigin.Begin);
+
+            ChunkHeader chunkHeader = new ChunkHeader()
+            {
+                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainChunks[chunk], (int)fs.Position)),
+                collisionPointer = SeekWrite(fs, level.collBytesChunks[chunk])
+            };
+
+            byte[] head = chunkHeader.Serialize();
+            fs.Seek(0, SeekOrigin.Begin);
+            fs.Write(head, 0, head.Length);
+
+            fs.Close();
+        }
+
+        private int SeekWrite(FileStream fs, byte[] bytes)
+        {
+            int pos = (int)fs.Position;
+            fs.Write(bytes, 0, bytes.Length);
+            SeekPast(fs);
+            return pos;
+        }
+
+        private void SeekPast(FileStream fs)
+        {
+            while (fs.Position % 0x10 != 0)
+            {
+                fs.Seek(4, SeekOrigin.Current);
+            }
+        }
+
+        private byte[] WriteTfrags(List<TerrainFragment> tFrags, int fileOffset)
+        {
+            List<List<byte>> vertBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
+            List<List<byte>> rgbaBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
+            List<List<byte>> uvBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
+            List<List<byte>> indexBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
+
+            List<byte> textureBytes = new List<byte>();
+
+            byte[] tfragHeads = new byte[0x30 * tFrags.Count];
+
+            ushort chunk = 0;
+
+            for (int i = 0; i < tFrags.Count; i++)
+            {
+                TerrainModel mod = (TerrainModel)(tFrags[i].model);
+
+                int offset = i * 0x30;
+                WriteFloat(tfragHeads, offset + 0x00, tFrags[i].off_00);
+                WriteFloat(tfragHeads, offset + 0x04, tFrags[i].off_04);
+                WriteFloat(tfragHeads, offset + 0x08, tFrags[i].off_08);
+                WriteFloat(tfragHeads, offset + 0x0C, tFrags[i].off_0C);
+
+                WriteInt(tfragHeads, offset + 0x10, fileOffset + 0x60 + tfragHeads.Length + textureBytes.Count);
+                WriteInt(tfragHeads, offset + 0x14, tFrags[i].model.textureConfig.Count);
+
+                byte[] modelVertBytes = mod.SerializeVerts();
+                if (((vertBytes[chunk].Count + modelVertBytes.Length) / 0x1c) > 0xffff)
+                {
+                    chunk++;
+                }
+
+                WriteUshort(tfragHeads, offset + 0x18, (ushort)(vertBytes[chunk].Count / 0x1c));
+                WriteUshort(tfragHeads, offset + 0x1a, (ushort)(tFrags[i].model.vertexBuffer.Length / 8));
+
+                WriteUshort(tfragHeads, offset + 0x1C, tFrags[i].off_1C);
+                WriteUshort(tfragHeads, offset + 0x1E, tFrags[i].off_1E);
+                WriteUshort(tfragHeads, offset + 0x20, tFrags[i].off_20);
+                WriteUshort(tfragHeads, offset + 0x22, chunk);
+                WriteUint(tfragHeads, offset + 0x24, tFrags[i].off_24);
+                WriteUint(tfragHeads, offset + 0x28, tFrags[i].off_28);
+                WriteUint(tfragHeads, offset + 0x2C, tFrags[i].off_2C);
+
+                foreach (var texConf in tFrags[i].model.textureConfig)
+                {
+                    byte[] texBytes = new byte[0x10];
+                    WriteInt(texBytes, 0x00, texConf.ID);
+                    WriteInt(texBytes, 0x04, texConf.start + indexBytes[chunk].Count / 2);
+                    WriteInt(texBytes, 0x08, texConf.size);
+                    WriteInt(texBytes, 0x0C, texConf.mode);
+                    textureBytes.AddRange(texBytes);
+                }
+
+                indexBytes[chunk].AddRange(tFrags[i].model.GetFaceBytes((ushort)(vertBytes[chunk].Count / 0x1C)));
+                vertBytes[chunk].AddRange(modelVertBytes);
+                rgbaBytes[chunk].AddRange(tFrags[i].model.rgbas);
+                uvBytes[chunk].AddRange(tFrags[i].model.SerializeUVs());
+
+            }
+
+            List<byte> outBytes = new List<byte>();
+
+            byte[] head = new byte[0x60];
+            WriteInt(head, 0, fileOffset + 0x60);
+            WriteUshort(head, 0x4, (ushort)tFrags.Count);
+            WriteUshort(head, 0x6, (ushort)tFrags.Count);
+
+            outBytes.AddRange(head);
+            outBytes.AddRange(tfragHeads);
+            outBytes.AddRange(textureBytes);
+
+            int[] vertOffsets = { 0, 0, 0, 0 };
+            int[] rgbaOffsets = { 0, 0, 0, 0 };
+            int[] uvOffsets = { 0, 0, 0, 0 };
+            int[] indexOffsets = { 0, 0, 0, 0 };
+
+            for (int i = 0; i < 4; i++)
+            {
+                if (vertBytes[i].Count == 0)
+                {
+                    continue;
+                }
+                Pad(outBytes);
+                vertOffsets[i] = fileOffset + outBytes.Count;
+                outBytes.AddRange(vertBytes[i]);
+                Pad(outBytes);
+                rgbaOffsets[i] = fileOffset + outBytes.Count;
+                outBytes.AddRange(rgbaBytes[i]);
+                Pad(outBytes);
+                uvOffsets[i] = fileOffset + outBytes.Count;
+                outBytes.AddRange(uvBytes[i]);
+                Pad(outBytes);
+                indexOffsets[i] = fileOffset + outBytes.Count;
+                outBytes.AddRange(indexBytes[i]);
+                Pad(outBytes);
+            }
+
+
+            byte[] outByteArr = outBytes.ToArray();
+
+            for (int i = 0; i < 4; i++)
+            {
+                WriteInt(outByteArr, 0x08 + i * 4, vertOffsets[i]);
+                WriteInt(outByteArr, 0x18 + i * 4, rgbaOffsets[i]);
+                WriteInt(outByteArr, 0x28 + i * 4, uvOffsets[i]);
+                WriteInt(outByteArr, 0x38 + i * 4, indexOffsets[i]);
+            }
+
+            return outByteArr;
+        }
+    }
+}

--- a/Replanetizer/CustomControls/CustomGLControl.cs
+++ b/Replanetizer/CustomControls/CustomGLControl.cs
@@ -853,6 +853,8 @@ namespace RatchetEdit
 
                     Collision col = (Collision)level.collisionChunks[i];
 
+                    if (col.indBuff.Length == 0) continue;
+
                     GL.UseProgram(colorShaderID);
                     Matrix4 worldView = this.worldView;
                     GL.UniformMatrix4(matrixID, false, ref worldView);

--- a/Replanetizer/Forms/Main.cs
+++ b/Replanetizer/Forms/Main.cs
@@ -641,6 +641,12 @@ namespace RatchetEdit
                 gameplaySerializer.Save(level, mapSaveDialog.FileName);
                 EngineSerializer engineSerializer = new EngineSerializer();
                 engineSerializer.Save(level, pathName);
+
+                for (int i = 0; i < level.terrainChunks.Count; i++)
+                {      
+                    ChunkSerializer chunkSerializer = new ChunkSerializer();
+                    chunkSerializer.Save(level, pathName, i);
+                }
             }
             InvalidateView();
         }


### PR DESCRIPTION
- Fixed saving and loading Rac 2 and 3 levels
- Fixed a crash on Grelbin, Yeedil and Rac 3's Insomniac Museum where for some reason there is no collision data in some of the chunks
- Fixed collision bytes being read further than they actually are

-------

I will keep this PR up for a bit and merge myself if no one has any suggestions.
