### PR TITLE
Serialization Fixes

### DIFF
--- a/LibReplanetizer/DataFunctions.cs
+++ b/LibReplanetizer/DataFunctions.cs
@@ -245,48 +245,5 @@ namespace LibReplanetizer
                 arr.Add(0);
             }
         }
-
-        // "Polyfill" for function in upcoming OpenTK version
-        public static Vector3 ToEulerAngles(Quaternion q)
-        {
-            /*
-            reference
-            http://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
-            http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/
-            */
-
-            Vector3 eulerAngles;
-
-            // Threshold for the singularities found at the north/south poles.
-            const float SINGULARITY_THRESHOLD = 0.4999995f;
-
-            var sqw = q.W * q.W;
-            var sqx = q.X * q.X;
-            var sqy = q.Y * q.Y;
-            var sqz = q.Z * q.Z;
-            var unit = sqx + sqy + sqz + sqw; // if normalised is one, otherwise is correction factor
-            var singularityTest = (q.X * q.Z) + (q.W * q.Y);
-
-            if (singularityTest > SINGULARITY_THRESHOLD * unit)
-            {
-                eulerAngles.Z = (float)(2 * Math.Atan2(q.X, q.W));
-                eulerAngles.Y = MathHelper.PiOver2;
-                eulerAngles.X = 0;
-            }
-            else if (singularityTest < -SINGULARITY_THRESHOLD * unit)
-            {
-                eulerAngles.Z = (float)(-2 * Math.Atan2(q.X, q.W));
-                eulerAngles.Y = -MathHelper.PiOver2;
-                eulerAngles.X = 0;
-            }
-            else
-            {
-                eulerAngles.Z = (float)Math.Atan2(2 * ((q.W * q.Z) - (q.X * q.Y)), sqw + sqx - sqy - sqz);
-                eulerAngles.Y = (float)Math.Asin(2 * singularityTest / unit);
-                eulerAngles.X = (float)Math.Atan2(2 * ((q.W * q.X) - (q.Y * q.Z)), sqw - sqx - sqy + sqz);
-            }
-
-            return eulerAngles;
-        }
     }
 }

--- a/LibReplanetizer/Headers/EngineHeader.cs
+++ b/LibReplanetizer/Headers/EngineHeader.cs
@@ -5,8 +5,8 @@ namespace LibReplanetizer.Headers
 {
     public class EngineHeader
     {
-        const int RAC123ENGINESIZE = 0x78;
-        const int DLENGINESIZE = 0x90;
+        const int RAC123ENGINESIZE = 0x84;
+        const int DLENGINESIZE = 0x98;
 
         public GameType game;
 
@@ -53,7 +53,6 @@ namespace LibReplanetizer.Headers
         public int unk7Pointer;
         public int unk8Pointer;
         public int unk9Pointer;
-        public int unk10Pointer;
 
         public EngineHeader() { }
 
@@ -185,7 +184,6 @@ namespace LibReplanetizer.Headers
             uiElementPointer = ReadInt(engineHeadBlock, 0x80);
             unk8Pointer = ReadInt(engineHeadBlock, 0x84);
             unk9Pointer = ReadInt(engineHeadBlock, 0x88);
-            unk10Pointer = ReadInt(engineHeadBlock, 0x8C);
         }
 
         public byte[] Serialize()
@@ -244,6 +242,10 @@ namespace LibReplanetizer.Headers
 
             WriteInt(bytes, 0x70, texture2dPointer);
             WriteInt(bytes, 0x74, uiElementPointer);
+            WriteInt(bytes, 0x78, 0);
+            WriteInt(bytes, 0x7C, 1);
+
+            WriteInt(bytes, 0x80, 2);
 
             return bytes;
         }
@@ -295,7 +297,10 @@ namespace LibReplanetizer.Headers
             WriteInt(bytes, 0x80, uiElementPointer);
             WriteInt(bytes, 0x84, unk8Pointer);
             WriteInt(bytes, 0x88, unk9Pointer);
-            WriteInt(bytes, 0x8C, unk10Pointer);
+            WriteInt(bytes, 0x8C, 0);
+
+            WriteInt(bytes, 0x90, 1);
+            WriteInt(bytes, 0x94, 2);
 
             return bytes;
         }

--- a/LibReplanetizer/Headers/GameplayHeader.cs
+++ b/LibReplanetizer/Headers/GameplayHeader.cs
@@ -6,6 +6,7 @@ namespace LibReplanetizer.Headers
     public class GameplayHeader
     {
         public const int GAMEPLAYSIZE = 0xA0;
+        public const int GAMEPLAYSIZEDL = 0x90;
 
         public int levelVarPointer;
         public int lightsPointer;
@@ -24,33 +25,41 @@ namespace LibReplanetizer.Headers
 
         public int tieIdPointer;
         public int tiePointer;
+        public int tieGroupsPointer;
         public int shrubIdPointer;
-        public int shrubPointer;
 
+        public int shrubPointer;
+        public int shrubGroupsPointer;
         public int mobyIdPointer;
         public int mobyPointer;
+
         public int mobyGroupsPointer;
         public int type4CPointer;
-
         public int type50Pointer;
         public int pvarSizePointer;
+
         public int pvarPointer;
         public int type5CPointer;
-
         public int cuboidPointer;
         public int spherePointer;
+
         public int cylinderPointer;
         public int unkPointer12;
-
         public int splinePointer;
         public int grindPathsPointer;
+
+        public int unkPointer16;
         public int unkPointer14;
         public int type7CPointer;
-
         public int type80Pointer;
+
         public int unkPointer17;
+        public int unkPointer18;
         public int type88Pointer;
         public int occlusionPointer;
+
+        public int tieAmbientPointer;
+        public int areasPointer;
 
         public GameplayHeader() { }
 
@@ -143,12 +152,12 @@ namespace LibReplanetizer.Headers
             koreanPointer = ReadInt(gameplayHeadBlock, 0x2C);
 
             tieIdPointer = ReadInt(gameplayHeadBlock, 0x30);
-            //tiePointer = ReadInt(gameplayHeadBlock, 0x34);
-            //tieGroupsPointer = ReadInt(gameplayHeadBlock, 0x38);
+            tiePointer = ReadInt(gameplayHeadBlock, 0x34);
+            tieGroupsPointer = ReadInt(gameplayHeadBlock, 0x38);
             shrubIdPointer = ReadInt(gameplayHeadBlock, 0x3C);
 
             shrubPointer = ReadInt(gameplayHeadBlock, 0x40);
-            //shrubGroupsPointer = ReadInt(gameplayHeadBlock, 0x44);
+            shrubGroupsPointer = ReadInt(gameplayHeadBlock, 0x44);
             mobyIdPointer = ReadInt(gameplayHeadBlock, 0x48);
             mobyPointer = ReadInt(gameplayHeadBlock, 0x4C);
 
@@ -167,14 +176,14 @@ namespace LibReplanetizer.Headers
             splinePointer = ReadInt(gameplayHeadBlock, 0x78);
             grindPathsPointer = ReadInt(gameplayHeadBlock, 0x7C);
 
-            // = ReadInt(gameplayHeadBlock, 0x80);
+            unkPointer16 = ReadInt(gameplayHeadBlock, 0x80);
             type80Pointer = ReadInt(gameplayHeadBlock, 0x84);
             unkPointer17 = ReadInt(gameplayHeadBlock, 0x88);
-            // = ReadInt(gameplayHeadBlock, 0x8C);
+            unkPointer18 = ReadInt(gameplayHeadBlock, 0x8C);
 
             occlusionPointer = ReadInt(gameplayHeadBlock, 0x90);
-            // tieAmbientPointer = ReadInt(gameplayHeadBlock, 0x94);
-            // areasPointer = ReadInt(gameplayHeadBlock, 0x98);
+            tieAmbientPointer = ReadInt(gameplayHeadBlock, 0x94);
+            areasPointer = ReadInt(gameplayHeadBlock, 0x98);
         }
 
         private void GetDLVals(byte[] gameplayHeadBlock)
@@ -184,7 +193,7 @@ namespace LibReplanetizer.Headers
             soundPointer = ReadInt(gameplayHeadBlock, 0x08);
             englishPointer = ReadInt(gameplayHeadBlock, 0x0C);
 
-            ukenglishPointer = ReadInt(gameplayHeadBlock, 0x10); 
+            ukenglishPointer = ReadInt(gameplayHeadBlock, 0x10);
             frenchPointer = ReadInt(gameplayHeadBlock, 0x14);
             germanPointer = ReadInt(gameplayHeadBlock, 0x18);
             spanishPointer = ReadInt(gameplayHeadBlock, 0x1C);
@@ -195,7 +204,7 @@ namespace LibReplanetizer.Headers
             mobyIdPointer = ReadInt(gameplayHeadBlock, 0x2C);
 
             mobyPointer = ReadInt(gameplayHeadBlock, 0x30);
-            
+
             pvarSizePointer = ReadInt(gameplayHeadBlock, 0x40);
             pvarPointer = ReadInt(gameplayHeadBlock, 0x44);
             cuboidPointer = ReadInt(gameplayHeadBlock, 0x4C);
@@ -207,33 +216,25 @@ namespace LibReplanetizer.Headers
             type04Pointer = ReadInt(gameplayHeadBlock, 0x04);
             
             
-
             lang2Pointer = ReadInt(gameplayHeadBlock, 0x14);
-
             tieIdPointer = ReadInt(gameplayHeadBlock, 0x30);
             // = ReadInt(gameplayHeadBlock, 0x34);
             // = ReadInt(gameplayHeadBlock, 0x38);
             shrubIdPointer = ReadInt(gameplayHeadBlock, 0x3C);
-
             shrubPointer = ReadInt(gameplayHeadBlock, 0x40);
             // = ReadInt(gameplayHeadBlock, 0x44);
-
             unkPointer6 = ReadInt(gameplayHeadBlock, 0x50);
             unkPointer7 = ReadInt(gameplayHeadBlock, 0x54);
             type50Pointer = ReadInt(gameplayHeadBlock, 0x58);
-
             type5CPointer = ReadInt(gameplayHeadBlock, 0x64);
             type64Pointer = ReadInt(gameplayHeadBlock, 0x6C);
-
             type68Pointer = ReadInt(gameplayHeadBlock, 0x70);
             unkPointer12 = ReadInt(gameplayHeadBlock, 0x74);
             unkPointer13 = ReadInt(gameplayHeadBlock, 0x7C);
-
             // = ReadInt(gameplayHeadBlock, 0x80);
             type80Pointer = ReadInt(gameplayHeadBlock, 0x84);
             unkPointer17 = ReadInt(gameplayHeadBlock, 0x88);
             // = ReadInt(gameplayHeadBlock, 0x8C);
-
             occlusionPointer = ReadInt(gameplayHeadBlock, 0x90);*/
         }
 
@@ -325,12 +326,12 @@ namespace LibReplanetizer.Headers
             WriteInt(bytes, 0x2C, koreanPointer);
 
             WriteInt(bytes, 0x30, tieIdPointer);
-            //0x34
-            //0x38
+            WriteInt(bytes, 0x34, tiePointer);
+            WriteInt(bytes, 0x38, tieGroupsPointer);
             WriteInt(bytes, 0x3C, shrubIdPointer);
 
             WriteInt(bytes, 0x40, shrubPointer);
-            //0x44
+            WriteInt(bytes, 0x44, shrubGroupsPointer);
             WriteInt(bytes, 0x48, mobyIdPointer);
             WriteInt(bytes, 0x4C, mobyPointer);
 
@@ -349,19 +350,21 @@ namespace LibReplanetizer.Headers
             WriteInt(bytes, 0x78, splinePointer);
             WriteInt(bytes, 0x7C, grindPathsPointer);
 
-            //0x80
+            WriteInt(bytes, 0x80, unkPointer16);
             WriteInt(bytes, 0x84, type80Pointer);
             WriteInt(bytes, 0x88, unkPointer17);
-            //0x8C
+            WriteInt(bytes, 0x8C, unkPointer18);
 
             WriteInt(bytes, 0x90, occlusionPointer);
