### PR TITLE
Suggested changes by CreepNT

### DIFF
--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -265,7 +265,7 @@ namespace Replanetizer.Frames
             }
         }
 
-        private void RenderTextOverlay()
+        private void RenderTextOverlay(float deltaTime)
         {
             if (!enableCameraInfo) return;
 
@@ -308,6 +308,9 @@ namespace Replanetizer.Frames
                 ImGui.Text(
                     $"Rotation: (yaw: {camRotZ:F4}, pitch: {camRotX:F4})"
                 );
+                float fps = (int) (1.0f / deltaTime);
+                float frametime = ((float) ((int) (10000.0f * deltaTime))) / 10;
+                ImGui.Text("FPS: " + fps + " (" + frametime + " ms)");
             }
             ImGui.End();
         }
@@ -369,7 +372,7 @@ namespace Replanetizer.Frames
             if (level == null) return;
 
             RenderMenuBar();
-            RenderTextOverlay();
+            RenderTextOverlay(deltaTime);
             UpdateWindowSize();
             Tick(deltaTime);
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -25,6 +25,8 @@ namespace Replanetizer.Frames
     {
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
         protected override string frameName { get; set; } = "Level";
+
+        private FramebufferRenderer renderer, fakeRenderer;
         public Level level { get; set; }
 
         private List<TerrainFragment> terrains = new List<TerrainFragment>();
@@ -84,7 +86,6 @@ namespace Replanetizer.Frames
         private List<int> collisionIbo = new List<int>();
 
         private int Width, Height;
-        private int targetTexture;
 
         private List<Frame> subFrames;
         private List<Action<LevelObject>> selectionCallbacks;
@@ -95,6 +96,8 @@ namespace Replanetizer.Frames
             selectionCallbacks = new List<Action<LevelObject>>();
             bufferTable = new ConditionalWeakTable<IRenderable, BufferContainer>();
             camera = new Camera();
+            UpdateWindowSize();
+            OnResize();
         }
 
         public static bool FrameMustClose(Frame frame)
@@ -378,7 +381,7 @@ namespace Replanetizer.Frames
 
             if (invalidate)
             {
-                FramebufferRenderer.ToTexture(Width, Height, ref targetTexture, () =>
+                renderer.RenderToTexture(() =>
                 {
                     //Setup openGL variables
                     GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
@@ -388,11 +391,10 @@ namespace Replanetizer.Frames
 
                     OnPaint();
                 });
-
                 invalidate = false;
             }
-            ImGui.Image((IntPtr) targetTexture, new System.Numerics.Vector2(Width, Height),
-                System.Numerics.Vector2.UnitY, System.Numerics.Vector2.UnitX);
+            ImGui.Image((IntPtr) renderer.targetTexture, new System.Numerics.Vector2(Width, Height),
+                    System.Numerics.Vector2.UnitY, System.Numerics.Vector2.UnitX);
         }
 
         private void RenderSubFrames(float deltaTime)
