### PR TITLE
Property related Changes

### DIFF
--- a/LibReplanetizer/Level Objects/Engine/Light.cs
+++ b/LibReplanetizer/Level Objects/Engine/Light.cs
@@ -1,77 +1,78 @@
-﻿using static LibReplanetizer.DataFunctions;
+﻿using OpenTK.Mathematics;
+using static LibReplanetizer.DataFunctions;
 
 namespace LibReplanetizer.LevelObjects
 {
+    /*
+     * Lights are used for everything but terrain
+     * Lights are applied differently for different things
+     * i.e. increasing the magnitude to the direction increases brightness of the light for shrubs a lot but not for mobies/ties etc.
+     * 
+     * Color channels are in [0,1]
+     */
     public class Light
     {
-        public float off_00;
-        public float off_04;
-        public float off_08;
-        public float off_0C;
-
-        public float off_10;
-        public float off_14;
-        public float off_18;
-        public float off_1C;
-
-        public float off_20;
-        public float off_24;
-        public float off_28;
-        public float off_2C;
-
-        public float off_30;
-        public float off_34;
-        public float off_38;
-        public float off_3C;
+        public Vector4 color1;
+        public Vector4 direction1;
+        public Vector4 color2;
+        public Vector4 direction2;
 
         public Light(byte[] block, int num)
         {
             int offset = num * 0x40;
 
-            off_00 = ReadFloat(block, offset + 0x00);
-            off_04 = ReadFloat(block, offset + 0x04);
-            off_08 = ReadFloat(block, offset + 0x08);
-            off_0C = ReadFloat(block, offset + 0x0C);
+            float c1R = ReadFloat(block, offset + 0x00);
+            float c1G = ReadFloat(block, offset + 0x04);
+            float c1B = ReadFloat(block, offset + 0x08);
+            float c1A = ReadFloat(block, offset + 0x0C);
 
-            off_10 = ReadFloat(block, offset + 0x10);
-            off_14 = ReadFloat(block, offset + 0x14);
-            off_18 = ReadFloat(block, offset + 0x18);
-            off_1C = ReadFloat(block, offset + 0x1C);
+            color1 = new Vector4(c1R, c1G, c1B, c1A);
 
-            off_20 = ReadFloat(block, offset + 0x20);
-            off_24 = ReadFloat(block, offset + 0x24);
-            off_28 = ReadFloat(block, offset + 0x28);
-            off_2C = ReadFloat(block, offset + 0x2C);
+            float d1X = ReadFloat(block, offset + 0x10);
+            float d1Y = ReadFloat(block, offset + 0x14);
+            float d1Z = ReadFloat(block, offset + 0x18);
+            float d1W = ReadFloat(block, offset + 0x1C);
 
-            off_30 = ReadFloat(block, offset + 0x30);
-            off_34 = ReadFloat(block, offset + 0x34);
-            off_38 = ReadFloat(block, offset + 0x38);
-            off_3C = ReadFloat(block, offset + 0x3C);
+            direction1 = new Vector4(d1X, d1Y, d1Z, d1W);
+
+            float c2R = ReadFloat(block, offset + 0x20);
+            float c2G = ReadFloat(block, offset + 0x24);
+            float c2B = ReadFloat(block, offset + 0x28);
+            float c2A = ReadFloat(block, offset + 0x2C);
+
+            color2 = new Vector4(c2R, c2G, c2B, c2A);
+
+            float d2X = ReadFloat(block, offset + 0x30);
+            float d2Y = ReadFloat(block, offset + 0x34);
+            float d2Z = ReadFloat(block, offset + 0x38);
+            float d2W = ReadFloat(block, offset + 0x3C);
+
+            direction2 = new Vector4(d2X, d2Y, d2Z, d2W);
         }
 
         public byte[] Serialize()
         {
             byte[] bytes = new byte[0x40];
 
-            WriteFloat(bytes, 0x00, off_00);
-            WriteFloat(bytes, 0x04, off_04);
-            WriteFloat(bytes, 0x08, off_08);
-            WriteFloat(bytes, 0x0C, off_0C);
+            WriteFloat(bytes, 0x00, color1.X);
+            WriteFloat(bytes, 0x04, color1.Y);
+            WriteFloat(bytes, 0x08, color1.Z);
+            WriteFloat(bytes, 0x0C, color1.W);
 
-            WriteFloat(bytes, 0x10, off_10);
-            WriteFloat(bytes, 0x14, off_14);
-            WriteFloat(bytes, 0x18, off_18);
-            WriteFloat(bytes, 0x1C, off_1C);
+            WriteFloat(bytes, 0x10, direction1.X);
+            WriteFloat(bytes, 0x14, direction1.Y);
+            WriteFloat(bytes, 0x18, direction1.Z);
+            WriteFloat(bytes, 0x1C, direction1.W);
 
-            WriteFloat(bytes, 0x20, off_20);
-            WriteFloat(bytes, 0x24, off_24);
-            WriteFloat(bytes, 0x28, off_28);
-            WriteFloat(bytes, 0x2C, off_2C);
+            WriteFloat(bytes, 0x20, color2.X);
+            WriteFloat(bytes, 0x24, color2.Y);
+            WriteFloat(bytes, 0x28, color2.Z);
+            WriteFloat(bytes, 0x2C, color2.W);
 
-            WriteFloat(bytes, 0x30, off_30);
-            WriteFloat(bytes, 0x34, off_34);
-            WriteFloat(bytes, 0x38, off_38);
-            WriteFloat(bytes, 0x3C, off_3C);
+            WriteFloat(bytes, 0x30, direction2.X);
+            WriteFloat(bytes, 0x34, direction2.Y);
+            WriteFloat(bytes, 0x38, direction2.Z);
+            WriteFloat(bytes, 0x3C, direction2.W);
 
             return bytes;
         }

--- a/LibReplanetizer/Level Objects/Engine/Shrub.cs
+++ b/LibReplanetizer/Level Objects/Engine/Shrub.cs
@@ -1,6 +1,8 @@
 using LibReplanetizer.Models;
 using OpenTK.Mathematics;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
 using static LibReplanetizer.DataFunctions;
 
 
@@ -10,17 +12,25 @@ namespace LibReplanetizer.LevelObjects
     {
         public const int ELEMENTSIZE = 0x70;
 
-        public short off_50 { get; set; }
-        public uint off_54 { get; set; }
+        [Category("Attributes"), DisplayName("Draw Distance")]
+        public float drawDistance { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_58: Always 0")]
         public uint off_58 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_5C: Always 0")]
         public uint off_5C { get; set; }
 
-        public int colors { get; set; }
+        // Seems to be some kind of static lighting color
+        // Changing it to red will make the shrub be very red
+        // the texture remains visible so cleary the visible
+        // color is some blend between texture and this
+        [Category("Attributes"), DisplayName("Static Color")]
+        public Color color { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_64: Always 0")]
         public uint off_64 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_68: Power of 2 minus 1")]
         public uint off_68 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_6C: Always 0")]
         public uint off_6C { get; set; }
-
-        public byte[] colorBytes;
 
 
         public Shrub(Matrix4 matrix4)
@@ -41,18 +51,21 @@ namespace LibReplanetizer.LevelObjects
             off_4C =    BAToUInt32(levelBlock, offset + 0x4C);
             */
 
-            off_50 = ReadShort(levelBlock, offset + 0x50);
-            modelID = ReadUshort(levelBlock, offset + 0x52);
-            off_54 = ReadUint(levelBlock, offset + 0x54);
+            modelID = ReadInt(levelBlock, offset + 0x50);
+            drawDistance = ReadFloat(levelBlock, offset + 0x54);
             off_58 = ReadUint(levelBlock, offset + 0x58);
             off_5C = ReadUint(levelBlock, offset + 0x5C);
 
-            colors = ReadInt(levelBlock, offset + 0x60);
+            byte r = levelBlock[offset + 0x60];
+            byte g = levelBlock[offset + 0x61];
+            byte b = levelBlock[offset + 0x62];
+            byte a = levelBlock[offset + 0x63];
             off_64 = ReadUint(levelBlock, offset + 0x64);
             off_68 = ReadUint(levelBlock, offset + 0x68);
             off_6C = ReadUint(levelBlock, offset + 0x6C);
 
             model = shrubModels.Find(shrubModel => shrubModel.id == modelID);
+            color = Color.FromArgb(a, r, g, b);
 
             rotation = modelMatrix.ExtractRotation();
             position = modelMatrix.ExtractTranslation();
@@ -81,13 +94,15 @@ namespace LibReplanetizer.LevelObjects
 
             WriteMatrix4(bytes, 0x00, modelMatrix);
 
-            WriteShort(bytes, 0x50, off_50);
-            WriteShort(bytes, 0x52, (short)modelID);
-            WriteUint(bytes, 0x54, off_54);
+            WriteInt(bytes, 0x50, modelID);
+            WriteFloat(bytes, 0x54, drawDistance);
             WriteUint(bytes, 0x58, off_58);
             WriteUint(bytes, 0x5C, off_5C);
 
-            WriteInt(bytes, 0x60, colors);
+            bytes[0x60] = color.R;
+            bytes[0x61] = color.G;
+            bytes[0x62] = color.B;
+            bytes[0x63] = color.A;
             WriteUint(bytes, 0x64, off_64);
             WriteUint(bytes, 0x68, off_68);
             WriteUint(bytes, 0x6C, off_6C);

--- a/LibReplanetizer/Level Objects/Engine/Terrain.cs
+++ b/LibReplanetizer/Level Objects/Engine/Terrain.cs
@@ -3,6 +3,7 @@ using LibReplanetizer.Models;
 using OpenTK.Mathematics;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using static LibReplanetizer.DataFunctions;
 
@@ -22,22 +23,39 @@ namespace LibReplanetizer.LevelObjects
 
     public class TerrainFragment : ModelObject
     {
-        public float off_00;
-        public float off_04;
-        public float off_08;
-        public float off_0C;
+        /*
+         * These first 4 values probably define an axis aligned bounding box
+         * which is probably used for frustum culling since terrain has no
+         * maximum render distance and the mesh is not "offset"
+         * Testing this seemed to confirm that this is culling related
+         * but it remains to be shown whether these are in fact AABBs
+         */
+        [Category("Unknowns"), DisplayName("OFF_00: AABB X")]
+        public float off_00 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_04: AABB Y")]
+        public float off_04 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_08: AABB Z")]
+        public float off_08 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_0C: AABB Size")]
+        public float off_0C { get; set; }
 
         // 0x10 = pointer to TextureConfig
         // 0x14 = TextureConfig count
         // 0x18 = vertex offset, vertex count
-        public ushort off_1C;   // Always 0xffff
-        public ushort off_1E;   // 0 in rac1, index in rac2/3
+        [Category("Unknowns"), DisplayName("OFF_1C: Always 65535")]
+        public ushort off_1C { get; set; }   // Always 0xffff
+        [Category("Unknowns"), DisplayName("OFF_1E: Fragment ID")]
+        public ushort off_1E { get; set; }   // 0 in rac1, index in rac2/3
 
-        public ushort off_20;   // Always 0xff00
+        [Category("Unknowns"), DisplayName("OFF_1C: Always 65280")]
+        public ushort off_20 { get; set; }   // Always 0xff00
         // 0x22 = which rgba, uv and index pointer to use (0 for the first, 1 for the second)
-        public uint off_24;     // Always 0
-        public uint off_28;     // Always 0
-        public uint off_2C;     // Always 0
+        [Category("Unknowns"), DisplayName("OFF_24: Always 0")]
+        public uint off_24 { get; set; }     // Always 0
+        [Category("Unknowns"), DisplayName("OFF_28: Always 0")]
+        public uint off_28 { get; set; }     // Always 0
+        [Category("Unknowns"), DisplayName("OFF_2C: Always 0")]
+        public uint off_2C { get; set; }     // Always 0
 
 
         public TerrainFragment(FileStream fs, TerrainHead head, byte[] tfragBlock, int num)
@@ -49,11 +67,10 @@ namespace LibReplanetizer.LevelObjects
             off_08 = ReadFloat(tfragBlock, offset + 0x08);
             off_0C = ReadFloat(tfragBlock, offset + 0x0C);
 
-
             off_1C = ReadUshort(tfragBlock, offset + 0x1C);
             off_1E = ReadUshort(tfragBlock, offset + 0x1E);
-            off_20 = ReadUshort(tfragBlock, offset + 0x20);
 
+            off_20 = ReadUshort(tfragBlock, offset + 0x20);
             off_24 = ReadUint(tfragBlock, offset + 0x24);
             off_28 = ReadUint(tfragBlock, offset + 0x28);
             off_2C = ReadUint(tfragBlock, offset + 0x2C);
@@ -70,9 +87,29 @@ namespace LibReplanetizer.LevelObjects
             throw new NotImplementedException();
         }
 
+        // Some variables are not written since they have to be dynamically determined based on the underlying data
         public override byte[] ToByteArray()
         {
-            throw new NotImplementedException();
+            byte[] head = new byte[0x30];
+
+            WriteFloat(head, 0x00, off_00);
+            WriteFloat(head, 0x04, off_04);
+            WriteFloat(head, 0x08, off_08);
+            WriteFloat(head, 0x0C, off_0C);
+
+            WriteInt(head, 0x10, 0);
+            WriteInt(head, 0x14, 0);
+            WriteInt(head, 0x18, 0);
+            WriteUshort(head, 0x1C, off_1C);
+            WriteUshort(head, 0x1E, off_1E);
+
+            WriteUshort(head, 0x20, off_20);
+            WriteUshort(head, 0x22, 0);
+            WriteUint(head, 0x24, off_24);
+            WriteUint(head, 0x28, off_28);
+            WriteUint(head, 0x2C, off_2C);
+
+            return head;
         }
 
     }

--- a/LibReplanetizer/Level Objects/Engine/Tie.cs
+++ b/LibReplanetizer/Level Objects/Engine/Tie.cs
@@ -1,6 +1,7 @@
 using LibReplanetizer.Models;
 using OpenTK.Mathematics;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using static LibReplanetizer.DataFunctions;
 
@@ -11,13 +12,18 @@ namespace LibReplanetizer.LevelObjects
     {
         const int ELEMENTSIZE = 0x70;
 
-        public short off_50 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_54: Always 4000 in RaC 2/3")]
         public uint off_54 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_58: Tie ID")]
         public uint off_58 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_5C: Always 0")]
         public uint off_5C { get; set; }
 
+        [Category("Unknowns"), DisplayName("OFF_64: Always 0")]
         public uint off_64 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_68: Power of 2 minus 1")]
         public uint off_68 { get; set; }
+        [Category("Unknowns"), DisplayName("OFF_6C: Always 0")]
         public uint off_6C { get; set; }
 
         public byte[] colorBytes;
@@ -40,8 +46,7 @@ namespace LibReplanetizer.LevelObjects
             off_4C =    BAToUInt32(levelBlock, offset + 0x4C);
             */
 
-            off_50 = ReadShort(levelBlock, offset + 0x50);
-            modelID = ReadUshort(levelBlock, offset + 0x52);
+            modelID = ReadInt(levelBlock, offset + 0x50);
             off_54 = ReadUint(levelBlock, offset + 0x54);
             off_58 = ReadUint(levelBlock, offset + 0x58);
             off_5C = ReadUint(levelBlock, offset + 0x5C);
@@ -80,8 +85,7 @@ namespace LibReplanetizer.LevelObjects
 
             WriteMatrix4(bytes, 0x00, modelMatrix);
 
-            WriteShort(bytes, 0x50, off_50);
-            WriteShort(bytes, 0x52, (short)modelID);
+            WriteInt(bytes, 0x50, modelID);
             WriteUint(bytes, 0x54, off_54);
             WriteUint(bytes, 0x58, off_58);
             WriteUint(bytes, 0x5C, off_5C);
@@ -94,9 +98,22 @@ namespace LibReplanetizer.LevelObjects
             return bytes;
         }
 
+        // this may cause issues since the colorOffset is not given
         public override byte[] ToByteArray()
         {
             var bytes = new byte[ELEMENTSIZE];
+
+            WriteMatrix4(bytes, 0x00, modelMatrix);
+
+            WriteInt(bytes, 0x50, modelID);
+            WriteUint(bytes, 0x54, off_54);
+            WriteUint(bytes, 0x58, off_58);
+            WriteUint(bytes, 0x5C, off_5C);
+
+            WriteInt(bytes, 0x60, 0);
+            WriteUint(bytes, 0x64, off_64);
+            WriteUint(bytes, 0x68, off_68);
+            WriteUint(bytes, 0x6C, off_6C);
 
             return bytes;
         }

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -372,7 +372,7 @@ namespace LibReplanetizer
         public void Save(string outputFile)
         {
             string directory;
-            if (File.GetAttributes(outputFile).HasFlag(FileAttributes.Directory))
+            if (File.Exists(outputFile) && File.GetAttributes(outputFile).HasFlag(FileAttributes.Directory))
             {
                 directory = outputFile;
             }

--- a/LibReplanetizer/Serializers/SerializerFunctions.cs
+++ b/LibReplanetizer/Serializers/SerializerFunctions.cs
@@ -70,10 +70,7 @@ namespace LibReplanetizer.Serializers
                 TerrainModel mod = (TerrainModel)(tFrags[i].model);
 
                 int offset = i * 0x30;
-                WriteFloat(tfragHeads, offset + 0x00, tFrags[i].off_00);
-                WriteFloat(tfragHeads, offset + 0x04, tFrags[i].off_04);
-                WriteFloat(tfragHeads, offset + 0x08, tFrags[i].off_08);
-                WriteFloat(tfragHeads, offset + 0x0C, tFrags[i].off_0C);
+                tFrags[i].ToByteArray().CopyTo(tfragHeads, offset);
 
                 WriteInt(tfragHeads, offset + 0x10, fileOffset + headerSize + tfragHeads.Length + textureBytes.Count);
                 WriteInt(tfragHeads, offset + 0x14, tFrags[i].model.textureConfig.Count);
@@ -87,13 +84,7 @@ namespace LibReplanetizer.Serializers
                 WriteUshort(tfragHeads, offset + 0x18, (ushort)(vertBytes[chunk].Count / 0x1c));
                 WriteUshort(tfragHeads, offset + 0x1a, (ushort)(tFrags[i].model.vertexBuffer.Length / 8));
 
-                WriteUshort(tfragHeads, offset + 0x1C, tFrags[i].off_1C);
-                WriteUshort(tfragHeads, offset + 0x1E, tFrags[i].off_1E);
-                WriteUshort(tfragHeads, offset + 0x20, tFrags[i].off_20);
                 WriteUshort(tfragHeads, offset + 0x22, chunk);
-                WriteUint(tfragHeads, offset + 0x24, tFrags[i].off_24);
-                WriteUint(tfragHeads, offset + 0x28, tFrags[i].off_28);
-                WriteUint(tfragHeads, offset + 0x2C, tFrags[i].off_2C);
 
                 foreach (var texConf in tFrags[i].model.textureConfig)
                 {

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -166,7 +166,7 @@ namespace Replanetizer.Frames
                 {
                     if (ImGui.MenuItem("Object properties"))
                     {
-                        var newFrame = new PropertyFrame(this.wnd, selectedObject, listenToCallbacks: true);
+                        var newFrame = new PropertyFrame(this.wnd, this, selectedObject, listenToCallbacks: true);
                         RegisterCallback(newFrame.SelectionCallback);
                         subFrames.Add(newFrame);
                     }
@@ -180,11 +180,11 @@ namespace Replanetizer.Frames
                     }
                     if (ImGui.MenuItem("Light config"))
                     {
-                        subFrames.Add(new PropertyFrame(this.wnd, level.lightConfig, "Light config"));
+                        subFrames.Add(new PropertyFrame(this.wnd, this, level.lightConfig, "Light config"));
                     }
                     if (ImGui.MenuItem("Level variables"))
                     {
-                        subFrames.Add(new PropertyFrame(this.wnd, level.levelVariables, "Level variables"));
+                        subFrames.Add(new PropertyFrame(this.wnd, this, level.levelVariables, "Level variables"));
                     }
                     ImGui.EndMenu();
                 }
@@ -252,7 +252,7 @@ namespace Replanetizer.Frames
 
             if (Width != prevWidth || Height != prevHeight)
             {
-                invalidate = true;
+                InvalidateView();
                 OnResize();
             }
 
@@ -1164,7 +1164,7 @@ namespace Replanetizer.Frames
         }
 
 
-        void InvalidateView()
+        public void InvalidateView()
         {
             invalidate = true;
         }

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Numerics;
 using System.Reflection;
 using System.Text;
+using System.Drawing;
 using ImGuiNET;
-
+using LibReplanetizer.LevelObjects;
 
 namespace Replanetizer.Frames
 {
@@ -106,10 +108,34 @@ namespace Replanetizer.Frames
                         }
                         else if (type == typeof(int))
                         {
-                            var v = (int) val;
+                            int v = (int) val;
                             if (ImGui.InputInt(key, ref v))
                             {
                                 value.SetValue(selectedObject, v);
+                            }
+                        }
+                        else if (type == typeof(uint))
+                        {
+                            int v = unchecked((int)(uint)val);
+                            if (ImGui.InputInt(key, ref v))
+                            {
+                                value.SetValue(selectedObject, unchecked((uint)v));
+                            }
+                        }
+                        else if (type == typeof(short))
+                        {
+                            int v = Convert.ToInt32(val);
+                            if (ImGui.InputInt(key, ref v))
+                            {
+                                value.SetValue(selectedObject, (short)(v & 0xffff));
+                            }
+                        }
+                        else if (type == typeof(ushort))
+                        {
+                            int v = unchecked((ushort)val);
+                            if (ImGui.InputInt(key, ref v))
+                            {
+                                value.SetValue(selectedObject, unchecked((ushort)(v & 0xffff)));
                             }
                         }
                         else if (type == typeof(float))
@@ -118,6 +144,142 @@ namespace Replanetizer.Frames
                             if (ImGui.InputFloat(key, ref v))
                             {
                                 value.SetValue(selectedObject, v);
+                            }
+                        }
+                        else if (type == typeof(Color))
+                        {
+                            Color c = (Color)val;
+                            Vector3 v = new Vector3(c.R / 255.0f, c.G / 255.0f, c.B / 255.0f);
+                            if (ImGui.ColorEdit3(key, ref v))
+                            {
+                                Color newColor = Color.FromArgb((int)(v.X * 255.0f), (int)(v.Y * 255.0f), (int)(v.Z * 255.0f));
+                                value.SetValue(selectedObject, newColor);
+                            }
+                        }
+                        else if (type == typeof(OpenTK.Mathematics.Vector3))
+                        {
+                            OpenTK.Mathematics.Vector3 origV = (OpenTK.Mathematics.Vector3)val;
+                            Vector3 v = new Vector3(origV.X, origV.Y, origV.Z);
+                            if (ImGui.InputFloat3(key, ref v))
+                            {
+                                origV.X = v.X;
+                                origV.Y = v.Y;
+                                origV.Z = v.Z;
+                                value.SetValue(selectedObject, origV);
+
+                                if (selectedObject is LevelObject)
+                                {
+                                    ((LevelObject)selectedObject).UpdateTransformMatrix();
+                                }
+                            }
+                        }
+                        else if (type == typeof(OpenTK.Mathematics.Quaternion))
+                        {
+                            OpenTK.Mathematics.Vector3 origRot = ((OpenTK.Mathematics.Quaternion)val).ToEulerAngles();
+                            Vector3 v = new Vector3(origRot.X, origRot.Y, origRot.Z);
+                            if (ImGui.InputFloat3(key, ref v))
+                            {
+                                origRot.X = v.X;
+                                origRot.Y = v.Y;
+                                origRot.Z = v.Z;
+                                value.SetValue(selectedObject, new OpenTK.Mathematics.Quaternion(origRot.X, origRot.Y, origRot.Z));
+
+                                if (selectedObject is LevelObject)
+                                {
+                                    ((LevelObject)selectedObject).UpdateTransformMatrix();
+                                }
+                            }
+                        }
+                        else if (type == typeof(OpenTK.Mathematics.Matrix4))
+                        {
+                            OpenTK.Mathematics.Matrix4 mat = (OpenTK.Mathematics.Matrix4)val;
+                            Vector4 v1 = new Vector4(mat.M11, mat.M12, mat.M13, mat.M14);
+                            Vector4 v2 = new Vector4(mat.M21, mat.M22, mat.M23, mat.M24);
+                            Vector4 v3 = new Vector4(mat.M31, mat.M32, mat.M33, mat.M34);
+                            Vector4 v4 = new Vector4(mat.M41, mat.M42, mat.M43, mat.M44);
+
+                            bool change = false;
+
+                            if (ImGui.InputFloat4(key + " Row 1", ref v1))
+                            {
+                                change = true;
+                                mat.M11 = v1.X;
+                                mat.M12 = v1.Y;
+                                mat.M13 = v1.Z;
+                                mat.M14 = v1.W;
+                            }
+
+                            if (ImGui.InputFloat4(key + " Row 2", ref v2))
+                            {
+                                change = true;
+                                mat.M21 = v2.X;
+                                mat.M22 = v2.Y;
+                                mat.M23 = v2.Z;
+                                mat.M24 = v2.W;
+                            }
+
+                            if (ImGui.InputFloat4(key + " Row 3", ref v3))
+                            {
+                                change = true;
+                                mat.M31 = v3.X;
+                                mat.M32 = v3.Y;
+                                mat.M33 = v3.Z;
+                                mat.M34 = v3.W;
+                            }
+
+                            if (ImGui.InputFloat4(key + " Row 4", ref v4))
+                            {
+                                change = true;
+                                mat.M41 = v4.X;
+                                mat.M42 = v4.Y;
+                                mat.M43 = v4.Z;
+                                mat.M44 = v4.W;
+                            }
+
+                            if (change)
+                            {
+                                value.SetValue(selectedObject, mat);
+
+                                if (selectedObject is LevelObject)
+                                {
+                                    ((LevelObject)selectedObject).UpdateTransformMatrix();
+                                }
+                            }
+                        }
+                        else if (type.IsArray)
+                        {
+                            if (ImGui.CollapsingHeader(key))
+                            {
+                                Array array = (Array)val;
+
+                                foreach(object o in array)
+                                {
+                                    ImGui.Text(Convert.ToString(o));
+                                }
+                            }
+                        }
+                        else if (type.IsEnum)
+                        {
+                            Array values = Enum.GetValues(type);
+
+                            string[] strings = new string[values.Length];
+
+                            for (int i = 0; i < values.Length; i++)
+                            {
+                                strings[i] = Convert.ToString(values.GetValue(i));
+                            }
+
+                            int index = (int)val;
+
+                            if (index < values.Length)
+                            {
+                                if (ImGui.Combo(key, ref index, strings, values.Length))
+                                {
+                                    value.SetValue(selectedObject, index);
+                                }
+                            } else
+                            {
+                                ImGui.LabelText(key, "[Out of Range] " + Convert.ToString(index));
                             }
                         }
                         else

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -16,16 +16,18 @@ namespace Replanetizer.Frames
         private object selectedObject;
         private bool listenToCallbacks;
         private bool hideCallbackButton = false;
+        private LevelFrame levelFrame;
 
         private Dictionary<string, Dictionary<string, PropertyInfo>> properties;
         
-        public PropertyFrame(Window wnd, object selectedObject = null, string overrideFrameName = null, bool listenToCallbacks = false, bool hideCallbackButton = false) : base(wnd)
+        public PropertyFrame(Window wnd, LevelFrame levelFrame = null, object selectedObject = null, string overrideFrameName = null, bool listenToCallbacks = false, bool hideCallbackButton = false) : base(wnd)
         {
             if (overrideFrameName != null && overrideFrameName.Length > 0)
             {
                 frameName = overrideFrameName;
             }
-            
+
+            this.levelFrame = levelFrame;
             this.selectedObject = selectedObject;
             this.listenToCallbacks = listenToCallbacks;
             this.hideCallbackButton = hideCallbackButton;
@@ -42,6 +44,11 @@ namespace Replanetizer.Frames
             }
             selectedObject = o;
             RecomputeProperties();
+        }
+
+        private void UpdateLevelFrame()
+        {
+            if (levelFrame != null) levelFrame.InvalidateView();
         }
 
         private void RecomputeProperties()
@@ -104,6 +111,7 @@ namespace Replanetizer.Frames
                             if (ImGui.InputText(key, v, (uint)v.Length))
                             {
                                 value.SetValue(selectedObject, Encoding.ASCII.GetString(v));
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(int))
@@ -112,6 +120,7 @@ namespace Replanetizer.Frames
                             if (ImGui.InputInt(key, ref v))
                             {
                                 value.SetValue(selectedObject, v);
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(uint))
@@ -120,6 +129,7 @@ namespace Replanetizer.Frames
                             if (ImGui.InputInt(key, ref v))
                             {
                                 value.SetValue(selectedObject, unchecked((uint)v));
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(short))
@@ -128,6 +138,7 @@ namespace Replanetizer.Frames
                             if (ImGui.InputInt(key, ref v))
                             {
                                 value.SetValue(selectedObject, (short)(v & 0xffff));
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(ushort))
@@ -136,6 +147,7 @@ namespace Replanetizer.Frames
                             if (ImGui.InputInt(key, ref v))
                             {
                                 value.SetValue(selectedObject, unchecked((ushort)(v & 0xffff)));
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(float))
@@ -144,6 +156,7 @@ namespace Replanetizer.Frames
                             if (ImGui.InputFloat(key, ref v))
                             {
                                 value.SetValue(selectedObject, v);
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(Color))
@@ -154,6 +167,7 @@ namespace Replanetizer.Frames
                             {
                                 Color newColor = Color.FromArgb((int)(v.X * 255.0f), (int)(v.Y * 255.0f), (int)(v.Z * 255.0f));
                                 value.SetValue(selectedObject, newColor);
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(OpenTK.Mathematics.Vector3))
@@ -171,6 +185,8 @@ namespace Replanetizer.Frames
                                 {
                                     ((LevelObject)selectedObject).UpdateTransformMatrix();
                                 }
+
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(OpenTK.Mathematics.Quaternion))
@@ -188,6 +204,8 @@ namespace Replanetizer.Frames
                                 {
                                     ((LevelObject)selectedObject).UpdateTransformMatrix();
                                 }
+
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(OpenTK.Mathematics.Matrix4))
@@ -244,6 +262,8 @@ namespace Replanetizer.Frames
                                 {
                                     ((LevelObject)selectedObject).UpdateTransformMatrix();
                                 }
+
+                                UpdateLevelFrame();
                             }
                         }
                         else if (type.IsArray)
@@ -276,6 +296,7 @@ namespace Replanetizer.Frames
                                 if (ImGui.Combo(key, ref index, strings, values.Length))
                                 {
                                     value.SetValue(selectedObject, index);
+                                    UpdateLevelFrame();
                                 }
                             } else
                             {


### PR DESCRIPTION
This PR includes:

- Updated property names and information for ties, shrubs, terrain fragments and lights.
- Added support for more types in the property frame.
- Fixed a bug where tools only work if the mouse remains on the arrows.
- Fixed a bug where changes in a property frame do not invalidate the level frame.
- Fixed a bug where saving a level to a non existent file causes a crash.

With this we now have a lot more lighting and shading information available. I plan to write shaders for each class (ties, mobies, shrubs etc) to match the visuals in replanetizer with the visuals of the game in a future PR.