+            WriteInt(bytes, 0x94, tieAmbientPointer);
+            WriteInt(bytes, 0x98, areasPointer);
 
             return bytes;
         }
 
         private byte[] SerializeDL()
         {
-            byte[] bytes = new byte[GAMEPLAYSIZE];
+            byte[] bytes = new byte[GAMEPLAYSIZEDL];
 
             WriteInt(bytes, 0x00, levelVarPointer);
             WriteInt(bytes, 0x04, cameraPointer);

--- a/LibReplanetizer/Headers/Headers.cs
+++ b/LibReplanetizer/Headers/Headers.cs
@@ -9,23 +9,44 @@ namespace LibReplanetizer.Headers
     public class TerrainHead
     {
         public uint headPointer;
+        // this number is equal over all terrains in a level but it differs between levels
+        public ushort levelNumber;
         public ushort headCount;
         public List<int> vertexPointers = new List<int>();
         public List<int> rgbaPointers = new List<int>();
         public List<int> UVpointers = new List<int>();
         public List<int> indexPointers = new List<int>();
+        public List<int> unkPointers = new List<int>();
 
-        public TerrainHead(byte[] terrainBlock)
+        public TerrainHead(byte[] terrainBlock, GameType game)
         {
             headPointer = ReadUint(terrainBlock, 0x00);
+            levelNumber = ReadUshort(terrainBlock, 0x04);
             headCount = ReadUshort(terrainBlock, 0x06);
 
-            for (int i = 0; i < 4; i++)
+            switch (game.num)
             {
-                vertexPointers.Add(ReadInt(terrainBlock, 0x08 + i * 4));
-                rgbaPointers.Add(ReadInt(terrainBlock, 0x18 + i * 4));
-                UVpointers.Add(ReadInt(terrainBlock, 0x28 + i * 4));
-                indexPointers.Add(ReadInt(terrainBlock, 0x38 + i * 4));
+                case 1:
+                case 2:
+                case 3:
+                    for (int i = 0; i < 4; i++)
+                    {
+                        vertexPointers.Add(ReadInt(terrainBlock, 0x08 + i * 4));
+                        rgbaPointers.Add(ReadInt(terrainBlock, 0x18 + i * 4));
+                        UVpointers.Add(ReadInt(terrainBlock, 0x28 + i * 4));
+                        indexPointers.Add(ReadInt(terrainBlock, 0x38 + i * 4));
+                    }
+                    break;
+                case 4:
+                    for (int i = 0; i < 4; i++)
+                    {
+                        vertexPointers.Add(ReadInt(terrainBlock, 0x08 + i * 4));
+                        rgbaPointers.Add(ReadInt(terrainBlock, 0x18 + i * 4));
+                        UVpointers.Add(ReadInt(terrainBlock, 0x28 + i * 4));
+                        indexPointers.Add(ReadInt(terrainBlock, 0x38 + i * 4));
+                        unkPointers.Add(ReadInt(terrainBlock, 0x48 + i * 4));
+                    }
+                    break;
             }
         }
     }

--- a/LibReplanetizer/Level Objects/Engine/Terrain.cs
+++ b/LibReplanetizer/Level Objects/Engine/Terrain.cs
@@ -2,12 +2,23 @@
 using LibReplanetizer.Models;
 using OpenTK.Mathematics;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using static LibReplanetizer.DataFunctions;
 
 namespace LibReplanetizer.LevelObjects
 {
+    public class Terrain
+    {
+        public ushort levelNumber;
+        public List<TerrainFragment> fragments;
 
+        public Terrain(List<TerrainFragment> fragments, ushort levelNumber)
+        {
+            this.fragments = fragments;
+            this.levelNumber = levelNumber;
+        }
+    }
 
     public class TerrainFragment : ModelObject
     {

--- a/LibReplanetizer/Level Objects/Gameplay/Cuboid.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Cuboid.cs
@@ -48,7 +48,7 @@ namespace LibReplanetizer.LevelObjects
             mat1 = ReadMatrix4(block, offset + 0x00);
             mat2 = ReadMatrix4(block, offset + 0x40);
 
-            modelMatrix = mat1 + mat2;
+            modelMatrix = mat1;
             rotation = modelMatrix.ExtractRotation();
             position = modelMatrix.ExtractTranslation();
             scale = modelMatrix.ExtractScale();

--- a/LibReplanetizer/Level Objects/Gameplay/Cylinder.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Cylinder.cs
@@ -94,7 +94,7 @@ namespace LibReplanetizer.LevelObjects
 
             mat1 = ReadMatrix4(block, offset + 0x00);
             mat2 = ReadMatrix4(block, offset + 0x40);
-            modelMatrix = mat1 + mat2;
+            modelMatrix = mat1;
             rotation = modelMatrix.ExtractRotation();
             position = modelMatrix.ExtractTranslation();
             scale = modelMatrix.ExtractScale();

--- a/LibReplanetizer/Level Objects/Gameplay/LevelVariables.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/LevelVariables.cs
@@ -41,8 +41,8 @@ namespace LibReplanetizer.LevelObjects
         [Category("Attributes"), DisplayName("Ship Rotation")]
         public float shipRotation { get; set; }
 
-        [Category("Attributes"), DisplayName("Ship Lighting")]
-        public Color shipColor { get; set; }
+        [Category("Unknown"), DisplayName("Unknown Color")]
+        public Color unkColor { get; set; }
 
         [Category("Unknown"), DisplayName("OFF_48: Always 0")]
         public int off_48 { get; set; }
@@ -52,6 +52,39 @@ namespace LibReplanetizer.LevelObjects
 
         [Category("Unknown"), DisplayName("OFF_58: Always 0")]
         public int off_58 { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_5C")]
+        public int off_5C { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_60")]
+        public int off_60 { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_64")]
+        public float off_64 { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_68")]
+        public int off_68 { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_6C")]
+        public int off_6C { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_70")]
+        public int off_70 { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_74")]
+        public float off_74 { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_78")]
+        public int off_78 { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_7C")]
+        public int off_7C { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_80")]
+        public int off_80 { get; set; }
+
+        [Category("Unknown"), DisplayName("OFF_84")]
+        public int[] DL_off_84 { get; set; }
 
         public LevelVariables(GameType game, FileStream fileStream, int levelVarPointer)
         {
@@ -63,10 +96,13 @@ namespace LibReplanetizer.LevelObjects
                     GetRC1Vals(fileStream, levelVarPointer);
                     break;
                 case 2:
+                    GetRC2Vals(fileStream, levelVarPointer);
+                    break;
                 case 3:
+                    GetRC3Vals(fileStream, levelVarPointer);
+                    break;
                 case 4:
-                default:
-                    GetRC23DLVals(fileStream, levelVarPointer);
+                    GetDLVals(fileStream, levelVarPointer);
                     break;
             }
         }
@@ -104,20 +140,20 @@ namespace LibReplanetizer.LevelObjects
             fogColor = Color.FromArgb(r, g, b);
             if (shipColorR != -1)
             {
-                shipColor = Color.FromArgb(shipColorR, shipColorG, shipColorB);
+                unkColor = Color.FromArgb(shipColorR, shipColorG, shipColorB);
             }
             else
             {
-                shipColor = Color.Empty;
+                unkColor = Color.Empty;
             }
 
             sphereCentre = Vector3.Zero;
             shipPosition = new Vector3(shipPositionX, shipPositionY, shipPositionZ);
         }
 
-        private void GetRC23DLVals(FileStream fileStream, int levelVarPointer)
+        private void GetRC2Vals(FileStream fileStream, int levelVarPointer)
         {
-            byte[] levelVarBlock = ReadBlock(fileStream, levelVarPointer, 0x5C);
+            byte[] levelVarBlock = ReadBlock(fileStream, levelVarPointer, 0x80);
 
             int bgRed = ReadInt(levelVarBlock, 0x00);
             int bgGreen = ReadInt(levelVarBlock, 0x04);
@@ -147,17 +183,160 @@ namespace LibReplanetizer.LevelObjects
             int shipColorG = ReadInt(levelVarBlock, 0x50);
             int shipColorB = ReadInt(levelVarBlock, 0x54);
             off_58 = ReadInt(levelVarBlock, 0x58);
+            off_5C = ReadInt(levelVarBlock, 0x5C);
+
+            off_60 = ReadInt(levelVarBlock, 0x60);
+            off_64 = ReadFloat(levelVarBlock, 0x64);
+            off_68 = ReadInt(levelVarBlock, 0x68);
+            off_6C = ReadInt(levelVarBlock, 0x6C);
+
+            off_70 = ReadInt(levelVarBlock, 0x70);
+            off_74 = ReadFloat(levelVarBlock, 0x74);
+            off_78 = ReadInt(levelVarBlock, 0x78);
+            off_7C = ReadInt(levelVarBlock, 0x7C);
 
             backgroundColor = Color.FromArgb(bgRed, bgGreen, bgBlue);
             fogColor = Color.FromArgb(r, g, b);
             if (shipColorR != -1)
             {
-                shipColor = Color.FromArgb(shipColorR, shipColorG, shipColorB);
-            } else
-            {
-                shipColor = Color.Empty;
+                unkColor = Color.FromArgb(shipColorR, shipColorG, shipColorB);
             }
-            
+            else
+            {
+                unkColor = Color.Empty;
+            }
+
+
+            sphereCentre = new Vector3(sphereCentreX, sphereCentreY, sphereCentreZ);
+            shipPosition = new Vector3(shipPositionX, shipPositionY, shipPositionZ);
+        }
+
+        private void GetRC3Vals(FileStream fileStream, int levelVarPointer)
+        {
+            byte[] levelVarBlock = ReadBlock(fileStream, levelVarPointer, 0x84);
+
+            int bgRed = ReadInt(levelVarBlock, 0x00);
+            int bgGreen = ReadInt(levelVarBlock, 0x04);
+            int bgBlue = ReadInt(levelVarBlock, 0x08);
+            int r = ReadInt(levelVarBlock, 0x0c);
+
+            int g = ReadInt(levelVarBlock, 0x10);
+            int b = ReadInt(levelVarBlock, 0x14);
+            fogNearDistance = ReadFloat(levelVarBlock, 0x18);
+            fogFarDistance = ReadFloat(levelVarBlock, 0x1C);
+
+            fogNearIntensity = ReadFloat(levelVarBlock, 0x20);
+            fogFarIntensity = ReadFloat(levelVarBlock, 0x24);
+            deathPlaneZ = ReadFloat(levelVarBlock, 0x28);
+            isSphericalWorld = ReadInt(levelVarBlock, 0x2C);
+
+            float sphereCentreX = ReadFloat(levelVarBlock, 0x30);
+            float sphereCentreY = ReadFloat(levelVarBlock, 0x34);
+            float sphereCentreZ = ReadFloat(levelVarBlock, 0x38);
+            float shipPositionX = ReadFloat(levelVarBlock, 0x3C);
+
+            float shipPositionY = ReadFloat(levelVarBlock, 0x40);
+            float shipPositionZ = ReadFloat(levelVarBlock, 0x44);
+            shipRotation = ReadFloat(levelVarBlock, 0x48);
+            int shipColorR = ReadInt(levelVarBlock, 0x4C);
+
+            int shipColorG = ReadInt(levelVarBlock, 0x50);
+            int shipColorB = ReadInt(levelVarBlock, 0x54);
+            off_58 = ReadInt(levelVarBlock, 0x58);
+            off_5C = ReadInt(levelVarBlock, 0x5C);
+
+            off_60 = ReadInt(levelVarBlock, 0x60);
+            off_64 = ReadFloat(levelVarBlock, 0x64);
+            off_68 = ReadInt(levelVarBlock, 0x68);
+            off_6C = ReadInt(levelVarBlock, 0x6C);
+
+            off_70 = ReadInt(levelVarBlock, 0x70);
+            off_74 = ReadFloat(levelVarBlock, 0x74);
+            off_78 = ReadInt(levelVarBlock, 0x78);
+            off_7C = ReadInt(levelVarBlock, 0x7C);
+
+            off_80 = ReadInt(levelVarBlock, 0x80);
+
+            backgroundColor = Color.FromArgb(bgRed, bgGreen, bgBlue);
+            fogColor = Color.FromArgb(r, g, b);
+            if (shipColorR != -1)
+            {
+                unkColor = Color.FromArgb(shipColorR, shipColorG, shipColorB);
+            }
+            else
+            {
+                unkColor = Color.Empty;
+            }
+
+
+            sphereCentre = new Vector3(sphereCentreX, sphereCentreY, sphereCentreZ);
+            shipPosition = new Vector3(shipPositionX, shipPositionY, shipPositionZ);
+        }
+
+        private void GetDLVals(FileStream fileStream, int levelVarPointer)
+        {
+            byte[] levelVarBlock = ReadBlock(fileStream, levelVarPointer, 0x34C);
+
+            int bgRed = ReadInt(levelVarBlock, 0x00);
+            int bgGreen = ReadInt(levelVarBlock, 0x04);
+            int bgBlue = ReadInt(levelVarBlock, 0x08);
+            int r = ReadInt(levelVarBlock, 0x0c);
+
+            int g = ReadInt(levelVarBlock, 0x10);
+            int b = ReadInt(levelVarBlock, 0x14);
+            fogNearDistance = ReadFloat(levelVarBlock, 0x18);
+            fogFarDistance = ReadFloat(levelVarBlock, 0x1C);
+
+            fogNearIntensity = ReadFloat(levelVarBlock, 0x20);
+            fogFarIntensity = ReadFloat(levelVarBlock, 0x24);
+            deathPlaneZ = ReadFloat(levelVarBlock, 0x28);
+            isSphericalWorld = ReadInt(levelVarBlock, 0x2C);
+
+            float sphereCentreX = ReadFloat(levelVarBlock, 0x30);
+            float sphereCentreY = ReadFloat(levelVarBlock, 0x34);
+            float sphereCentreZ = ReadFloat(levelVarBlock, 0x38);
+            float shipPositionX = ReadFloat(levelVarBlock, 0x3C);
+
+            float shipPositionY = ReadFloat(levelVarBlock, 0x40);
+            float shipPositionZ = ReadFloat(levelVarBlock, 0x44);
+            shipRotation = ReadFloat(levelVarBlock, 0x48);
+            int shipColorR = ReadInt(levelVarBlock, 0x4C);
+
+            int shipColorG = ReadInt(levelVarBlock, 0x50);
+            int shipColorB = ReadInt(levelVarBlock, 0x54);
+            off_58 = ReadInt(levelVarBlock, 0x58);
+            off_5C = ReadInt(levelVarBlock, 0x5C);
+
+            off_60 = ReadInt(levelVarBlock, 0x60);
+            off_64 = ReadFloat(levelVarBlock, 0x64);
+            off_68 = ReadInt(levelVarBlock, 0x68);
+            off_6C = ReadInt(levelVarBlock, 0x6C);
+
+            off_70 = ReadInt(levelVarBlock, 0x70);
+            off_74 = ReadFloat(levelVarBlock, 0x74);
+            off_78 = ReadInt(levelVarBlock, 0x78);
+            off_7C = ReadInt(levelVarBlock, 0x7C);
+
+            off_80 = ReadInt(levelVarBlock, 0x80);
+
+            DL_off_84 = new int[211 - 33];
+
+            for (int i = 0; i < DL_off_84.Length; i++)
+            {
+                DL_off_84[i] = ReadInt(levelVarBlock, 0x84 + i * 0x4);
+            }
+
+            backgroundColor = Color.FromArgb(bgRed, bgGreen, bgBlue);
+            fogColor = Color.FromArgb(r, g, b);
+            if (shipColorR != -1)
+            {
+                unkColor = Color.FromArgb(shipColorR, shipColorG, shipColorB);
+            }
+            else
+            {
+                unkColor = Color.Empty;
+            }
+
 
             sphereCentre = new Vector3(sphereCentreX, sphereCentreY, sphereCentreZ);
             shipPosition = new Vector3(shipPositionX, shipPositionY, shipPositionZ);
@@ -170,10 +349,13 @@ namespace LibReplanetizer.LevelObjects
                 case 1:
                     return SerializeRC1();
                 case 2:
+                    return SerializeRC2();
                 case 3:
+                    return SerializeRC3();
                 case 4:
+                    return SerializeDL();
                 default:
-                    return SerializeRC23DL();
+                    return SerializeRC3();
             }
         }
 
@@ -200,7 +382,7 @@ namespace LibReplanetizer.LevelObjects
             WriteFloat(bytes, 0x34, shipPosition.Z);
             WriteFloat(bytes, 0x38, shipRotation);
 
-            if (shipColor.IsEmpty)
+            if (unkColor.IsEmpty)
             {
                 WriteInt(bytes, 0x3C, -1);
                 WriteInt(bytes, 0x40, 0);
@@ -208,9 +390,9 @@ namespace LibReplanetizer.LevelObjects
             }
             else
             {
-                WriteInt(bytes, 0x3C, shipColor.R);
-                WriteInt(bytes, 0x40, shipColor.G);
-                WriteInt(bytes, 0x44, shipColor.B);
+                WriteInt(bytes, 0x3C, unkColor.R);
+                WriteInt(bytes, 0x40, unkColor.G);
+                WriteInt(bytes, 0x44, unkColor.B);
             }
 
             WriteInt(bytes, 0x48, off_48);
@@ -219,9 +401,9 @@ namespace LibReplanetizer.LevelObjects
             return bytes;
         }
 
-        private byte[] SerializeRC23DL()
+        private byte[] SerializeRC2()
         {
-            byte[] bytes = new byte[0x5C];
+            byte[] bytes = new byte[0x80];
 
             WriteUint(bytes, 0x00, backgroundColor.R);
             WriteUint(bytes, 0x04, backgroundColor.G);
@@ -247,22 +429,156 @@ namespace LibReplanetizer.LevelObjects
             WriteFloat(bytes, 0x44, shipPosition.Z);
             WriteFloat(bytes, 0x48, shipRotation);
 
-            if (shipColor.IsEmpty)
+            if (unkColor.IsEmpty)
             {
                 WriteInt(bytes, 0x4C, -1);
                 WriteInt(bytes, 0x50, 0);
                 WriteInt(bytes, 0x54, 0);
-            } else
+            }
+            else
             {
-                WriteInt(bytes, 0x4C, shipColor.R);
-                WriteInt(bytes, 0x50, shipColor.G);
-                WriteInt(bytes, 0x54, shipColor.B);
+                WriteInt(bytes, 0x4C, unkColor.R);
+                WriteInt(bytes, 0x50, unkColor.G);
+                WriteInt(bytes, 0x54, unkColor.B);
             }
 
             WriteInt(bytes, 0x58, off_58);
+            WriteInt(bytes, 0x5C, off_5C);
+
+            WriteInt(bytes, 0x60, off_60);
+            WriteFloat(bytes, 0x64, off_64);
+            WriteInt(bytes, 0x68, off_68);
+            WriteInt(bytes, 0x6C, off_6C);
+
+            WriteInt(bytes, 0x70, off_70);
+            WriteFloat(bytes, 0x74, off_74);
+            WriteInt(bytes, 0x78, off_78);
+            WriteInt(bytes, 0x7C, off_7C);
 
             return bytes;
         }
 
+        private byte[] SerializeRC3()
+        {
+            byte[] bytes = new byte[0x84];
+
+            WriteUint(bytes, 0x00, backgroundColor.R);
+            WriteUint(bytes, 0x04, backgroundColor.G);
+            WriteUint(bytes, 0x08, backgroundColor.B);
+            WriteUint(bytes, 0x0C, fogColor.R);
+
+            WriteUint(bytes, 0x10, fogColor.G);
+            WriteUint(bytes, 0x14, fogColor.B);
+            WriteFloat(bytes, 0x18, fogNearDistance);
+            WriteFloat(bytes, 0x1C, fogFarDistance);
+
+            WriteFloat(bytes, 0x20, fogNearIntensity);
+            WriteFloat(bytes, 0x24, fogFarIntensity);
+            WriteFloat(bytes, 0x28, deathPlaneZ);
+            WriteInt(bytes, 0x2C, isSphericalWorld);
+
+            WriteFloat(bytes, 0x30, sphereCentre.X);
+            WriteFloat(bytes, 0x34, sphereCentre.Y);
+            WriteFloat(bytes, 0x38, sphereCentre.Z);
+            WriteFloat(bytes, 0x3C, shipPosition.X);
+
+            WriteFloat(bytes, 0x40, shipPosition.Y);
+            WriteFloat(bytes, 0x44, shipPosition.Z);
+            WriteFloat(bytes, 0x48, shipRotation);
+
+            if (unkColor.IsEmpty)
+            {
+                WriteInt(bytes, 0x4C, -1);
+                WriteInt(bytes, 0x50, 0);
+                WriteInt(bytes, 0x54, 0);
+            }
+            else
+            {
+                WriteInt(bytes, 0x4C, unkColor.R);
+                WriteInt(bytes, 0x50, unkColor.G);
+                WriteInt(bytes, 0x54, unkColor.B);
+            }
+
+            WriteInt(bytes, 0x58, off_58);
+            WriteInt(bytes, 0x5C, off_5C);
+
+            WriteInt(bytes, 0x60, off_60);
+            WriteFloat(bytes, 0x64, off_64);
+            WriteInt(bytes, 0x68, off_68);
+            WriteInt(bytes, 0x6C, off_6C);
+
+            WriteInt(bytes, 0x70, off_70);
+            WriteFloat(bytes, 0x74, off_74);
+            WriteInt(bytes, 0x78, off_78);
+            WriteInt(bytes, 0x7C, off_7C);
+
+            WriteInt(bytes, 0x80, off_80);
+
+            return bytes;
+        }
+
+        private byte[] SerializeDL()
+        {
+            byte[] bytes = new byte[0x34C];
+
+            WriteUint(bytes, 0x00, backgroundColor.R);
+            WriteUint(bytes, 0x04, backgroundColor.G);
+            WriteUint(bytes, 0x08, backgroundColor.B);
+            WriteUint(bytes, 0x0C, fogColor.R);
+
+            WriteUint(bytes, 0x10, fogColor.G);
+            WriteUint(bytes, 0x14, fogColor.B);
+            WriteFloat(bytes, 0x18, fogNearDistance);
+            WriteFloat(bytes, 0x1C, fogFarDistance);
+
+            WriteFloat(bytes, 0x20, fogNearIntensity);
+            WriteFloat(bytes, 0x24, fogFarIntensity);
+            WriteFloat(bytes, 0x28, deathPlaneZ);
+            WriteInt(bytes, 0x2C, isSphericalWorld);
+
+            WriteFloat(bytes, 0x30, sphereCentre.X);
+            WriteFloat(bytes, 0x34, sphereCentre.Y);
+            WriteFloat(bytes, 0x38, sphereCentre.Z);
+            WriteFloat(bytes, 0x3C, shipPosition.X);
+
+            WriteFloat(bytes, 0x40, shipPosition.Y);
+            WriteFloat(bytes, 0x44, shipPosition.Z);
+            WriteFloat(bytes, 0x48, shipRotation);
+
+            if (unkColor.IsEmpty)
+            {
+                WriteInt(bytes, 0x4C, -1);
+                WriteInt(bytes, 0x50, 0);
+                WriteInt(bytes, 0x54, 0);
+            }
+            else
+            {
+                WriteInt(bytes, 0x4C, unkColor.R);
+                WriteInt(bytes, 0x50, unkColor.G);
+                WriteInt(bytes, 0x54, unkColor.B);
+            }
+
+            WriteInt(bytes, 0x58, off_58);
+            WriteInt(bytes, 0x5C, off_5C);
+
+            WriteInt(bytes, 0x60, off_60);
+            WriteFloat(bytes, 0x64, off_64);
+            WriteInt(bytes, 0x68, off_68);
+            WriteInt(bytes, 0x6C, off_6C);
+
+            WriteInt(bytes, 0x70, off_70);
+            WriteFloat(bytes, 0x74, off_74);
+            WriteInt(bytes, 0x78, off_78);
+            WriteInt(bytes, 0x7C, off_7C);
+
+            WriteInt(bytes, 0x80, off_80);
+
+            for (int i = 0; i < DL_off_84.Length; i++)
+            {
+                WriteInt(bytes, 0x84 + i * 0x4, DL_off_84[i]);
+            }
+
+            return bytes;
+        }
     }
 }

--- a/LibReplanetizer/Level Objects/Gameplay/LevelVariables.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/LevelVariables.cs
@@ -83,34 +83,34 @@ namespace LibReplanetizer.LevelObjects
         [Category("Unknown"), DisplayName("OFF_80")]
         public int off_80 { get; set; }
 
-        [Category("Unknown"), DisplayName("OFF_84")]
-        public int[] DL_off_84 { get; set; }
+        [Category("Unknown"), DisplayName("UnknownBytes")]
+        public byte[] unknownBytes { get; set; }
 
-        public LevelVariables(GameType game, FileStream fileStream, int levelVarPointer)
+        public LevelVariables(GameType game, FileStream fileStream, int levelVarPointer, int length)
         {
-            if (levelVarPointer == 0) return;
+            if (levelVarPointer == 0 || length == 0) return;
+
+            byte[] levelVarBlock = ReadBlock(fileStream, levelVarPointer, length);
 
             switch (game.num)
             {
                 case 1:
-                    GetRC1Vals(fileStream, levelVarPointer);
+                    GetRC1Vals(levelVarBlock);
                     break;
                 case 2:
-                    GetRC2Vals(fileStream, levelVarPointer);
+                    GetRC2Vals(levelVarBlock);
                     break;
                 case 3:
-                    GetRC3Vals(fileStream, levelVarPointer);
+                    GetRC3Vals(levelVarBlock);
                     break;
                 case 4:
-                    GetDLVals(fileStream, levelVarPointer);
+                    GetDLVals(levelVarBlock);
                     break;
             }
         }
 
-        private void GetRC1Vals(FileStream fileStream, int levelVarPointer)
+        private void GetRC1Vals(byte[] levelVarBlock)
         {
-            byte[] levelVarBlock = ReadBlock(fileStream, levelVarPointer, 0x50);
-
             int bgRed = ReadInt(levelVarBlock, 0x00);
             int bgGreen = ReadInt(levelVarBlock, 0x04);
             int bgBlue = ReadInt(levelVarBlock, 0x08);
@@ -136,6 +136,13 @@ namespace LibReplanetizer.LevelObjects
             off_48 = ReadInt(levelVarBlock, 0x48);
             off_4c = ReadInt(levelVarBlock, 0x4C);
 
+            unknownBytes = new byte[levelVarBlock.Length - 0x50];
+
+            for (int i = 0; i < levelVarBlock.Length - 0x50; i++)
+            {
+                unknownBytes[i] = levelVarBlock[0x50 + i];
+            }
+
             backgroundColor = Color.FromArgb(bgRed, bgGreen, bgBlue);
             fogColor = Color.FromArgb(r, g, b);
             if (shipColorR != -1)
@@ -151,10 +158,8 @@ namespace LibReplanetizer.LevelObjects
             shipPosition = new Vector3(shipPositionX, shipPositionY, shipPositionZ);
         }
 
-        private void GetRC2Vals(FileStream fileStream, int levelVarPointer)
+        private void GetRC2Vals(byte[] levelVarBlock)
         {
-            byte[] levelVarBlock = ReadBlock(fileStream, levelVarPointer, 0x80);
-
             int bgRed = ReadInt(levelVarBlock, 0x00);
             int bgGreen = ReadInt(levelVarBlock, 0x04);
             int bgBlue = ReadInt(levelVarBlock, 0x08);
@@ -195,6 +200,13 @@ namespace LibReplanetizer.LevelObjects
             off_78 = ReadInt(levelVarBlock, 0x78);
             off_7C = ReadInt(levelVarBlock, 0x7C);
 
+            unknownBytes = new byte[levelVarBlock.Length - 0x80];
+
+            for (int i = 0; i < levelVarBlock.Length - 0x80; i++)
+            {
+                unknownBytes[i] = levelVarBlock[0x80 + i];
+            }
+
             backgroundColor = Color.FromArgb(bgRed, bgGreen, bgBlue);
             fogColor = Color.FromArgb(r, g, b);
             if (shipColorR != -1)
@@ -211,10 +223,8 @@ namespace LibReplanetizer.LevelObjects
             shipPosition = new Vector3(shipPositionX, shipPositionY, shipPositionZ);
         }
 
-        private void GetRC3Vals(FileStream fileStream, int levelVarPointer)
+        private void GetRC3Vals(byte[] levelVarBlock)
         {
-            byte[] levelVarBlock = ReadBlock(fileStream, levelVarPointer, 0x84);
-
             int bgRed = ReadInt(levelVarBlock, 0x00);
             int bgGreen = ReadInt(levelVarBlock, 0x04);
             int bgBlue = ReadInt(levelVarBlock, 0x08);
@@ -257,6 +267,13 @@ namespace LibReplanetizer.LevelObjects
 
             off_80 = ReadInt(levelVarBlock, 0x80);
 
+            unknownBytes = new byte[levelVarBlock.Length - 0x84];
+
+            for (int i = 0; i < levelVarBlock.Length - 0x84; i++)
+            {
+                unknownBytes[i] = levelVarBlock[0x84 + i];
+            }
+
             backgroundColor = Color.FromArgb(bgRed, bgGreen, bgBlue);
             fogColor = Color.FromArgb(r, g, b);
             if (shipColorR != -1)
@@ -273,10 +290,8 @@ namespace LibReplanetizer.LevelObjects
             shipPosition = new Vector3(shipPositionX, shipPositionY, shipPositionZ);
         }
 
-        private void GetDLVals(FileStream fileStream, int levelVarPointer)
+        private void GetDLVals(byte[] levelVarBlock)
         {
-            byte[] levelVarBlock = ReadBlock(fileStream, levelVarPointer, 0x34C);
-
             int bgRed = ReadInt(levelVarBlock, 0x00);
             int bgGreen = ReadInt(levelVarBlock, 0x04);
             int bgBlue = ReadInt(levelVarBlock, 0x08);
@@ -319,11 +334,11 @@ namespace LibReplanetizer.LevelObjects
 
             off_80 = ReadInt(levelVarBlock, 0x80);
 
-            DL_off_84 = new int[211 - 33];
-
-            for (int i = 0; i < DL_off_84.Length; i++)
+            unknownBytes = new byte[levelVarBlock.Length - 0x84];
+            
+            for (int i = 0; i < levelVarBlock.Length - 0x84; i++)
             {
-                DL_off_84[i] = ReadInt(levelVarBlock, 0x84 + i * 0x4);
+                unknownBytes[i] = levelVarBlock[0x84 + i];
             }
 
             backgroundColor = Color.FromArgb(bgRed, bgGreen, bgBlue);
@@ -361,7 +376,7 @@ namespace LibReplanetizer.LevelObjects
 
         private byte[] SerializeRC1()
         {
-            byte[] bytes = new byte[0x50];
+            byte[] bytes = new byte[0x50 + unknownBytes.Length];
 
             WriteUint(bytes, 0x00, backgroundColor.R);
             WriteUint(bytes, 0x04, backgroundColor.G);
@@ -398,12 +413,14 @@ namespace LibReplanetizer.LevelObjects
             WriteInt(bytes, 0x48, off_48);
             WriteInt(bytes, 0x4C, off_4c);
 
+            unknownBytes.CopyTo(bytes, 0x50);
+
             return bytes;
         }
 
         private byte[] SerializeRC2()
         {
-            byte[] bytes = new byte[0x80];
+            byte[] bytes = new byte[0x80 + unknownBytes.Length];
 
             WriteUint(bytes, 0x00, backgroundColor.R);
             WriteUint(bytes, 0x04, backgroundColor.G);
@@ -454,13 +471,15 @@ namespace LibReplanetizer.LevelObjects
             WriteFloat(bytes, 0x74, off_74);
             WriteInt(bytes, 0x78, off_78);
             WriteInt(bytes, 0x7C, off_7C);
+
+            unknownBytes.CopyTo(bytes, 0x80);
 
             return bytes;
         }
 
         private byte[] SerializeRC3()
         {
-            byte[] bytes = new byte[0x84];
+            byte[] bytes = new byte[0x84 + unknownBytes.Length];
 
             WriteUint(bytes, 0x00, backgroundColor.R);
             WriteUint(bytes, 0x04, backgroundColor.G);
@@ -513,13 +532,15 @@ namespace LibReplanetizer.LevelObjects
             WriteInt(bytes, 0x7C, off_7C);
 
             WriteInt(bytes, 0x80, off_80);
+
+            unknownBytes.CopyTo(bytes, 0x84);
 
             return bytes;
         }
 
         private byte[] SerializeDL()
         {
-            byte[] bytes = new byte[0x34C];
+            byte[] bytes = new byte[0x84 + unknownBytes.Length];
 
             WriteUint(bytes, 0x00, backgroundColor.R);
             WriteUint(bytes, 0x04, backgroundColor.G);
@@ -573,10 +594,7 @@ namespace LibReplanetizer.LevelObjects
 
             WriteInt(bytes, 0x80, off_80);
 
-            for (int i = 0; i < DL_off_84.Length; i++)
-            {
-                WriteInt(bytes, 0x84 + i * 0x4, DL_off_84[i]);
-            }
+            unknownBytes.CopyTo(bytes, 0x84);
 
             return bytes;
         }

--- a/LibReplanetizer/Level Objects/Gameplay/Moby.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Moby.cs
@@ -372,7 +372,7 @@ namespace LibReplanetizer.LevelObjects
 
         private byte[] ToByteArrayRC1()
         {
-            Vector3 eulerAngles = ToEulerAngles(modelMatrix.ExtractRotation());
+            Vector3 eulerAngles = rotation.ToEulerAngles();
 
             byte[] buffer = new byte[game.mobyElemSize];
 
@@ -422,7 +422,7 @@ namespace LibReplanetizer.LevelObjects
 
         private byte[] ToByteArrayRC23()
         {
-            Vector3 eulerAngles = ToEulerAngles(modelMatrix.ExtractRotation());
+            Vector3 eulerAngles = rotation.ToEulerAngles();
 
             byte[] buffer = new byte[game.mobyElemSize];
 
@@ -478,7 +478,7 @@ namespace LibReplanetizer.LevelObjects
 
         private byte[] ToByteArrayDL()
         {
-            Vector3 eulerAngles = ToEulerAngles(modelMatrix.ExtractRotation());
+            Vector3 eulerAngles = rotation.ToEulerAngles();
 
             byte[] buffer = new byte[game.mobyElemSize];
 
@@ -532,10 +532,13 @@ namespace LibReplanetizer.LevelObjects
 
         public override void UpdateTransformMatrix()
         {
-            Matrix4 rot = Matrix4.CreateFromQuaternion(rotation);
+            Vector3 euler = rotation.ToEulerAngles();
+            Matrix4 rot_z = Matrix4.CreateFromAxisAngle(Vector3.UnitZ, euler.Z);
+            Matrix4 rot_y = Matrix4.CreateFromAxisAngle(Vector3.UnitY, euler.Y);
+            Matrix4 rot_x = Matrix4.CreateFromAxisAngle(Vector3.UnitX, euler.X);
             Matrix4 scaleMatrix = Matrix4.CreateScale(scale * model.size);
             Matrix4 translationMatrix = Matrix4.CreateTranslation(position);
-            modelMatrix = scaleMatrix * rot * translationMatrix;
+            modelMatrix = scaleMatrix * rot_x * rot_y * rot_z * translationMatrix;
         }
 
         public void UpdateFromMemory(byte[] mobyMemory, int offset, List<Model> models)

--- a/LibReplanetizer/Level Objects/Gameplay/Sphere.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Sphere.cs
@@ -150,7 +150,7 @@ namespace LibReplanetizer.LevelObjects
             mat1 = ReadMatrix4(block, offset + 0x00);
             mat2 = ReadMatrix4(block, offset + 0x40);
 
-            modelMatrix = mat1 + mat2;
+            modelMatrix = mat1;
             rotation = modelMatrix.ExtractRotation();
             position = modelMatrix.ExtractTranslation();
             scale = modelMatrix.ExtractScale();

--- a/LibReplanetizer/Level Objects/Gameplay/Type0C.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Type0C.cs
@@ -50,7 +50,7 @@ namespace LibReplanetizer.LevelObjects
             mat1 = ReadMatrix4(block, offset + 0x10);
             mat2 = ReadMatrix4(block, offset + 0x50);
 
-            modelMatrix = mat1 + mat2;
+            modelMatrix = mat1;
             rotation = modelMatrix.ExtractRotation();
             position = modelMatrix.ExtractTranslation();
             scale = modelMatrix.ExtractScale();

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -51,8 +51,8 @@ namespace LibReplanetizer
         public List<Shrub> shrubs;
         public List<Light> lights;
         public List<Spline> splines;
-        public List<TerrainFragment> terrainEngine;
-        public List<List<TerrainFragment>> terrainChunks;
+        public Terrain terrainEngine;
+        public List<Terrain> terrainChunks;
         public List<int> textureConfigMenus;
         public List<Mission> missions;
 
@@ -174,8 +174,8 @@ namespace LibReplanetizer
                 Logger.Debug("Added {0} lights", lights.Count);
 
                 Logger.Debug("Parsing terrain elements...");
-                terrainEngine = engineParser.GetTerrainModels();
-                Logger.Debug("Added {0} terrain elements", terrainEngine?.Count);
+                terrainEngine = engineParser.GetTerrainModel();
+                Logger.Debug("Added {0} terrain elements", terrainEngine?.fragments.Count);
 
                 Logger.Debug("Parsing player animations...");
                 playerAnimations = engineParser.GetPlayerAnimations((MobyModel)mobyModels[0]);
@@ -260,7 +260,7 @@ namespace LibReplanetizer
                 occlusionData = gameplayParser.GetOcclusionData();
             }
 
-            terrainChunks = new List<List<TerrainFragment>>();
+            terrainChunks = new List<Terrain>();
             collisionChunks = new List<Model>();
             collBytesChunks = new List<byte[]>();
 
@@ -269,7 +269,7 @@ namespace LibReplanetizer
                 var chunkPath = Path.Join(path, @"chunk"+i+".ps3");
                 if (!File.Exists(chunkPath)) continue;
 
-                using (ChunkParser chunkParser = new ChunkParser(chunkPath))
+                using (ChunkParser chunkParser = new ChunkParser(chunkPath, game))
                 {
                     terrainChunks.Add(chunkParser.GetTerrainModels());
                     collisionChunks.Add(chunkParser.GetCollisionModel());

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -68,8 +68,12 @@ namespace LibReplanetizer
         public Dictionary<int, String> japanese;
         public Dictionary<int, String> korean;
 
+        public byte[] unk3;
+        public byte[] unk4;
+        public byte[] unk5;
         public byte[] unk6;
         public byte[] unk7;
+        public byte[] unk8;
         public byte[] unk9;
         public byte[] unk12;
         public byte[] unk13;
@@ -184,6 +188,12 @@ namespace LibReplanetizer
                 textureConfigMenus = engineParser.GetTextureConfigMenu();
 
                 collisionEngine = engineParser.GetCollisionModel();
+
+                unk3 = engineParser.GetUnk3Bytes();
+                unk4 = engineParser.GetUnk4Bytes();
+                unk5 = engineParser.GetUnk5Bytes();
+                unk8 = engineParser.GetUnk8Bytes();
+                unk9 = engineParser.GetUnk9Bytes();
             }
 
 

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -73,8 +73,10 @@ namespace LibReplanetizer
         public byte[] unk9;
         public byte[] unk12;
         public byte[] unk13;
-        public byte[] unk17;
         public byte[] unk14;
+        public byte[] unk16;
+        public byte[] unk17;
+        public byte[] unk18;
 
         public LightConfig lightConfig;
 
@@ -83,6 +85,11 @@ namespace LibReplanetizer
 
         public byte[] tieData;
         public byte[] shrubData;
+
+        public byte[] tieGroupData;
+        public byte[] shrubGroupData;
+
+        public byte[] areasData;
 
         public List<DirectionalLight> directionalLights;
         public List<Type0C> type0Cs;
@@ -209,11 +216,18 @@ namespace LibReplanetizer
                 unk7 = gameplayParser.GetUnk7();
                 unk12 = gameplayParser.GetUnk12();
                 unk13 = gameplayParser.GetUnk13();
-                unk17 = gameplayParser.GetUnk17();
                 unk14 = gameplayParser.GetUnk14();
+                unk16 = gameplayParser.GetUnk16();
+                unk17 = gameplayParser.GetUnk17();
+                unk18 = gameplayParser.GetUnk18();
 
                 tieData = gameplayParser.GetTieData(ties.Count);
                 shrubData = gameplayParser.getShrubData(shrubs.Count);
+
+                tieGroupData = gameplayParser.getTieGroups();
+                shrubGroupData = gameplayParser.getShrubGroups();
+
+                areasData = gameplayParser.getAreasData();
 
                 directionalLights = gameplayParser.GetDirectionalLights();
                 type0Cs = gameplayParser.GetType0Cs();
@@ -348,17 +362,16 @@ namespace LibReplanetizer
         public void Save(string outputFile)
         {
             string directory;
-            if (!outputFile.EndsWith(".ps3") && File.GetAttributes(outputFile).HasFlag(FileAttributes.Directory))
+            if (File.GetAttributes(outputFile).HasFlag(FileAttributes.Directory))
             {
                 directory = outputFile;
-                outputFile = Path.Join(outputFile, "engine.ps3");
             }
             else
             {
                 directory = Path.GetDirectoryName(outputFile);
             }
             EngineSerializer engineSerializer = new EngineSerializer();
-            engineSerializer.Save(this, outputFile);
+            engineSerializer.Save(this, directory);
             GameplaySerializer gameplaySerializer = new GameplaySerializer();
             gameplaySerializer.Save(this, directory);
 

--- a/LibReplanetizer/Parsers/ChunkParser.cs
+++ b/LibReplanetizer/Parsers/ChunkParser.cs
@@ -12,15 +12,17 @@ namespace LibReplanetizer.Parsers
     {
 
         ChunkHeader chunkHeader;
+        GameType game;
 
-        public ChunkParser(string chunkFile) : base(chunkFile)
+        public ChunkParser(string chunkFile, GameType game) : base(chunkFile)
         {
             chunkHeader = new ChunkHeader(fileStream);
+            this.game = game;
         }
 
-        public List<TerrainFragment> GetTerrainModels()
+        public Terrain GetTerrainModels()
         {
-            return GetTerrainModels(chunkHeader.terrainPointer);
+            return GetTerrainModels(chunkHeader.terrainPointer, game);
         }
 
         public Model GetCollisionModel()

--- a/LibReplanetizer/Parsers/EngineParser.cs
+++ b/LibReplanetizer/Parsers/EngineParser.cs
@@ -115,27 +115,83 @@ namespace LibReplanetizer.Parsers
         {
             if (engineHead.collisionPointer > 0)
             {
-                byte[] headBlock = ReadBlock(fileStream, engineHead.collisionPointer, 8);
-                int collisionStart = engineHead.collisionPointer + ReadInt(headBlock, 0);
-                int collisionLength = ReadInt(headBlock, 4);
-                int totalLength = collisionStart + collisionLength - engineHead.collisionPointer;
+                if (engineHead.game.num == 1)
+                {
+                    byte[] headBlock = ReadBlock(fileStream, engineHead.collisionPointer, 8);
+                    int collisionStart = engineHead.collisionPointer + ReadInt(headBlock, 0);
+                    int collisionLength = ReadInt(headBlock, 4);
+                    int totalLength = collisionStart + collisionLength - engineHead.collisionPointer;
 
-                return ReadArbBytes(engineHead.collisionPointer, totalLength);
+                    return ReadArbBytes(engineHead.collisionPointer, totalLength);
+                } else
+                {
+                    return ReadBlock(fileStream, engineHead.collisionPointer, engineHead.tieModelPointer - engineHead.collisionPointer);
+                }
             }
             else
             {
-                return new byte[0];
+                return null;
             }
         }
 
         public byte[] GetBillboardBytes()
         {
-            return ReadArbBytes(engineHead.texture2dPointer, engineHead.soundConfigPointer - engineHead.texture2dPointer);
+            switch (engineHead.game.num)
+            {
+                case 1:
+                    return ReadArbBytes(engineHead.texture2dPointer, engineHead.soundConfigPointer - engineHead.texture2dPointer);
+                case 2:
+                case 3:
+                case 4:
+                default:
+                    return ReadArbBytes(engineHead.texture2dPointer, engineHead.mobyModelPointer - engineHead.texture2dPointer);
+            }
         }
 
         public byte[] GetSoundConfigBytes()
         {
-            return ReadArbBytes(engineHead.soundConfigPointer, engineHead.lightPointer - engineHead.soundConfigPointer);
+            switch (engineHead.game.num)
+            {
+                case 1:
+                    return ReadArbBytes(engineHead.soundConfigPointer, engineHead.lightPointer - engineHead.soundConfigPointer);
+                case 2:
+                case 3:
+                case 4:
+                default:
+                    return ReadArbBytes(engineHead.soundConfigPointer, engineHead.playerAnimationPointer - engineHead.soundConfigPointer);
+            }
+        }
+
+        public byte[] GetUnk3Bytes()
+        {
+            if (engineHead.unk3Pointer == 0) { return null; }
+            return ReadBlock(fileStream, engineHead.unk3Pointer, engineHead.texturePointer - engineHead.unk3Pointer);
+        }
+
+        public byte[] GetUnk4Bytes()
+        {
+            if (engineHead.unk4Pointer == 0) { return null; }
+            return ReadBlock(fileStream, engineHead.unk4Pointer, engineHead.textureConfigMenuPointer - engineHead.unk4Pointer);
+        }
+
+        public byte[] GetUnk5Bytes()
+        {
+            if (engineHead.unk5Pointer == 0) { return null; }
+            return ReadBlock(fileStream, engineHead.unk5Pointer, engineHead.tieModelPointer - engineHead.unk5Pointer);
+        }
+
+        public byte[] GetUnk8Bytes()
+        {
+            if (engineHead.unk8Pointer == 0) { return null; }
+            byte[] head = ReadBlock(fileStream, engineHead.unk8Pointer, 16);
+            int amount = ReadInt(head, 4);
+            return ReadBlock(fileStream, engineHead.unk8Pointer, 0x10 + amount);
+        }
+
+        public byte[] GetUnk9Bytes()
+        {
+            if (engineHead.unk9Pointer == 0) { return null; }
+            return ReadBlock(fileStream, engineHead.unk9Pointer, engineHead.terrainPointer - engineHead.unk9Pointer);
         }
 
         public void Dispose()

--- a/LibReplanetizer/Parsers/EngineParser.cs
+++ b/LibReplanetizer/Parsers/EngineParser.cs
@@ -57,9 +57,9 @@ namespace LibReplanetizer.Parsers
             return GetShrubs(shrubModels, engineHead.shrubPointer, engineHead.shrubCount);
         }
 
-        public List<TerrainFragment> GetTerrainModels()
+        public Terrain GetTerrainModel()
         {
-            return GetTerrainModels(engineHead.terrainPointer);
+            return GetTerrainModels(engineHead.terrainPointer, engineHead.game);
         }
 
         public SkyboxModel GetSkyboxModel()

--- a/LibReplanetizer/Parsers/GameplayParser.cs
+++ b/LibReplanetizer/Parsers/GameplayParser.cs
@@ -43,7 +43,7 @@ namespace LibReplanetizer.Parsers
 
         public LevelVariables GetLevelVariables()
         {
-            return new LevelVariables(game, fileStream, gameplayHeader.levelVarPointer);
+            return new LevelVariables(game, fileStream, gameplayHeader.levelVarPointer, gameplayHeader.englishPointer - gameplayHeader.levelVarPointer);
         }
 
         public Dictionary<int, String> GetLang(int offset)

--- a/LibReplanetizer/Parsers/GameplayParser.cs
+++ b/LibReplanetizer/Parsers/GameplayParser.cs
@@ -334,23 +334,30 @@ namespace LibReplanetizer.Parsers
 
         public byte[] GetUnk13()
         {
-            int sectionLength = gameplayHeader.occlusionPointer - gameplayHeader.grindPathsPointer;
+            int sectionLength;
+
+            switch (game.num)
+            {
+                case 1:
+                    sectionLength = gameplayHeader.occlusionPointer - gameplayHeader.grindPathsPointer;
+                    break;
+                case 2:
+                case 3:
+                case 4:
+                default:
+                    sectionLength = gameplayHeader.areasPointer - gameplayHeader.grindPathsPointer;
+                    break;
+            }
+
             if (sectionLength > 0)
             {
                 return ReadBlock(fileStream, gameplayHeader.grindPathsPointer, sectionLength);
             }
             else
             {
-                return new byte[0x10];
+                return null;
             }
 
-        }
-
-        public byte[] GetUnk17()
-        {
-            if (gameplayHeader.unkPointer17 == 0) { return null; }
-            int sectionLength = ReadInt(ReadBlock(fileStream, gameplayHeader.unkPointer17, 4), 0);
-            return ReadBlock(fileStream, gameplayHeader.unkPointer17, sectionLength);
         }
 
         public byte[] GetUnk14()
@@ -360,6 +367,25 @@ namespace LibReplanetizer.Parsers
             return ReadBlock(fileStream, gameplayHeader.unkPointer14, sectionLength);
         }
 
+        public byte[] GetUnk16()
+        {
+            if (gameplayHeader.unkPointer16 == 0) { return null; }
+            return ReadBlock(fileStream, gameplayHeader.unkPointer16, gameplayHeader.grindPathsPointer - gameplayHeader.unkPointer16);
+        }
+
+        public byte[] GetUnk17()
+        {
+            if (gameplayHeader.unkPointer17 == 0) { return null; }
+            int sectionLength = ReadInt(ReadBlock(fileStream, gameplayHeader.unkPointer17, 4), 0);
+            return ReadBlock(fileStream, gameplayHeader.unkPointer17, sectionLength);
+        }
+
+        public byte[] GetUnk18()
+        {
+            if (gameplayHeader.unkPointer18 == 0) { return null; }
+            int amount = ReadInt(ReadBlock(fileStream, gameplayHeader.unkPointer18, 4), 0);
+            return ReadBlock(fileStream, gameplayHeader.unkPointer18, 0x10 + amount * 0x20);
+        }
 
         public List<int> GetMobyIds()
         {
@@ -426,17 +452,54 @@ namespace LibReplanetizer.Parsers
             return data;
         }
 
+        //In RaC 2/3 each element should be of size 0x60 but the block is much larger and not a multiple of that
+        //Hence we just load the block based on pointers
         public byte[] GetTieData(int tieCount)
         {
-            return ReadBlock(fileStream, gameplayHeader.tiePointer, 0x10 + 0xE0 * tieCount);
+            if (gameplayHeader.tiePointer == 0) { return null; }
+
+            switch (game.num)
+            {
+                case 1:
+                    return ReadBlock(fileStream, gameplayHeader.tiePointer, 0x10 + 0xE0 * tieCount);
+                case 2:
+                case 3:
+                case 4:
+                default:
+                    return ReadBlock(fileStream, gameplayHeader.tiePointer, gameplayHeader.tieGroupsPointer - gameplayHeader.tiePointer);
+            }
         }
+
 
         public byte[] getShrubData(int shrubCount)
         {
+            if (gameplayHeader.shrubPointer == 0) { return null; }
             return ReadBlock(fileStream, gameplayHeader.shrubPointer, 0x10 + 0x70 * shrubCount);
         }
 
+        public byte[] getTieGroups()
+        {
+            if (gameplayHeader.tieGroupsPointer == 0) { return null; }
+            byte[] header = ReadBlock(fileStream, gameplayHeader.tieGroupsPointer, 16);
+            int count = ReadInt(header, 0);
+            int length = ReadInt(header, 4);
+            return ReadBlock(fileStream, gameplayHeader.tieGroupsPointer, 0x10 + length + count * 0x4);
+        }
 
+        public byte[] getShrubGroups()
+        {
+            if (gameplayHeader.shrubGroupsPointer == 0) { return null; }
+            byte[] header = ReadBlock(fileStream, gameplayHeader.shrubGroupsPointer, 16);
+            int count = ReadInt(header, 0);
+            int length = ReadInt(header, 4);
+            return ReadBlock(fileStream, gameplayHeader.shrubGroupsPointer, 0x10 + length + count * 0x4);
+        }
+
+        public byte[] getAreasData()
+        {
+            if (gameplayHeader.areasPointer == 0) { return null; }
+            return ReadBlock(fileStream, gameplayHeader.areasPointer, gameplayHeader.occlusionPointer - gameplayHeader.areasPointer);
+        }
 
         public List<byte[]> GetPvars(List<Moby> mobs)
         {

--- a/LibReplanetizer/Parsers/RatchetFileParser.cs
+++ b/LibReplanetizer/Parsers/RatchetFileParser.cs
@@ -117,13 +117,15 @@ namespace LibReplanetizer.Parsers
         }
 
 
-        protected List<TerrainFragment> GetTerrainModels(int terrainModelPointer)
+        protected Terrain GetTerrainModels(int terrainModelPointer, GameType game)
         {
             List<TerrainFragment> tFrags = new List<TerrainFragment>();
 
             //Read the whole terrain header
-            byte[] terrainBlock = ReadBlock(fileStream, terrainModelPointer, 0x60);
-            TerrainHead head = new TerrainHead(terrainBlock);
+            int headerSize = (game.num == 4) ? 0x70 : 0x60;
+            byte[] terrainBlock = ReadBlock(fileStream, terrainModelPointer, headerSize);
+            
+            TerrainHead head = new TerrainHead(terrainBlock, game);
 
             byte[] tfragBlock = ReadBlock(fileStream, head.headPointer, head.headCount * 0x30);
 
@@ -132,7 +134,9 @@ namespace LibReplanetizer.Parsers
                 tFrags.Add(new TerrainFragment(fileStream, head, tfragBlock, i));
             }
 
-            return tFrags;
+            Terrain terrain = new Terrain(tFrags, head.levelNumber);
+
+            return terrain;
         }
 
         protected SkyboxModel GetSkyboxModel(GameType game, int skyboxPointer)

--- a/LibReplanetizer/Serializers/ChunkSerializer.cs
+++ b/LibReplanetizer/Serializers/ChunkSerializer.cs
@@ -1,17 +1,12 @@
 ﻿using LibReplanetizer.Headers;
-using LibReplanetizer.LevelObjects;
-using LibReplanetizer.Models;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using static LibReplanetizer.DataFunctions;
+using static LibReplanetizer.Serializers.SerializerFunctions;
 
 namespace LibReplanetizer.Serializers
 {
     public class ChunkSerializer
     {
-
         public void Save(Level level, string directory, int chunk)
         {
             if (chunk >= level.terrainChunks.Count)
@@ -26,7 +21,7 @@ namespace LibReplanetizer.Serializers
 
             ChunkHeader chunkHeader = new ChunkHeader()
             {
-                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainChunks[chunk], (int)fs.Position)),
+                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainChunks[chunk], (int)fs.Position, level.game)),
                 collisionPointer = SeekWrite(fs, level.collBytesChunks[chunk])
             };
 
@@ -53,115 +48,6 @@ namespace LibReplanetizer.Serializers
             }
         }
 
-        private byte[] WriteTfrags(List<TerrainFragment> tFrags, int fileOffset)
-        {
-            List<List<byte>> vertBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
-            List<List<byte>> rgbaBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
-            List<List<byte>> uvBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
-            List<List<byte>> indexBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
-
-            List<byte> textureBytes = new List<byte>();
-
-            byte[] tfragHeads = new byte[0x30 * tFrags.Count];
-
-            ushort chunk = 0;
-
-            for (int i = 0; i < tFrags.Count; i++)
-            {
-                TerrainModel mod = (TerrainModel)(tFrags[i].model);
-
-                int offset = i * 0x30;
-                WriteFloat(tfragHeads, offset + 0x00, tFrags[i].off_00);
-                WriteFloat(tfragHeads, offset + 0x04, tFrags[i].off_04);
-                WriteFloat(tfragHeads, offset + 0x08, tFrags[i].off_08);
-                WriteFloat(tfragHeads, offset + 0x0C, tFrags[i].off_0C);
-
-                WriteInt(tfragHeads, offset + 0x10, fileOffset + 0x60 + tfragHeads.Length + textureBytes.Count);
-                WriteInt(tfragHeads, offset + 0x14, tFrags[i].model.textureConfig.Count);
-
-                byte[] modelVertBytes = mod.SerializeVerts();
-                if (((vertBytes[chunk].Count + modelVertBytes.Length) / 0x1c) > 0xffff)
-                {
-                    chunk++;
-                }
-
-                WriteUshort(tfragHeads, offset + 0x18, (ushort)(vertBytes[chunk].Count / 0x1c));
-                WriteUshort(tfragHeads, offset + 0x1a, (ushort)(tFrags[i].model.vertexBuffer.Length / 8));
-
-                WriteUshort(tfragHeads, offset + 0x1C, tFrags[i].off_1C);
-                WriteUshort(tfragHeads, offset + 0x1E, tFrags[i].off_1E);
-                WriteUshort(tfragHeads, offset + 0x20, tFrags[i].off_20);
-                WriteUshort(tfragHeads, offset + 0x22, chunk);
-                WriteUint(tfragHeads, offset + 0x24, tFrags[i].off_24);
-                WriteUint(tfragHeads, offset + 0x28, tFrags[i].off_28);
-                WriteUint(tfragHeads, offset + 0x2C, tFrags[i].off_2C);
-
-                foreach (var texConf in tFrags[i].model.textureConfig)
-                {
-                    byte[] texBytes = new byte[0x10];
-                    WriteInt(texBytes, 0x00, texConf.ID);
-                    WriteInt(texBytes, 0x04, texConf.start + indexBytes[chunk].Count / 2);
-                    WriteInt(texBytes, 0x08, texConf.size);
-                    WriteInt(texBytes, 0x0C, texConf.mode);
-                    textureBytes.AddRange(texBytes);
-                }
-
-                indexBytes[chunk].AddRange(tFrags[i].model.GetFaceBytes((ushort)(vertBytes[chunk].Count / 0x1C)));
-                vertBytes[chunk].AddRange(modelVertBytes);
-                rgbaBytes[chunk].AddRange(tFrags[i].model.rgbas);
-                uvBytes[chunk].AddRange(tFrags[i].model.SerializeUVs());
-
-            }
-
-            List<byte> outBytes = new List<byte>();
-
-            byte[] head = new byte[0x60];
-            WriteInt(head, 0, fileOffset + 0x60);
-            WriteUshort(head, 0x4, (ushort)tFrags.Count);
-            WriteUshort(head, 0x6, (ushort)tFrags.Count);
-
-            outBytes.AddRange(head);
-            outBytes.AddRange(tfragHeads);
-            outBytes.AddRange(textureBytes);
-
-            int[] vertOffsets = { 0, 0, 0, 0 };
-            int[] rgbaOffsets = { 0, 0, 0, 0 };
-            int[] uvOffsets = { 0, 0, 0, 0 };
-            int[] indexOffsets = { 0, 0, 0, 0 };
-
-            for (int i = 0; i < 4; i++)
-            {
-                if (vertBytes[i].Count == 0)
-                {
-                    continue;
-                }
-                Pad(outBytes);
-                vertOffsets[i] = fileOffset + outBytes.Count;
-                outBytes.AddRange(vertBytes[i]);
-                Pad(outBytes);
-                rgbaOffsets[i] = fileOffset + outBytes.Count;
-                outBytes.AddRange(rgbaBytes[i]);
-                Pad(outBytes);
-                uvOffsets[i] = fileOffset + outBytes.Count;
-                outBytes.AddRange(uvBytes[i]);
-                Pad(outBytes);
-                indexOffsets[i] = fileOffset + outBytes.Count;
-                outBytes.AddRange(indexBytes[i]);
-                Pad(outBytes);
-            }
-
-
-            byte[] outByteArr = outBytes.ToArray();
-
-            for (int i = 0; i < 4; i++)
-            {
-                WriteInt(outByteArr, 0x08 + i * 4, vertOffsets[i]);
-                WriteInt(outByteArr, 0x18 + i * 4, rgbaOffsets[i]);
-                WriteInt(outByteArr, 0x28 + i * 4, uvOffsets[i]);
-                WriteInt(outByteArr, 0x38 + i * 4, indexOffsets[i]);
-            }
-
-            return outByteArr;
-        }
+        
     }
 }

--- a/LibReplanetizer/Serializers/ChunkSerializer.cs
+++ b/LibReplanetizer/Serializers/ChunkSerializer.cs
@@ -11,15 +11,15 @@ namespace LibReplanetizer.Serializers
 {
     public class ChunkSerializer
     {
-        public string pathName;
 
-        public void Save(Level level, string pathName, int chunk)
+        public void Save(Level level, string directory, int chunk)
         {
             if (chunk >= level.terrainChunks.Count)
                 throw new IndexOutOfRangeException("Chunk does not exist!");
 
-            this.pathName = pathName;
-            FileStream fs = File.Open(pathName + "/chunk" + chunk +".ps3", FileMode.Create);
+            directory = Path.Join(directory, "chunk" + chunk + ".ps3");
+
+            FileStream fs = File.Open(directory, FileMode.Create);
 
             // Seek past the header
             fs.Seek(0x10, SeekOrigin.Begin);

--- a/LibReplanetizer/Serializers/EngineSerializer.cs
+++ b/LibReplanetizer/Serializers/EngineSerializer.cs
@@ -5,7 +5,7 @@ using LibReplanetizer.Models.Animations;
 using System.Collections.Generic;
 using System.IO;
 using static LibReplanetizer.DataFunctions;
-
+using static LibReplanetizer.Serializers.SerializerFunctions;
 
 namespace LibReplanetizer.Serializers
 {
@@ -44,7 +44,7 @@ namespace LibReplanetizer.Serializers
                 game = level.game,
                 uiElementPointer = SeekWrite(fs, WriteUiElements(level.uiElements, (int)fs.Position)),
                 skyboxPointer = SeekWrite(fs, level.skybox.Serialize((int)fs.Position)),
-                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int)fs.Position)),
+                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int)fs.Position, level.game)),
                 renderDefPointer = SeekWrite(fs, level.renderDefBytes),
                 collisionPointer = SeekWrite(fs, level.collBytesEngine),
                 mobyModelPointer = SeekWrite(fs, WriteMobies(level.mobyModels, (int)fs.Position)),
@@ -85,7 +85,7 @@ namespace LibReplanetizer.Serializers
             {
                 game = level.game,
                 uiElementPointer = SeekWrite(fs, WriteUiElements(level.uiElements, (int)fs.Position)),
-                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int)fs.Position)),
+                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int)fs.Position, level.game)),
                 renderDefPointer = SeekWrite(fs, level.renderDefBytes),
                 collisionPointer = SeekWrite(fs, level.collBytesEngine),
                 tieModelPointer = SeekWrite(fs, WriteTieModels(level.tieModels, (int)fs.Position)),