@@ -837,9 +839,8 @@ namespace Replanetizer.Frames
             {
                 LevelObject obj = null;
                 Vector3 direction = Vector3.Zero;
-                int tempTextureId = 0;
 
-                FramebufferRenderer.ToTexture(Width, Height, ref tempTextureId, () =>
+                fakeRenderer.RenderToTexture(() =>
                 {
                     obj = GetObjectAtScreenPosition(mousePos);
                 });
@@ -1070,6 +1071,12 @@ namespace Replanetizer.Frames
             GL.Viewport(0, 0, Width, Height);
             projection = Matrix4.CreatePerspectiveFieldOfView((float) Math.PI / 3, (float) Width / Height, 0.1f, 10000.0f);
             view = camera.GetViewMatrix();
+
+            renderer?.Dispose();
+            renderer = new FramebufferRenderer(Width, Height);
+
+            fakeRenderer?.Dispose();
+            fakeRenderer = new FramebufferRenderer(Width, Height);
         }
 
         public LevelObject GetObjectAtScreenPosition(Vector2 pos)

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -19,7 +19,7 @@ namespace Replanetizer.Frames
         private LevelFrame levelFrame;
 
         private Dictionary<string, Dictionary<string, PropertyInfo>> properties;
-        
+
         public PropertyFrame(Window wnd, LevelFrame levelFrame = null, object selectedObject = null, string overrideFrameName = null, bool listenToCallbacks = false, bool hideCallbackButton = false) : base(wnd)
         {
             if (overrideFrameName != null && overrideFrameName.Length > 0)
@@ -59,15 +59,15 @@ namespace Replanetizer.Frames
             {
                 string category = prop.GetCustomAttribute<CategoryAttribute>()?.Category;
                 if (category == null) category = "Unknowns";
-                
+
                 string displayName = prop.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName;
                 if (displayName == null) displayName = prop.Name;
-                
+
                 if (!properties.ContainsKey(category))
                 {
                     properties[category] = new Dictionary<string, PropertyInfo>();
                 }
-                
+
                 properties[category][displayName] = prop;
             }
         }
@@ -105,10 +105,15 @@ namespace Replanetizer.Frames
                         var val = value.GetValue(selectedObject);
                         var type = value.PropertyType;
                         if (value.GetSetMethod() == null) type = null;
-                        if (type == typeof(string))
+
+                        if (val == null)
                         {
-                            var v = Encoding.ASCII.GetBytes((string)val ?? string.Empty);
-                            if (ImGui.InputText(key, v, (uint)v.Length))
+                            ImGui.LabelText(key, "null");
+                        }
+                        else if (type == typeof(string))
+                        {
+                            var v = Encoding.ASCII.GetBytes((string) val ?? string.Empty);
+                            if (ImGui.InputText(key, v, (uint) v.Length))
                             {
                                 value.SetValue(selectedObject, Encoding.ASCII.GetString(v));
                                 UpdateLevelFrame();
@@ -125,10 +130,10 @@ namespace Replanetizer.Frames
                         }
                         else if (type == typeof(uint))
                         {
-                            int v = unchecked((int)(uint)val);
+                            int v = unchecked((int) (uint) val);
                             if (ImGui.InputInt(key, ref v))
                             {
-                                value.SetValue(selectedObject, unchecked((uint)v));
+                                value.SetValue(selectedObject, unchecked((uint) v));
                                 UpdateLevelFrame();
                             }
                         }
@@ -137,16 +142,16 @@ namespace Replanetizer.Frames
                             int v = Convert.ToInt32(val);
                             if (ImGui.InputInt(key, ref v))
                             {
-                                value.SetValue(selectedObject, (short)(v & 0xffff));
+                                value.SetValue(selectedObject, (short) (v & 0xffff));
                                 UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(ushort))
                         {
-                            int v = unchecked((ushort)val);
+                            int v = unchecked((ushort) val);
                             if (ImGui.InputInt(key, ref v))
                             {
-                                value.SetValue(selectedObject, unchecked((ushort)(v & 0xffff)));
+                                value.SetValue(selectedObject, unchecked((ushort) (v & 0xffff)));
                                 UpdateLevelFrame();
                             }
                         }
@@ -161,18 +166,18 @@ namespace Replanetizer.Frames
                         }
                         else if (type == typeof(Color))
                         {
-                            Color c = (Color)val;
+                            Color c = (Color) val;
                             Vector3 v = new Vector3(c.R / 255.0f, c.G / 255.0f, c.B / 255.0f);
                             if (ImGui.ColorEdit3(key, ref v))
                             {
-                                Color newColor = Color.FromArgb((int)(v.X * 255.0f), (int)(v.Y * 255.0f), (int)(v.Z * 255.0f));
+                                Color newColor = Color.FromArgb((int) (v.X * 255.0f), (int) (v.Y * 255.0f), (int) (v.Z * 255.0f));
                                 value.SetValue(selectedObject, newColor);
                                 UpdateLevelFrame();
                             }
                         }
                         else if (type == typeof(OpenTK.Mathematics.Vector3))
                         {
-                            OpenTK.Mathematics.Vector3 origV = (OpenTK.Mathematics.Vector3)val;
+                            OpenTK.Mathematics.Vector3 origV = (OpenTK.Mathematics.Vector3) val;
                             Vector3 v = new Vector3(origV.X, origV.Y, origV.Z);
                             if (ImGui.InputFloat3(key, ref v))
                             {
@@ -183,7 +188,7 @@ namespace Replanetizer.Frames
 
                                 if (selectedObject is LevelObject)
                                 {
-                                    ((LevelObject)selectedObject).UpdateTransformMatrix();
+                                    ((LevelObject) selectedObject).UpdateTransformMatrix();
                                 }
 
                                 UpdateLevelFrame();
@@ -191,7 +196,7 @@ namespace Replanetizer.Frames
                         }
                         else if (type == typeof(OpenTK.Mathematics.Quaternion))
                         {
-                            OpenTK.Mathematics.Vector3 origRot = ((OpenTK.Mathematics.Quaternion)val).ToEulerAngles();
+                            OpenTK.Mathematics.Vector3 origRot = ((OpenTK.Mathematics.Quaternion) val).ToEulerAngles();
                             Vector3 v = new Vector3(origRot.X, origRot.Y, origRot.Z);
                             if (ImGui.InputFloat3(key, ref v))
                             {
@@ -202,7 +207,7 @@ namespace Replanetizer.Frames
 
                                 if (selectedObject is LevelObject)
                                 {
-                                    ((LevelObject)selectedObject).UpdateTransformMatrix();
+                                    ((LevelObject) selectedObject).UpdateTransformMatrix();
                                 }
 
                                 UpdateLevelFrame();
@@ -210,7 +215,7 @@ namespace Replanetizer.Frames
                         }
                         else if (type == typeof(OpenTK.Mathematics.Matrix4))
                         {
-                            OpenTK.Mathematics.Matrix4 mat = (OpenTK.Mathematics.Matrix4)val;
+                            OpenTK.Mathematics.Matrix4 mat = (OpenTK.Mathematics.Matrix4) val;
                             Vector4 v1 = new Vector4(mat.M11, mat.M12, mat.M13, mat.M14);
                             Vector4 v2 = new Vector4(mat.M21, mat.M22, mat.M23, mat.M24);
                             Vector4 v3 = new Vector4(mat.M31, mat.M32, mat.M33, mat.M34);
@@ -260,7 +265,7 @@ namespace Replanetizer.Frames
 
                                 if (selectedObject is LevelObject)
                                 {
-                                    ((LevelObject)selectedObject).UpdateTransformMatrix();
+                                    ((LevelObject) selectedObject).UpdateTransformMatrix();
                                 }
 
                                 UpdateLevelFrame();
@@ -270,9 +275,9 @@ namespace Replanetizer.Frames
                         {
                             if (ImGui.CollapsingHeader(key))
                             {
-                                Array array = (Array)val;
+                                Array array = (Array) val;
 
-                                foreach(object o in array)
+                                foreach (object o in array)
                                 {
                                     ImGui.Text(Convert.ToString(o));
                                 }
@@ -289,7 +294,7 @@ namespace Replanetizer.Frames
                                 strings[i] = Convert.ToString(values.GetValue(i));
                             }
 
-                            int index = (int)val;
+                            int index = (int) val;
 
                             if (index < values.Length)
                             {
@@ -298,7 +303,8 @@ namespace Replanetizer.Frames
                                     value.SetValue(selectedObject, index);
                                     UpdateLevelFrame();
                                 }
-                            } else
+                            }
+                            else
                             {
                                 ImGui.LabelText(key, "[Out of Range] " + Convert.ToString(index));
                             }

--- a/Replanetizer/Utils/FramebufferRenderer.cs
+++ b/Replanetizer/Utils/FramebufferRenderer.cs
@@ -3,15 +3,17 @@ using OpenTK.Graphics.OpenGL4;
 
 namespace Replanetizer.Utils
 {
-    public static class FramebufferRenderer
+    public class FramebufferRenderer : IDisposable
     {
-        public static void ToTexture(int width, int height, ref int targetTexture, Action renderFunction)
+        private bool disposed = false;
+
+        public int targetTexture { get; }
+        private int bufferTexture;
+        private int framebufferID;
+
+        public FramebufferRenderer(int width, int height)
         {
-            int bufferTexture, framebufferId;
-            
-            GL.DeleteTexture(targetTexture);
             targetTexture = GL.GenTexture();
-            
             GL.BindTexture(TextureTarget.Texture2D, targetTexture);
             GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgb, width, height, 0, PixelFormat.Rgb, PixelType.UnsignedByte, (IntPtr) 0);
             GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);
@@ -23,10 +25,15 @@ namespace Replanetizer.Utils
             GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);
             GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) TextureMagFilter.Nearest);
 
-            framebufferId = GL.GenFramebuffer();
-            GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferId);
+            framebufferID = GL.GenFramebuffer();
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferID);
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, targetTexture, 0);
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, TextureTarget.Texture2D, bufferTexture, 0);
+        }
+
+        public void RenderToTexture(Action renderFunction)
+        {
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferID);
 
             GL.Enable(EnableCap.DepthTest);
             GL.DepthFunc(DepthFunction.Less);
@@ -36,9 +43,31 @@ namespace Replanetizer.Utils
 
             renderFunction();
 
-            GL.DeleteFramebuffer(framebufferId);
-            GL.DeleteTexture(bufferTexture);
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+            GL.DeleteVertexArray(VAO);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                GL.DeleteFramebuffer(framebufferID);
+                GL.DeleteTexture(bufferTexture);
+                GL.DeleteTexture(targetTexture);
+            }
+
+            disposed = true;
         }
     }
 }


### PR DESCRIPTION
This implements some changes suggested by CreepNT.

- Fixes a crash when variables in PropertyFrame are null.
- Adds a framerate counter to the camera info overlay.
- Fixes framebuffers being allocated every frame which caused a heavy memory leak when pressing left click.

While the third fix improves performance when pressing left click, the GetObjectAtScreenPosition() function is still too costly and causes performance drops. However, this will be time consuming to fix.