### PR TITLE
Fix level viewer greedy rotation

### DIFF
--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -58,6 +58,7 @@ namespace Replanetizer.Frames
         private Rectangle contentRegion;
         private int lastMouseX, lastMouseY;
         private bool xLock = false, yLock = false, zLock = false;
+        private MouseGrabHandler mouseGrabHandler = new();
 
         public bool initialized, invalidate;
         public bool[] selectedChunks;
@@ -668,27 +669,8 @@ namespace Replanetizer.Frames
         /// <returns>whether the user is holding right click to rotate</returns>
         private bool CheckForRotationInput(float deltaTime)
         {
-            var isDown = wnd.MouseState.IsButtonDown(MouseButton.Right);
-            var wasDown = wnd.MouseState.WasButtonDown(MouseButton.Right);
-
-            if (!isDown)
-            {
-                if (wasDown)
-                {
-                    // Released right click; unhide the cursor
-                    wnd.CursorVisible = true;
-                    wnd.CursorGrabbed = false;
-                }
+            if (!mouseGrabHandler.TryGrabMouse(wnd, MouseButton.Right))
                 return false;
-            }
-
-            if (!wasDown)
-            {
-                // Began pressing right click; hide the cursor and allow it to
-                // move without any bounds
-                wnd.CursorVisible = false;
-                wnd.CursorGrabbed = true;
-            }
 
             camera.rotation.Z -= (wnd.MouseState.Delta.X) * camera.speed * deltaTime;
             camera.rotation.X -= (wnd.MouseState.Delta.Y) * camera.speed * deltaTime;

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -58,7 +58,10 @@ namespace Replanetizer.Frames
         private Rectangle contentRegion;
         private int lastMouseX, lastMouseY;
         private bool xLock = false, yLock = false, zLock = false;
-        private MouseGrabHandler mouseGrabHandler = new();
+        private MouseGrabHandler mouseGrabHandler = new()
+        {
+            MouseButton = MouseButton.Right
+        };
 
         public bool initialized, invalidate;
         public bool[] selectedChunks;
@@ -666,10 +669,11 @@ namespace Replanetizer.Frames
             InvalidateView();
         }
 