@@ -129,7 +129,7 @@ namespace LibReplanetizer.Serializers
                 mobyModelPointer = SeekWrite(fs, WriteMobies(level.mobyModels, (int)fs.Position)),
                 soundConfigPointer = SeekWrite(fs, level.soundConfigBytes),
                 unk9Pointer = SeekWrite(fs, level.unk9),
-                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int)fs.Position)),
+                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int)fs.Position, level.game)),
                 renderDefPointer = SeekWrite(fs, level.renderDefBytes),
                 collisionPointer = SeekWrite(fs, level.collBytesEngine),
                 shrubModelPointer = SeekWrite(fs, WriteShrubModels(level.shrubModels, (int)fs.Position)),
@@ -161,141 +161,9 @@ namespace LibReplanetizer.Serializers
             fs.Write(head, 0, head.Length);
         }
 
-        private int SeekWrite(FileStream fs, byte[] bytes)
-        {
-            if (bytes != null)
-            {
-                SeekPast(fs);
-                int pos = (int)fs.Position;
-                fs.Write(bytes, 0, bytes.Length);
-                return pos;
-            }
-            else return 0;
-        }
-
-        private void SeekPast(FileStream fs)
-        {
-            while (fs.Position % 0x10 != 0)
-            {
-                fs.Seek(4, SeekOrigin.Current);
-            }
-        }
-
         private byte[] WriteLightConfig(LightConfig config)
         {
-
             return config.Serialize();
-        }
-
-        private byte[] WriteTfrags(List<TerrainFragment> tFrags, int fileOffset)
-        {
-            List<List<byte>> vertBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
-            List<List<byte>> rgbaBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
-            List<List<byte>> uvBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
-            List<List<byte>> indexBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
-
-            List<byte> textureBytes = new List<byte>();
-
-            byte[] tfragHeads = new byte[0x30 * tFrags.Count];
-
-            ushort chunk = 0;
-
-            for (int i = 0; i < tFrags.Count; i++)
-            {
-                TerrainModel mod = (TerrainModel)(tFrags[i].model);
-
-                int offset = i * 0x30;
-                WriteFloat(tfragHeads, offset + 0x00, tFrags[i].off_00);
-                WriteFloat(tfragHeads, offset + 0x04, tFrags[i].off_04);
-                WriteFloat(tfragHeads, offset + 0x08, tFrags[i].off_08);
-                WriteFloat(tfragHeads, offset + 0x0C, tFrags[i].off_0C);
-
-                WriteInt(tfragHeads, offset + 0x10, fileOffset + 0x60 + tfragHeads.Length + textureBytes.Count);
-                WriteInt(tfragHeads, offset + 0x14, tFrags[i].model.textureConfig.Count);
-
-                byte[] modelVertBytes = mod.SerializeVerts();
-                if (((vertBytes[chunk].Count + modelVertBytes.Length) / 0x1c) > 0xffff)
-                {
-                    chunk++;
-                }
-
-                WriteUshort(tfragHeads, offset + 0x18, (ushort)(vertBytes[chunk].Count / 0x1c));
-                WriteUshort(tfragHeads, offset + 0x1a, (ushort)(tFrags[i].model.vertexBuffer.Length / 8));
-
-                WriteUshort(tfragHeads, offset + 0x1C, tFrags[i].off_1C);
-                WriteUshort(tfragHeads, offset + 0x1E, tFrags[i].off_1E);
-                WriteUshort(tfragHeads, offset + 0x20, tFrags[i].off_20);
-                WriteUshort(tfragHeads, offset + 0x22, chunk);
-                WriteUint(tfragHeads, offset + 0x24, tFrags[i].off_24);
-                WriteUint(tfragHeads, offset + 0x28, tFrags[i].off_28);
-                WriteUint(tfragHeads, offset + 0x2C, tFrags[i].off_2C);
-
-                foreach (var texConf in tFrags[i].model.textureConfig)
-                {
-                    byte[] texBytes = new byte[0x10];
-                    WriteInt(texBytes, 0x00, texConf.ID);
-                    WriteInt(texBytes, 0x04, texConf.start + indexBytes[chunk].Count / 2);
-                    WriteInt(texBytes, 0x08, texConf.size);
-                    WriteInt(texBytes, 0x0C, texConf.mode);
-                    textureBytes.AddRange(texBytes);
-                }
-
-                indexBytes[chunk].AddRange(tFrags[i].model.GetFaceBytes((ushort)(vertBytes[chunk].Count / 0x1C)));
-                vertBytes[chunk].AddRange(modelVertBytes);
-                rgbaBytes[chunk].AddRange(tFrags[i].model.rgbas);
-                uvBytes[chunk].AddRange(tFrags[i].model.SerializeUVs());
-
-            }
-
-            List<byte> outBytes = new List<byte>();
-
-            byte[] head = new byte[0x60];
-            WriteInt(head, 0, fileOffset + 0x60);
-            WriteUshort(head, 0x4, (ushort)tFrags.Count);
-            WriteUshort(head, 0x6, (ushort)tFrags.Count);
-
-            outBytes.AddRange(head);
-            outBytes.AddRange(tfragHeads);
-            outBytes.AddRange(textureBytes);
-
-            int[] vertOffsets = { 0, 0, 0, 0 };
-            int[] rgbaOffsets = { 0, 0, 0, 0 };
-            int[] uvOffsets = { 0, 0, 0, 0 };
-            int[] indexOffsets = { 0, 0, 0, 0 };
-
-            for (int i = 0; i < 4; i++)
-            {
-                if (vertBytes[i].Count == 0)
-                {
-                    continue;
-                }
-                Pad(outBytes);
-                vertOffsets[i] = fileOffset + outBytes.Count;
-                outBytes.AddRange(vertBytes[i]);
-                Pad(outBytes);
-                rgbaOffsets[i] = fileOffset + outBytes.Count;
-                outBytes.AddRange(rgbaBytes[i]);
-                Pad(outBytes);
-                uvOffsets[i] = fileOffset + outBytes.Count;
-                outBytes.AddRange(uvBytes[i]);
-                Pad(outBytes);
-                indexOffsets[i] = fileOffset + outBytes.Count;
-                outBytes.AddRange(indexBytes[i]);
-                Pad(outBytes);
-            }
-
-
-            byte[] outByteArr = outBytes.ToArray();
-
-            for (int i = 0; i < 4; i++)
-            {
-                WriteInt(outByteArr, 0x08 + i * 4, vertOffsets[i]);
-                WriteInt(outByteArr, 0x18 + i * 4, rgbaOffsets[i]);
-                WriteInt(outByteArr, 0x28 + i * 4, uvOffsets[i]);
-                WriteInt(outByteArr, 0x38 + i * 4, indexOffsets[i]);
-            }
-
-            return outByteArr;
         }
 
         private byte[] WriteUiElements(List<UiElement> uiElements, int fileOffset)

