### PR TITLE
Export Class IDs Lists

### DIFF
--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -146,21 +146,26 @@ namespace Replanetizer.Frames
                                 TextureIO.ExportAllTextures(level, res);
                             }
                         }
-                        if (ImGui.MenuItem("Moby class IDs list"))
+                        if (ImGui.BeginMenu("Class IDs lists"))
                         {
-                            var path = CrossFileDialog.SaveFile("mobyIDs.txt", ".txt");
-                            ExportListOfProperties<Moby>(path, level.mobs, (m) => { return m.modelID.ToString(); });
+                            if (ImGui.MenuItem("Mobies"))
+                            {
+                                var path = CrossFileDialog.SaveFile("mobyIDs.txt", ".txt");
+                                ExportListOfProperties<Moby>(path, level.mobs, (m) => { return m.modelID.ToString(); });
+                            }
+                            if (ImGui.MenuItem("Ties"))
+                            {
+                                var path = CrossFileDialog.SaveFile("tieIDs.txt", ".txt");
+                                ExportListOfProperties<Tie>(path, level.ties, (t) => { return t.modelID.ToString(); });
+                            }
+                            if (ImGui.MenuItem("Shrubs"))
+                            {
+                                var path = CrossFileDialog.SaveFile("shrubIDs.txt", ".txt");
+                                ExportListOfProperties<Shrub>(path, level.shrubs, (s) => { return s.modelID.ToString(); });
+                            }
+                            ImGui.EndMenu();
                         }
-                        if (ImGui.MenuItem("Tie class IDs list"))
-                        {
-                            var path = CrossFileDialog.SaveFile("tieIDs.txt", ".txt");
-                            ExportListOfProperties<Tie>(path, level.ties, (t) => { return t.modelID.ToString(); });
-                        }
-                        if (ImGui.MenuItem("Shrub class IDs list"))
-                        {
-                            var path = CrossFileDialog.SaveFile("shrubIDs.txt", ".txt");
-                            ExportListOfProperties<Shrub>(path, level.shrubs, (s) => { return s.modelID.ToString(); });
-                        }
+
                         ImGui.EndMenu();
                     }
                     if (ImGui.BeginMenu("Import"))

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -134,7 +134,7 @@ namespace Replanetizer.Frames
                                 fs.Close();
                             }
                         }
-                        if (ImGui.MenuItem("Level Model"))
+                        if (ImGui.MenuItem("Level as Model"))
                         {
                             subFrames.Add(new LevelExportFrame(this.wnd, this));
                         }


### PR DESCRIPTION
This adds buttons with which you can export a list of all class IDs present in a level for a certain object type. This was requested by people on Discord.

Note that the second commit contains some removal of trailing whitespaces and whitespaces after casts are made consistent there.

I will just merge, this PR just adds a small feature and does not interact with anything else.