-        /// <returns>whether the user is holding right click to rotate</returns>
-        private bool CheckForRotationInput(float deltaTime)
+        /// <param name="allowNewGrab">whether a new click will begin grabbing</param>
+        /// <returns>whether the cursor is being grabbed</returns>
+        private bool CheckForRotationInput(float deltaTime, bool allowNewGrab)
         {
-            if (!mouseGrabHandler.TryGrabMouse(wnd, MouseButton.Right))
+            if (!mouseGrabHandler.TryGrabMouse(wnd, allowNewGrab))
                 return false;
 
             camera.rotation.Z -= (wnd.MouseState.Delta.X) * camera.speed * deltaTime;
@@ -728,12 +732,16 @@ namespace Replanetizer.Frames
         public void Tick(float deltaTime)
         {
             Point absoluteMousePos = new Point((int)wnd.MousePosition.X, (int)wnd.MousePosition.Y);
+            var isWindowHovered = ImGui.IsWindowHovered();
+            var isMouseInContentRegion = contentRegion.Contains(absoluteMousePos);
+            // Allow rotation if the cursor is directly over the level frame,
+            // otherwise defer handling to any foreground frames
+            var isRotating = CheckForRotationInput(deltaTime, isWindowHovered);
             // If we're holding right click and rotating, the mouse can
             // leave the bounds of the window (GLFW CursorDisabled mode
             // allows the mouse to move freely). We want to keep rendering
             // in that case
-            var isRotating = CheckForRotationInput(deltaTime);
-            if (!isRotating && !(ImGui.IsWindowHovered() && contentRegion.Contains(absoluteMousePos)))
+            if (!isRotating && !(isWindowHovered && isMouseInContentRegion))
                 return;
 
             HandleMouseWheelChanges();

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -673,8 +673,13 @@ namespace Replanetizer.Frames
         /// <returns>whether the cursor is being grabbed</returns>
         private bool CheckForRotationInput(float deltaTime, bool allowNewGrab)
         {
-            if (!mouseGrabHandler.TryGrabMouse(wnd, allowNewGrab))
+            if (mouseGrabHandler.TryGrabMouse(wnd, allowNewGrab))
+                ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.NoMouse;
+            else
+            {
+                ImGui.GetIO().ConfigFlags &= ~ImGuiConfigFlags.NoMouse;
                 return false;
+            }
 
             camera.rotation.Z -= (wnd.MouseState.Delta.X) * camera.speed * deltaTime;
             camera.rotation.X -= (wnd.MouseState.Delta.Y) * camera.speed * deltaTime;

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -28,7 +28,7 @@ namespace Replanetizer.Frames
         private List<Texture> selectedTextureSet;
         private List<Texture> modelTextureList;
 
-        private readonly ImGuiKeyHeldHandler keyHeldHandler = new()
+        private readonly KeyHeldHandler keyHeldHandler = new()
         {
             WatchedKeys = { Keys.Up, Keys.Down },
             HoldDelay = 0.45f,

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -434,8 +434,13 @@ namespace Replanetizer.Frames
         /// <returns>whether the cursor is being grabbed</returns>
         private bool CheckForRotationInput(float deltaTime, bool allowNewGrab)
         {
-            if (!mouseGrabHandler.TryGrabMouse(wnd, allowNewGrab))
+            if (mouseGrabHandler.TryGrabMouse(wnd, allowNewGrab))
+                ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.NoMouse;
+            else
+            {
+                ImGui.GetIO().ConfigFlags &= ~ImGuiConfigFlags.NoMouse;
                 return false;
+            }
 
             xDelta += wnd.MouseState.Delta.X * deltaTime;
             rot = Matrix4.CreateRotationZ(xDelta);

--- a/Replanetizer/Utils/KeyHeldHandler.cs
+++ b/Replanetizer/Utils/KeyHeldHandler.cs
@@ -6,7 +6,7 @@ using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace Replanetizer.Utils
 {
-    public class ImGuiKeyHeldHandler
+    public class KeyHeldHandler
     {
         private class KeyHeldInfo
         {
@@ -39,7 +39,7 @@ namespace Replanetizer.Utils
 
         private readonly Dictionary<Keys, KeyHeldInfo> keysHeld = new();
 
-        public ImGuiKeyHeldHandler()
+        public KeyHeldHandler()
         {
             WatchedKeys = new ObservableCollection<Keys>();
             WatchedKeys.CollectionChanged += WatchedKeysOnCollectionChanged;

--- a/Replanetizer/Utils/MouseGrabHandler.cs
+++ b/Replanetizer/Utils/MouseGrabHandler.cs
@@ -4,17 +4,32 @@ namespace Replanetizer.Utils
 {
     public class MouseGrabHandler
     {
-        /// <returns>whether the user is holding right click to rotate</returns>
-        public bool TryGrabMouse(Window wnd, MouseButton mouseButton)
+        private bool _isGrabbed;
+        /// <summary>
+        /// the mouse button to check for being held
+        /// </summary>
+        public MouseButton MouseButton { get; set; }
+
+        /// <summary>
+        /// Check that the mouse button is being held and grab the cursor.
+        /// Grabbing will hide the cursor and allow it to move freely beyond
+        /// the bounds of the window/screen.
+        /// </summary>
+        /// <param name="wnd">the window</param>
+        /// <param name="allowNewGrab">whether a new click will begin grabbing</param>
+        /// <returns>whether the cursor is being grabbed</returns>
+        public bool TryGrabMouse(Window wnd, bool allowNewGrab)
         {
-            var isDown = wnd.MouseState.IsButtonDown(mouseButton);
-            var wasDown = wnd.MouseState.WasButtonDown(mouseButton);
+            var isDown = wnd.MouseState.IsButtonDown(MouseButton);
+            var wasDown = wnd.MouseState.WasButtonDown(MouseButton);
 
             if (!isDown)
             {
-                if (wasDown)
+                if (wasDown && _isGrabbed)
                 {
-                    // Released right click; unhide the cursor
+                    // Released click while cursor was being grabbed; unhide
+                    // the cursor
+                    _isGrabbed = false;
                     wnd.CursorVisible = true;
                     wnd.CursorGrabbed = false;
                 }
@@ -23,13 +38,17 @@ namespace Replanetizer.Utils
 
             if (!wasDown)
             {
-                // Began pressing right click; hide the cursor and allow it to
-                // move without any bounds
+                // Began pressing click
+                if (!allowNewGrab)
+                    return false;
+
+                // Hide the cursor and allow it to move without any bounds
+                _isGrabbed = true;
                 wnd.CursorVisible = false;
                 wnd.CursorGrabbed = true;
             }
 
-            return true;
+            return _isGrabbed;
         }
     }
 }

--- a/Replanetizer/Utils/MouseGrabHandler.cs
+++ b/Replanetizer/Utils/MouseGrabHandler.cs
@@ -1,0 +1,35 @@
+﻿using OpenTK.Windowing.GraphicsLibraryFramework;
+
+namespace Replanetizer.Utils
+{
+    public class MouseGrabHandler
+    {
+        /// <returns>whether the user is holding right click to rotate</returns>
+        public bool TryGrabMouse(Window wnd, MouseButton mouseButton)
+        {
+            var isDown = wnd.MouseState.IsButtonDown(mouseButton);
+            var wasDown = wnd.MouseState.WasButtonDown(mouseButton);
+
+            if (!isDown)
+            {
+                if (wasDown)
+                {
+                    // Released right click; unhide the cursor
+                    wnd.CursorVisible = true;
+                    wnd.CursorGrabbed = false;
+                }
+                return false;
+            }
+
+            if (!wasDown)
+            {
+                // Began pressing right click; hide the cursor and allow it to
+                // move without any bounds
+                wnd.CursorVisible = false;
+                wnd.CursorGrabbed = true;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
After I added the infinite drag feature in #21, I realized it messed with rotation in the model viewer (trying to rotate in the model viewer would also rotate the level). It now will check if the mouse is hovering directly over the level frame before allowing rotation. I also added similar rotation functionality to the model viewer.