--- a/LibReplanetizer/Serializers/EngineSerializer.cs
+++ b/LibReplanetizer/Serializers/EngineSerializer.cs
@@ -11,16 +11,12 @@ namespace LibReplanetizer.Serializers
 {
     public class EngineSerializer
     {
-        public string pathName;
+        private string enginePath;
 
-        public void Save(Level level, string pathName)
+        public void Save(Level level, string directory)
         {
-            if (Path.GetFileName(pathName) != "engine.ps3")
-            {
-                pathName = Path.Join(pathName, "engine.ps3");
-            }
-            this.pathName = pathName;
-            FileStream fs = File.Open(this.pathName, FileMode.Create);
+            enginePath = Path.Join(directory, "engine.ps3");
+            FileStream fs = File.Open(enginePath, FileMode.Create);
 
             // Seek past the header, as we don't have the data ready for it yet
             if (level.game.num == 4)
@@ -421,6 +417,8 @@ namespace LibReplanetizer.Serializers
 
         private byte[] WriteTextures(List<Texture> textures)
         {
+            if (enginePath == null) return null;
+
             var vramBytes = new List<byte>();
             var outBytes = new byte[textures.Count * 0x24];
 
@@ -433,7 +431,7 @@ namespace LibReplanetizer.Serializers
                 vramBytes.AddRange(textures[i].data);
             }
 
-            FileStream fs = File.Open(Path.Join(Path.GetDirectoryName(pathName), "vram.ps3"), FileMode.Create);
+            FileStream fs = File.Open(Path.Join(Path.GetDirectoryName(enginePath), "vram.ps3"), FileMode.Create);
             fs.Write(vramBytes.ToArray(), 0, vramBytes.Count);
             fs.Close();
 

--- a/LibReplanetizer/Serializers/GameplaySerializer.cs
+++ b/LibReplanetizer/Serializers/GameplaySerializer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using static LibReplanetizer.DataFunctions;
+using static LibReplanetizer.Serializers.SerializerFunctions;
 
 namespace LibReplanetizer.Serializers
 {
@@ -243,46 +244,6 @@ namespace LibReplanetizer.Serializers
             byte[] head = gameplayHeader.Serialize(level.game);
             fs.Seek(0, SeekOrigin.Begin);
             fs.Write(head, 0, head.Length);
-        }
-
-        private int SeekWrite(FileStream fs, byte[] bytes)
-        {
-            if (bytes != null)
-            {
-                SeekPast(fs);
-                int pos = (int)fs.Position;
-                fs.Write(bytes, 0, bytes.Length);
-                return pos;
-            }
-            else return 0;
-        }
-
-        private int SeekWrite4(FileStream fs, byte[] bytes)
-        {
-            if (bytes != null)
-            {
-                SeekPast4(fs);
-                int pos = (int)fs.Position;
-                fs.Write(bytes, 0, bytes.Length);
-                return pos;
-            }
-            else return 0;
-        }
-
-        private void SeekPast(FileStream fs)
-        {
-            while (fs.Position % 0x10 != 0)
-            {
-                fs.Seek(2, SeekOrigin.Current);
-            }
-        }
-
-        private void SeekPast4(FileStream fs)
-        {
-            while (fs.Position % 0x4 != 0)
-            {
-                fs.Seek(2, SeekOrigin.Current);
-            }
         }
 
         public static byte[] GetLangBytes(Dictionary<int, String> languageData)

--- a/LibReplanetizer/Serializers/GameplaySerializer.cs
+++ b/LibReplanetizer/Serializers/GameplaySerializer.cs
@@ -12,14 +12,32 @@ namespace LibReplanetizer.Serializers
     {
         public const int MOBYLENGTH = 0x78;
 
-        public void Save(Level level, string pathName)
+        public void Save(Level level, string directory)
         {
-            if (Path.GetFileName(pathName) != "gameplay_ntsc")
-            {
-                pathName = Path.Join(pathName, "gameplay_ntsc");
-            }
-            FileStream fs = File.Open(pathName, FileMode.Create);
+            directory = Path.Join(directory, "gameplay_ntsc");
+            FileStream fs = File.Open(directory, FileMode.Create);
 
+            switch (level.game.num)
+            {
+                case 1:
+                    SaveRC1(level, fs);
+                    break;
+                case 2:
+                    SaveRC2(level, fs);
+                    break;
+                case 3:
+                    SaveRC3(level, fs);
+                    break;
+                case 4:
+                    SaveRC4(level, fs);
+                    break;
+            }
+
+            fs.Close();
+        }
+
+        private void SaveRC1(Level level, FileStream fs)
+        {
             //Seek past the header
             fs.Seek(0xA0, SeekOrigin.Begin);
 
@@ -67,8 +85,164 @@ namespace LibReplanetizer.Serializers
             byte[] head = gameplayHeader.Serialize(level.game);
             fs.Seek(0, SeekOrigin.Begin);
             fs.Write(head, 0, head.Length);
+        }
 
-            fs.Close();
+        private void SaveRC2(Level level, FileStream fs)
+        {
+            //Seek past the header
+            fs.Seek(0xA0, SeekOrigin.Begin);
+
+            GameplayHeader gameplayHeader = new GameplayHeader
+            {
+                unkPointer18 = SeekWrite(fs, level.unk18),
+                levelVarPointer = SeekWrite(fs, level.levelVariables.Serialize(level.game)),
+                englishPointer = SeekWrite(fs, GetLangBytes(level.english)),
+                ukenglishPointer = SeekWrite(fs, GetLangBytes(level.ukenglish)),
+                frenchPointer = SeekWrite(fs, GetLangBytes(level.french)),
+                germanPointer = SeekWrite(fs, GetLangBytes(level.german)),
+                spanishPointer = SeekWrite(fs, GetLangBytes(level.spanish)),
+                italianPointer = SeekWrite(fs, GetLangBytes(level.italian)),
+                japanesePointer = SeekWrite(fs, GetLangBytes(level.japanese)),
+                koreanPointer = SeekWrite(fs, GetLangBytes(level.korean)),
+                lightsPointer = SeekWrite(fs, SerializeLevelObjects(level.directionalLights, DirectionalLight.ELEMENTSIZE)),
+                type80Pointer = SeekWrite(fs, GetType80Bytes(level.type80s)),
+                cameraPointer = SeekWrite(fs, SerializeLevelObjects(level.gameCameras, GameCamera.ELEMENTSIZE)),
+                soundPointer = SeekWrite(fs, SerializeLevelObjects(level.type0Cs, Type0C.ELEMENTSIZE)),
+                mobyIdPointer = SeekWrite(fs, GetIdBytes(level.mobyIds)),
+                mobyPointer = SeekWrite(fs, GetMobyBytes(level.mobs, level.game)),
+                pvarSizePointer = SeekWrite(fs, GetPvarSizeBytes(level.pVars)),
+                pvarPointer = SeekWrite(fs, GetPvarBytes(level.pVars)),
+                type50Pointer = SeekWrite(fs, GetKeyValueBytes(level.type50s)),
+                type5CPointer = SeekWrite(fs, GetKeyValueBytes(level.type5Cs)),
+                mobyGroupsPointer = SeekWrite(fs, level.unk6),
+                type4CPointer = SeekWrite(fs, level.unk7),
+                tieIdPointer = SeekWrite(fs, GetIdBytes(level.tieIds)),
+                tiePointer = SeekWrite(fs, level.tieData),
+                tieGroupsPointer = SeekWrite(fs, level.tieGroupData),
+                shrubIdPointer = SeekWrite(fs, GetIdBytes(level.shrubIds)),
+                shrubPointer = SeekWrite(fs, level.shrubData),
+                shrubGroupsPointer = SeekWrite(fs, level.shrubGroupData),
+                splinePointer = SeekWrite(fs, GetSplineBytes(level.splines)),
+                cuboidPointer = SeekWrite(fs, SerializeLevelObjects(level.cuboids, Cuboid.ELEMENTSIZE)),
+                spherePointer = SeekWrite(fs, SerializeLevelObjects(level.spheres, Sphere.ELEMENTSIZE)),
+                cylinderPointer = SeekWrite(fs, SerializeLevelObjects(level.cylinders, Cylinder.ELEMENTSIZE)),
+                unkPointer12 = SeekWrite(fs, new byte[0x10]),
+                unkPointer17 = SeekWrite(fs, level.unk17),
+                unkPointer16 = SeekWrite(fs, level.unk16),
+                grindPathsPointer = SeekWrite(fs, level.unk13),
+                areasPointer = SeekWrite(fs, level.areasData),
+                occlusionPointer = SeekWrite(fs, GetOcclusionBytes(level.occlusionData))
+            };
+
+            //Seek to the beginning of the file to append the updated header
+            byte[] head = gameplayHeader.Serialize(level.game);
+            fs.Seek(0, SeekOrigin.Begin);
+            fs.Write(head, 0, head.Length);
+        }
+
+        private void SaveRC3(Level level, FileStream fs)
+        {
+            //Seek past the header
+            fs.Seek(0xA0, SeekOrigin.Begin);
+
+            GameplayHeader gameplayHeader = new GameplayHeader
+            {
+                unkPointer18 = SeekWrite4(fs, level.unk18),
+                levelVarPointer = SeekWrite4(fs, level.levelVariables.Serialize(level.game)),
+                englishPointer = SeekWrite4(fs, GetLangBytes(level.english)),
+                ukenglishPointer = SeekWrite4(fs, GetLangBytes(level.ukenglish)),
+                frenchPointer = SeekWrite4(fs, GetLangBytes(level.french)),
+                germanPointer = SeekWrite4(fs, GetLangBytes(level.german)),
+                spanishPointer = SeekWrite4(fs, GetLangBytes(level.spanish)),
+                italianPointer = SeekWrite4(fs, GetLangBytes(level.italian)),
+                japanesePointer = SeekWrite4(fs, GetLangBytes(level.japanese)),
+                koreanPointer = SeekWrite4(fs, GetLangBytes(level.korean)),
+                lightsPointer = SeekWrite4(fs, SerializeLevelObjects(level.directionalLights, DirectionalLight.ELEMENTSIZE)),
+                type80Pointer = SeekWrite4(fs, GetType80Bytes(level.type80s)),
+                cameraPointer = SeekWrite4(fs, SerializeLevelObjects(level.gameCameras, GameCamera.ELEMENTSIZE)),
+                soundPointer = SeekWrite4(fs, SerializeLevelObjects(level.type0Cs, Type0C.ELEMENTSIZE)),
+                mobyIdPointer = SeekWrite4(fs, GetIdBytes(level.mobyIds)),
+                mobyPointer = SeekWrite4(fs, GetMobyBytes(level.mobs, level.game)),
+                pvarSizePointer = SeekWrite4(fs, GetPvarSizeBytes(level.pVars)),
+                pvarPointer = SeekWrite4(fs, GetPvarBytes(level.pVars)),
+                type50Pointer = SeekWrite4(fs, GetKeyValueBytes(level.type50s)),
+                type5CPointer = SeekWrite4(fs, GetKeyValueBytes(level.type5Cs)),
+                mobyGroupsPointer = SeekWrite4(fs, level.unk6),
+                type4CPointer = SeekWrite4(fs, level.unk7),
+                tieIdPointer = SeekWrite4(fs, GetIdBytes(level.tieIds)),
+                tiePointer = SeekWrite4(fs, level.tieData),
+                tieGroupsPointer = SeekWrite4(fs, level.tieGroupData),
+                shrubIdPointer = SeekWrite4(fs, GetIdBytes(level.shrubIds)),
+                shrubPointer = SeekWrite4(fs, level.shrubData),
+                shrubGroupsPointer = SeekWrite4(fs, level.shrubGroupData),
+                splinePointer = SeekWrite4(fs, GetSplineBytes(level.splines)),
+                cuboidPointer = SeekWrite4(fs, SerializeLevelObjects(level.cuboids, Cuboid.ELEMENTSIZE)),
+                spherePointer = SeekWrite4(fs, SerializeLevelObjects(level.spheres, Sphere.ELEMENTSIZE)),
+                cylinderPointer = SeekWrite4(fs, SerializeLevelObjects(level.cylinders, Cylinder.ELEMENTSIZE)),
+                unkPointer12 = SeekWrite4(fs, new byte[0x10]),
+                unkPointer17 = SeekWrite4(fs, level.unk17),
+                unkPointer16 = SeekWrite4(fs, level.unk16),
+                grindPathsPointer = SeekWrite4(fs, level.unk13),
+                areasPointer = SeekWrite4(fs, level.areasData),
+                occlusionPointer = SeekWrite4(fs, GetOcclusionBytes(level.occlusionData))
+            };
+
+            //Seek to the beginning of the file to append the updated header
+            byte[] head = gameplayHeader.Serialize(level.game);
+            fs.Seek(0, SeekOrigin.Begin);
+            fs.Write(head, 0, head.Length);
+        }
+
+        private void SaveRC4(Level level, FileStream fs)
+        {
+            //Seek past the header
+            fs.Seek(0x90, SeekOrigin.Begin);
+
+            GameplayHeader gameplayHeader = new GameplayHeader
+            {
+                levelVarPointer = SeekWrite4(fs, level.levelVariables.Serialize(level.game)),
+                englishPointer = SeekWrite4(fs, GetLangBytes(level.english)),
+                ukenglishPointer = SeekWrite4(fs, GetLangBytes(level.ukenglish)),
+                frenchPointer = SeekWrite4(fs, GetLangBytes(level.french)),
+                germanPointer = SeekWrite4(fs, GetLangBytes(level.german)),
+                spanishPointer = SeekWrite4(fs, GetLangBytes(level.spanish)),
+                italianPointer = SeekWrite4(fs, GetLangBytes(level.italian)),
+                japanesePointer = SeekWrite4(fs, GetLangBytes(level.japanese)),
+                koreanPointer = SeekWrite4(fs, GetLangBytes(level.korean)),
+                lightsPointer = SeekWrite4(fs, SerializeLevelObjects(level.directionalLights, DirectionalLight.ELEMENTSIZE)),
+                type80Pointer = SeekWrite4(fs, GetType80Bytes(level.type80s)),
+                cameraPointer = SeekWrite4(fs, SerializeLevelObjects(level.gameCameras, GameCamera.ELEMENTSIZE)),
+                soundPointer = SeekWrite4(fs, SerializeLevelObjects(level.type0Cs, Type0C.ELEMENTSIZE)),
+                mobyIdPointer = SeekWrite4(fs, GetIdBytes(level.mobyIds)),
+                mobyPointer = SeekWrite4(fs, GetMobyBytes(level.mobs, level.game)),
+                pvarSizePointer = SeekWrite4(fs, GetPvarSizeBytes(level.pVars)),
+                pvarPointer = SeekWrite4(fs, GetPvarBytes(level.pVars)),
+                type50Pointer = SeekWrite4(fs, GetKeyValueBytes(level.type50s)),
+                type5CPointer = SeekWrite4(fs, GetKeyValueBytes(level.type5Cs)),
+                mobyGroupsPointer = SeekWrite4(fs, level.unk6),
+                type4CPointer = SeekWrite4(fs, level.unk7),
+                tieIdPointer = SeekWrite4(fs, GetIdBytes(level.tieIds)),
+                tiePointer = SeekWrite4(fs, level.tieData),
+                tieGroupsPointer = SeekWrite4(fs, level.tieGroupData),
+                shrubIdPointer = SeekWrite4(fs, GetIdBytes(level.shrubIds)),
+                shrubPointer = SeekWrite4(fs, level.shrubData),
+                shrubGroupsPointer = SeekWrite4(fs, level.shrubGroupData),
+                splinePointer = SeekWrite4(fs, GetSplineBytes(level.splines)),
+                cuboidPointer = SeekWrite4(fs, SerializeLevelObjects(level.cuboids, Cuboid.ELEMENTSIZE)),
+                spherePointer = SeekWrite4(fs, SerializeLevelObjects(level.spheres, Sphere.ELEMENTSIZE)),
+                cylinderPointer = SeekWrite4(fs, SerializeLevelObjects(level.cylinders, Cylinder.ELEMENTSIZE)),
+                unkPointer12 = SeekWrite4(fs, new byte[0x10]),
+                unkPointer17 = SeekWrite4(fs, level.unk17),
+                unkPointer16 = SeekWrite4(fs, level.unk16),
+                grindPathsPointer = SeekWrite4(fs, level.unk13),
+                areasPointer = SeekWrite4(fs, level.areasData),
+                occlusionPointer = SeekWrite4(fs, GetOcclusionBytes(level.occlusionData))
+            };
+
+            //Seek to the beginning of the file to append the updated header
+            byte[] head = gameplayHeader.Serialize(level.game);
+            fs.Seek(0, SeekOrigin.Begin);
+            fs.Write(head, 0, head.Length);
         }
 
         private int SeekWrite(FileStream fs, byte[] bytes)
@@ -83,11 +257,31 @@ namespace LibReplanetizer.Serializers
             else return 0;
         }
 
+        private int SeekWrite4(FileStream fs, byte[] bytes)
+        {
+            if (bytes != null)
+            {
+                SeekPast4(fs);
+                int pos = (int)fs.Position;
+                fs.Write(bytes, 0, bytes.Length);
+                return pos;
+            }
+            else return 0;
+        }
+
         private void SeekPast(FileStream fs)
         {
             while (fs.Position % 0x10 != 0)
             {
-                fs.Seek(4, SeekOrigin.Current);
+                fs.Seek(2, SeekOrigin.Current);
+            }
+        }
+
+        private void SeekPast4(FileStream fs)
+        {
+            while (fs.Position % 0x4 != 0)
+            {
+                fs.Seek(2, SeekOrigin.Current);
             }
         }
 

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -284,7 +284,7 @@ namespace LibReplanetizer
             {
                 if (settings.chunksSelected[0])
                 {
-                    terrain.AddRange(level.terrainEngine);
+                    terrain.AddRange(level.terrainEngine.fragments);
                 }     
             } else
             {
@@ -292,7 +292,7 @@ namespace LibReplanetizer
                 {
                     if (settings.chunksSelected[i])
                     {
-                        terrain.AddRange(level.terrainChunks[i]);
+                        terrain.AddRange(level.terrainChunks[i].fragments);
                     }
                 }
             }

--- a/LibReplanetizer/Serializers/SerializerFunctions.cs
+++ b/LibReplanetizer/Serializers/SerializerFunctions.cs
@@ -1,0 +1,170 @@
+﻿using LibReplanetizer.LevelObjects;
+using LibReplanetizer.Models;
+using System.Collections.Generic;
+using System.IO;
+using static LibReplanetizer.DataFunctions;
+
+namespace LibReplanetizer.Serializers
+{
+    public static class SerializerFunctions
+    {
+        public static int SeekWrite(FileStream fs, byte[] bytes)
+        {
+            if (bytes != null)
+            {
+                SeekPast(fs);
+                int pos = (int)fs.Position;
+                fs.Write(bytes, 0, bytes.Length);
+                return pos;
+            }
+            else return 0;
+        }
+
+        public static int SeekWrite4(FileStream fs, byte[] bytes)
+        {
+            if (bytes != null)
+            {
+                SeekPast4(fs);
+                int pos = (int)fs.Position;
+                fs.Write(bytes, 0, bytes.Length);
+                return pos;
+            }
+            else return 0;
+        }
+
+        public static void SeekPast(FileStream fs)
+        {
+            while (fs.Position % 0x10 != 0)
+            {
+                fs.Seek(2, SeekOrigin.Current);
+            }
+        }
+
+        public static void SeekPast4(FileStream fs)
+        {
+            while (fs.Position % 0x4 != 0)
+            {
+                fs.Seek(2, SeekOrigin.Current);
+            }
+        }
+
+        public static byte[] WriteTfrags(Terrain terrain, int fileOffset, GameType game)
+        {
+            List<TerrainFragment> tFrags = terrain.fragments;
+
+            List<List<byte>> vertBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
+            List<List<byte>> rgbaBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
+            List<List<byte>> uvBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
+            List<List<byte>> indexBytes = new List<List<byte>>() { new List<byte>(), new List<byte>(), new List<byte>(), new List<byte>() };
+
+            List<byte> textureBytes = new List<byte>();
+
+            byte[] tfragHeads = new byte[0x30 * tFrags.Count];
+
+            int headerSize = (game.num == 4) ? 0x70 : 0x60;
+
+            ushort chunk = 0;
+
+            for (int i = 0; i < tFrags.Count; i++)
+            {
+                TerrainModel mod = (TerrainModel)(tFrags[i].model);
+
+                int offset = i * 0x30;
+                WriteFloat(tfragHeads, offset + 0x00, tFrags[i].off_00);
+                WriteFloat(tfragHeads, offset + 0x04, tFrags[i].off_04);
+                WriteFloat(tfragHeads, offset + 0x08, tFrags[i].off_08);
+                WriteFloat(tfragHeads, offset + 0x0C, tFrags[i].off_0C);
+
+                WriteInt(tfragHeads, offset + 0x10, fileOffset + headerSize + tfragHeads.Length + textureBytes.Count);
+                WriteInt(tfragHeads, offset + 0x14, tFrags[i].model.textureConfig.Count);
+
+                byte[] modelVertBytes = mod.SerializeVerts();
+                if (((vertBytes[chunk].Count + modelVertBytes.Length) / 0x1c) > 0xffff)
+                {
+                    chunk++;
+                }
+
+                WriteUshort(tfragHeads, offset + 0x18, (ushort)(vertBytes[chunk].Count / 0x1c));
+                WriteUshort(tfragHeads, offset + 0x1a, (ushort)(tFrags[i].model.vertexBuffer.Length / 8));
+
+                WriteUshort(tfragHeads, offset + 0x1C, tFrags[i].off_1C);
+                WriteUshort(tfragHeads, offset + 0x1E, tFrags[i].off_1E);
+                WriteUshort(tfragHeads, offset + 0x20, tFrags[i].off_20);
+                WriteUshort(tfragHeads, offset + 0x22, chunk);
+                WriteUint(tfragHeads, offset + 0x24, tFrags[i].off_24);
+                WriteUint(tfragHeads, offset + 0x28, tFrags[i].off_28);
+                WriteUint(tfragHeads, offset + 0x2C, tFrags[i].off_2C);
+
+                foreach (var texConf in tFrags[i].model.textureConfig)
+                {
+                    byte[] texBytes = new byte[0x10];
+                    WriteInt(texBytes, 0x00, texConf.ID);
+                    WriteInt(texBytes, 0x04, texConf.start + indexBytes[chunk].Count / 2);
+                    WriteInt(texBytes, 0x08, texConf.size);
+                    WriteInt(texBytes, 0x0C, texConf.mode);
+                    textureBytes.AddRange(texBytes);
+                }
+
+                indexBytes[chunk].AddRange(tFrags[i].model.GetFaceBytes((ushort)(vertBytes[chunk].Count / 0x1C)));
+                vertBytes[chunk].AddRange(modelVertBytes);
+                rgbaBytes[chunk].AddRange(tFrags[i].model.rgbas);
+                uvBytes[chunk].AddRange(tFrags[i].model.SerializeUVs());
+
+            }
+
+            List<byte> outBytes = new List<byte>();
+
+            byte[] head = new byte[headerSize];
+            WriteInt(head, 0, fileOffset + headerSize);
+            WriteUshort(head, 0x4, terrain.levelNumber);
+            WriteUshort(head, 0x6, (ushort)tFrags.Count);
+
+            outBytes.AddRange(head);
+            outBytes.AddRange(tfragHeads);
+            outBytes.AddRange(textureBytes);
+
+            int[] vertOffsets = { 0, 0, 0, 0 };
+            int[] rgbaOffsets = { 0, 0, 0, 0 };
+            int[] uvOffsets = { 0, 0, 0, 0 };
+            int[] indexOffsets = { 0, 0, 0, 0 };
+            int[] unkOffsets = { 0, 0, 0, 0 };
+
+            for (int i = 0; i < 4; i++)
+            {
+                if (vertBytes[i].Count == 0)
+                {
+                    continue;
+                }
+                Pad(outBytes);
+                vertOffsets[i] = fileOffset + outBytes.Count;
+                outBytes.AddRange(vertBytes[i]);
+                Pad(outBytes);
+                rgbaOffsets[i] = fileOffset + outBytes.Count;
+                outBytes.AddRange(rgbaBytes[i]);
+                Pad(outBytes);
+                uvOffsets[i] = fileOffset + outBytes.Count;
+                outBytes.AddRange(uvBytes[i]);
+                Pad(outBytes);
+                indexOffsets[i] = fileOffset + outBytes.Count;
+                outBytes.AddRange(indexBytes[i]);
+                Pad(outBytes);
+                unkOffsets[i] = fileOffset + outBytes.Count;
+            }
+
+
+            byte[] outByteArr = outBytes.ToArray();
+
+            for (int i = 0; i < 4; i++)
+            {
+                WriteInt(outByteArr, 0x08 + i * 4, vertOffsets[i]);
+                WriteInt(outByteArr, 0x18 + i * 4, rgbaOffsets[i]);
+                WriteInt(outByteArr, 0x28 + i * 4, uvOffsets[i]);
+                WriteInt(outByteArr, 0x38 + i * 4, indexOffsets[i]);
+                if (game.num == 4)
+                    WriteInt(outByteArr, 0x48 + i * 4, unkOffsets[i]);
+            }
+
+            return outByteArr;
+        }
+    }
+}

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -516,7 +516,7 @@ namespace Replanetizer.Frames
             if (level.terrainChunks.Count == 0)
             {
                 terrains.Clear();
-                terrains.AddRange(level.terrainEngine);
+                terrains.AddRange(level.terrainEngine.fragments);
                 collisions.Clear();
                 collisions.Add(new Tuple<Model,int,int>(level.collisionEngine, collisionVbo[0], collisionIbo[0]));
             } else
@@ -527,7 +527,7 @@ namespace Replanetizer.Frames
                 for (int i = 0; i < level.terrainChunks.Count; i++)
                 {
                     if (selectedChunks[i])
-                        terrains.AddRange(level.terrainChunks[i]);
+                        terrains.AddRange(level.terrainChunks[i].fragments);
                 }
 
                 for (int i = 0; i < level.collisionChunks.Count; i++)
@@ -591,9 +591,9 @@ namespace Replanetizer.Frames
                     //level.shrubModels.RemoveRange(5, level.shrubModels.Count - 5);
                     break;
                 case TerrainFragment tFrag:
-                    foreach (List<TerrainFragment> list in level.terrainChunks)
+                    foreach (Terrain terrain in level.terrainChunks)
                     {
-                        list.Remove(tFrag);
+                        terrain.fragments.Remove(tFrag);
                     }
                     break;
                 case Spline spline:


### PR DESCRIPTION
This PR fixes most major serialization errors. I did this by serializing and then looking at the diffs of the output to the original files. The result is not perfect especially as things like languages, shrub models etc are not parsed/serialized 100% accurately. However, the output is good enough that RaC 1 and 2 are able to load the files. I did not test whether RaC 3 or Deadlocked are able to do so but Deadlocked most likely isn't yet as there is still a lot not being parsed.

Additionally, since I got a bit of an insight in what we currently parse incorrectly some things have changed. For example, there are now a lot more level variables being parsed. Further I noticed that there is another set of pointers in the terrain in Deadlocked.

Further, as suggested by chaoticgd, this PR fixes the modelmatrices of spheres, cylinders, cuboids and type0Cs and rotations of mobies. 