### PR TITLE
Lights and Serialization Fixes.

### DIFF
--- a/LibReplanetizer/Level Objects/Engine/Light.cs
+++ b/LibReplanetizer/Level Objects/Engine/Light.cs
@@ -1,4 +1,5 @@
 ﻿using OpenTK.Mathematics;
+using System.ComponentModel;
 using static LibReplanetizer.DataFunctions;
 
 namespace LibReplanetizer.LevelObjects
@@ -12,10 +13,17 @@ namespace LibReplanetizer.LevelObjects
      */
     public class Light
     {
-        public Vector4 color1;
-        public Vector4 direction1;
-        public Vector4 color2;
-        public Vector4 direction2;
+        [Category("Attributes"), DisplayName("Color 1")]
+        public Vector4 color1 { get; set; }
+
+        [Category("Attributes"), DisplayName("Direction 1")]
+        public Vector4 direction1 { get; set; }
+
+        [Category("Attributes"), DisplayName("Color 2")]
+        public Vector4 color2 { get; set; }
+
+        [Category("Attributes"), DisplayName("Direction 2")]
+        public Vector4 direction2 { get; set; }
 
         public Light(byte[] block, int num)
         {

--- a/LibReplanetizer/Level Objects/Engine/Shrub.cs
+++ b/LibReplanetizer/Level Objects/Engine/Shrub.cs
@@ -104,6 +104,7 @@ namespace LibReplanetizer.LevelObjects
             bytes[0x63] = color.A;
             WriteUint(bytes, 0x64, off_64);
             WriteUshort(bytes, 0x68, light);
+            WriteUshort(bytes, 0x6A, 0xffff);
             WriteUint(bytes, 0x6C, off_6C);
 
             return bytes;

--- a/LibReplanetizer/Level Objects/Engine/Shrub.cs
+++ b/LibReplanetizer/Level Objects/Engine/Shrub.cs
@@ -27,8 +27,8 @@ namespace LibReplanetizer.LevelObjects
         public Color color { get; set; }
         [Category("Unknowns"), DisplayName("OFF_64: Always 0")]
         public uint off_64 { get; set; }
-        [Category("Unknowns"), DisplayName("OFF_68: Power of 2 minus 1")]
-        public uint off_68 { get; set; }
+        [Category("Attributes"), DisplayName("Light")]
+        public ushort light { get; set; }
         [Category("Unknowns"), DisplayName("OFF_6C: Always 0")]
         public uint off_6C { get; set; }
 
@@ -61,7 +61,7 @@ namespace LibReplanetizer.LevelObjects
             byte b = levelBlock[offset + 0x62];
             byte a = levelBlock[offset + 0x63];
             off_64 = ReadUint(levelBlock, offset + 0x64);
-            off_68 = ReadUint(levelBlock, offset + 0x68);
+            light = ReadUshort(levelBlock, offset + 0x68);
             off_6C = ReadUint(levelBlock, offset + 0x6C);
 
             model = shrubModels.Find(shrubModel => shrubModel.id == modelID);
@@ -83,7 +83,6 @@ namespace LibReplanetizer.LevelObjects
             {
                 attributes = Matrix4.Identity;
             }
-            
 
             reflection = modelMatrix * attributes;
         }
@@ -104,7 +103,7 @@ namespace LibReplanetizer.LevelObjects
             bytes[0x62] = color.B;
             bytes[0x63] = color.A;
             WriteUint(bytes, 0x64, off_64);
-            WriteUint(bytes, 0x68, off_68);
+            WriteUshort(bytes, 0x68, light);
             WriteUint(bytes, 0x6C, off_6C);
 
             return bytes;

--- a/LibReplanetizer/Level Objects/Engine/Tie.cs
+++ b/LibReplanetizer/Level Objects/Engine/Tie.cs
@@ -93,6 +93,7 @@ namespace LibReplanetizer.LevelObjects
             WriteInt(bytes, 0x60, colorOffset);
             WriteUint(bytes, 0x64, off_64);
             WriteUshort(bytes, 0x68, light);
+            WriteUshort(bytes, 0x6A, 0xffff);
             WriteUint(bytes, 0x6C, off_6C);
 
             return bytes;
@@ -113,6 +114,7 @@ namespace LibReplanetizer.LevelObjects
             WriteInt(bytes, 0x60, 0);
             WriteUint(bytes, 0x64, off_64);
             WriteUshort(bytes, 0x68, light);
+            WriteUshort(bytes, 0x6A, 0xffff);
             WriteUint(bytes, 0x6C, off_6C);
 
             return bytes;

--- a/LibReplanetizer/Level Objects/Engine/Tie.cs
+++ b/LibReplanetizer/Level Objects/Engine/Tie.cs
@@ -21,8 +21,8 @@ namespace LibReplanetizer.LevelObjects
 
         [Category("Unknowns"), DisplayName("OFF_64: Always 0")]
         public uint off_64 { get; set; }
-        [Category("Unknowns"), DisplayName("OFF_68: Power of 2 minus 1")]
-        public uint off_68 { get; set; }
+        [Category("Attributes"), DisplayName("Light")]
+        public ushort light { get; set; }
         [Category("Unknowns"), DisplayName("OFF_6C: Always 0")]
         public uint off_6C { get; set; }
 
@@ -53,7 +53,7 @@ namespace LibReplanetizer.LevelObjects
 
             int colorOffset = ReadInt(levelBlock, offset + 0x60);
             off_64 = ReadUint(levelBlock, offset + 0x64);
-            off_68 = ReadUint(levelBlock, offset + 0x68);
+            light = ReadUshort(levelBlock, offset + 0x68);
             off_6C = ReadUint(levelBlock, offset + 0x6C);
 
             model = tieModels.Find(tieModel => tieModel.id == modelID);
@@ -92,7 +92,7 @@ namespace LibReplanetizer.LevelObjects
 
             WriteInt(bytes, 0x60, colorOffset);
             WriteUint(bytes, 0x64, off_64);
-            WriteUint(bytes, 0x68, off_68);
+            WriteUshort(bytes, 0x68, light);
             WriteUint(bytes, 0x6C, off_6C);
 
             return bytes;
@@ -112,7 +112,7 @@ namespace LibReplanetizer.LevelObjects
 
             WriteInt(bytes, 0x60, 0);
             WriteUint(bytes, 0x64, off_64);
-            WriteUint(bytes, 0x68, off_68);
+            WriteUshort(bytes, 0x68, light);
             WriteUint(bytes, 0x6C, off_6C);
 
             return bytes;

--- a/LibReplanetizer/Models/ShrubModel.cs
+++ b/LibReplanetizer/Models/ShrubModel.cs
@@ -81,7 +81,7 @@ namespace LibReplanetizer.Models
 
             WriteUint(outBytes, 0x20, off_20);
             WriteInt(outBytes, 0x24, vertexBuffer.Length / 8);
-            WriteShort(outBytes, 0x28, (short)textureConfig.Count);
+            WriteShort(outBytes, 0x28, (short) textureConfig.Count);
             WriteShort(outBytes, 0x2A, off_2A);
             WriteUint(outBytes, 0x2C, off_2C);
 
@@ -96,7 +96,7 @@ namespace LibReplanetizer.Models
         public byte[] SerializeBody(int offStart)
         {
             int texturePointer = 0;
-            int hack = DistToFile80(offStart + texturePointer + textureConfig.Count * SHRUBTEXELEMSIZE);
+            int hack = DistToFile80(GetLength(offStart) + texturePointer + textureConfig.Count * SHRUBTEXELEMSIZE);
             int vertexPointer = GetLength(texturePointer + textureConfig.Count * SHRUBTEXELEMSIZE + hack); //+ 0x70
             int UVPointer = GetLength(vertexPointer + (vertexBuffer.Length / 8) * SHRUBVERTELEMSIZE);
             int indexPointer = GetLength(UVPointer + (vertexBuffer.Length / 8) * SHRUBUVELEMSIZE);

--- a/LibReplanetizer/Parsers/EngineParser.cs
+++ b/LibReplanetizer/Parsers/EngineParser.cs
@@ -117,13 +117,9 @@ namespace LibReplanetizer.Parsers
             {
                 if (engineHead.game.num == 1)
                 {
-                    byte[] headBlock = ReadBlock(fileStream, engineHead.collisionPointer, 8);
-                    int collisionStart = engineHead.collisionPointer + ReadInt(headBlock, 0);
-                    int collisionLength = ReadInt(headBlock, 4);
-                    int totalLength = collisionStart + collisionLength - engineHead.collisionPointer;
-
-                    return ReadArbBytes(engineHead.collisionPointer, totalLength);
-                } else
+                    return ReadBlock(fileStream, engineHead.collisionPointer, engineHead.mobyModelPointer - engineHead.collisionPointer);
+                }
+                else
                 {
                     return ReadBlock(fileStream, engineHead.collisionPointer, engineHead.tieModelPointer - engineHead.collisionPointer);
                 }

--- a/LibReplanetizer/Serializers/EngineSerializer.cs
+++ b/LibReplanetizer/Serializers/EngineSerializer.cs
@@ -32,7 +32,7 @@ namespace LibReplanetizer.Serializers
                     break;
             }
 
-            fs.Close();   
+            fs.Close();
         }
 
         private void SaveRC1(Level level, FileStream fs)
@@ -42,17 +42,17 @@ namespace LibReplanetizer.Serializers
             EngineHeader engineHeader = new EngineHeader
             {
                 game = level.game,
-                uiElementPointer = SeekWrite(fs, WriteUiElements(level.uiElements, (int)fs.Position)),
-                skyboxPointer = SeekWrite(fs, level.skybox.Serialize((int)fs.Position)),
-                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int)fs.Position, level.game)),
+                uiElementPointer = SeekWrite(fs, WriteUiElements(level.uiElements, (int) fs.Position)),
+                skyboxPointer = SeekWrite(fs, level.skybox.Serialize((int) fs.Position)),
+                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int) fs.Position, level.game)),
                 renderDefPointer = SeekWrite(fs, level.renderDefBytes),
                 collisionPointer = SeekWrite(fs, level.collBytesEngine),
-                mobyModelPointer = SeekWrite(fs, WriteMobies(level.mobyModels, (int)fs.Position)),
-                playerAnimationPointer = SeekWrite(fs, WritePlayerAnimations(level.playerAnimations, (int)fs.Position)),
-                gadgetPointer = SeekWrite(fs, WriteWeapons(level.gadgetModels, (int)fs.Position)),
-                tieModelPointer = SeekWrite(fs, WriteTieModels(level.tieModels, (int)fs.Position)),
-                tiePointer = SeekWrite(fs, WriteTies(level.ties, (int)fs.Position)),
-                shrubModelPointer = SeekWrite(fs, WriteShrubModels(level.shrubModels, (int)fs.Position)),
+                mobyModelPointer = SeekWrite(fs, WriteMobies(level.mobyModels, (int) fs.Position)),
+                playerAnimationPointer = SeekWrite(fs, WritePlayerAnimations(level.playerAnimations, (int) fs.Position)),
+                gadgetPointer = SeekWrite(fs, WriteWeapons(level.gadgetModels, (int) fs.Position)),
+                tieModelPointer = SeekWrite(fs, WriteTieModels(level.tieModels, (int) fs.Position)),
+                tiePointer = SeekWrite(fs, WriteTies(level.ties, (int) fs.Position)),
+                shrubModelPointer = SeekWrite(fs, WriteShrubModels(level.shrubModels, (int) fs.Position)),
                 shrubPointer = SeekWrite(fs, WriteShrubs(level.shrubs)),
                 textureConfigMenuPointer = SeekWrite(fs, WriteTextureConfigMenus(level.textureConfigMenus)),
                 texture2dPointer = SeekWrite(fs, level.billboardBytes),
@@ -84,20 +84,20 @@ namespace LibReplanetizer.Serializers
             EngineHeader engineHeader = new EngineHeader
             {
                 game = level.game,
-                uiElementPointer = SeekWrite(fs, WriteUiElements(level.uiElements, (int)fs.Position)),
-                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int)fs.Position, level.game)),
+                uiElementPointer = SeekWrite(fs, WriteUiElements(level.uiElements, (int) fs.Position)),
+                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int) fs.Position, level.game)),
                 renderDefPointer = SeekWrite(fs, level.renderDefBytes),
                 collisionPointer = SeekWrite(fs, level.collBytesEngine),
-                tieModelPointer = SeekWrite(fs, WriteTieModels(level.tieModels, (int)fs.Position)),
-                tiePointer = SeekWrite(fs, WriteTies(level.ties, (int)fs.Position)),
-                shrubModelPointer = SeekWrite(fs, WriteShrubModels(level.shrubModels, (int)fs.Position)),
+                tieModelPointer = SeekWrite(fs, WriteTieModels(level.tieModels, (int) fs.Position)),
+                tiePointer = SeekWrite(fs, WriteTies(level.ties, (int) fs.Position)),
+                shrubModelPointer = SeekWrite(fs, WriteShrubModels(level.shrubModels, (int) fs.Position)),
                 shrubPointer = SeekWrite(fs, WriteShrubs(level.shrubs)),
                 textureConfigMenuPointer = SeekWrite(fs, WriteTextureConfigMenus(level.textureConfigMenus)),
                 texture2dPointer = SeekWrite(fs, level.billboardBytes),
-                mobyModelPointer = SeekWrite(fs, WriteMobies(level.mobyModels, (int)fs.Position)),
+                mobyModelPointer = SeekWrite(fs, WriteMobies(level.mobyModels, (int) fs.Position)),
                 soundConfigPointer = SeekWrite(fs, level.soundConfigBytes),
-                playerAnimationPointer = SeekWrite(fs, WritePlayerAnimations(level.playerAnimations, (int)fs.Position)),
-                skyboxPointer = SeekWrite(fs, level.skybox.Serialize((int)fs.Position)),
+                playerAnimationPointer = SeekWrite(fs, WritePlayerAnimations(level.playerAnimations, (int) fs.Position)),
+                skyboxPointer = SeekWrite(fs, level.skybox.Serialize((int) fs.Position)),
                 lightPointer = SeekWrite(fs, WriteLights(level.lights)),
                 lightConfigPointer = SeekWrite(fs, WriteLightConfig(level.lightConfig)),
                 texturePointer = SeekWrite(fs, WriteTextures(level.textures)),
@@ -124,23 +124,23 @@ namespace LibReplanetizer.Serializers
             EngineHeader engineHeader = new EngineHeader
             {
                 game = level.game,
-                uiElementPointer = SeekWrite(fs, WriteUiElements(level.uiElements, (int)fs.Position)),
+                uiElementPointer = SeekWrite(fs, WriteUiElements(level.uiElements, (int) fs.Position)),
                 unk8Pointer = SeekWrite(fs, level.unk8),
-                mobyModelPointer = SeekWrite(fs, WriteMobies(level.mobyModels, (int)fs.Position)),
+                mobyModelPointer = SeekWrite(fs, WriteMobies(level.mobyModels, (int) fs.Position)),
                 soundConfigPointer = SeekWrite(fs, level.soundConfigBytes),
                 unk9Pointer = SeekWrite(fs, level.unk9),
-                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int)fs.Position, level.game)),
+                terrainPointer = SeekWrite(fs, WriteTfrags(level.terrainEngine, (int) fs.Position, level.game)),
                 renderDefPointer = SeekWrite(fs, level.renderDefBytes),
                 collisionPointer = SeekWrite(fs, level.collBytesEngine),
-                shrubModelPointer = SeekWrite(fs, WriteShrubModels(level.shrubModels, (int)fs.Position)),
+                shrubModelPointer = SeekWrite(fs, WriteShrubModels(level.shrubModels, (int) fs.Position)),
                 shrubPointer = SeekWrite(fs, WriteShrubs(level.shrubs)),
                 unk5Pointer = SeekWrite(fs, level.unk5),
-                tieModelPointer = SeekWrite(fs, WriteTieModels(level.tieModels, (int)fs.Position)),
-                tiePointer = SeekWrite(fs, WriteTies(level.ties, (int)fs.Position)),
+                tieModelPointer = SeekWrite(fs, WriteTieModels(level.tieModels, (int) fs.Position)),
+                tiePointer = SeekWrite(fs, WriteTies(level.ties, (int) fs.Position)),
                 unk4Pointer = SeekWrite(fs, level.unk4),
                 textureConfigMenuPointer = SeekWrite(fs, WriteTextureConfigMenus(level.textureConfigMenus)),
                 texture2dPointer = SeekWrite(fs, level.billboardBytes),
-                skyboxPointer = SeekWrite(fs, level.skybox.Serialize((int)fs.Position)),
+                skyboxPointer = SeekWrite(fs, level.skybox.Serialize((int) fs.Position)),
                 lightPointer = SeekWrite(fs, WriteLights(level.lights)),
                 lightConfigPointer = SeekWrite(fs, WriteLightConfig(level.lightConfig)),
                 unk3Pointer = SeekWrite(fs, level.unk3),
@@ -176,12 +176,12 @@ namespace LibReplanetizer.Serializers
             {
                 WriteShort(elemBytes, i * 8 + 0x00, uiElements[i].id);
                 if (uiElements[i].id == -1) continue;
-                WriteShort(elemBytes, i * 8 + 0x02, (short)uiElements[i].sprites.Count);
+                WriteShort(elemBytes, i * 8 + 0x02, (short) uiElements[i].sprites.Count);
                 WriteShort(elemBytes, i * 8 + 0x04, offset);
 
                 spriteIds.AddRange(uiElements[i].sprites);
 
-                offset += (short)uiElements[i].sprites.Count;
+                offset += (short) uiElements[i].sprites.Count;
             }
 
             var spriteBytes = new byte[spriteIds.Count * 4];
@@ -194,8 +194,8 @@ namespace LibReplanetizer.Serializers
             int spriteStart = GetLength(elemStart + elemBytes.Length);
 
             var headBytes = new byte[0x10];
-            WriteShort(headBytes, 0x00, (short)uiElements.Count);
-            WriteShort(headBytes, 0x02, (short)spriteIds.Count);
+            WriteShort(headBytes, 0x00, (short) uiElements.Count);
+            WriteShort(headBytes, 0x02, (short) spriteIds.Count);
             WriteInt(headBytes, 0x04, elemStart);
             WriteInt(headBytes, 0x08, spriteStart);
 
@@ -219,7 +219,7 @@ namespace LibReplanetizer.Serializers
             {
                 WriteInt(headBytes, 4 + i * 8, mobyModels[i].id);
 
-                MobyModel g = (MobyModel)mobyModels[i];
+                MobyModel g = (MobyModel) mobyModels[i];
                 if (!g.isModel)
                     continue;
 
@@ -249,7 +249,7 @@ namespace LibReplanetizer.Serializers
             {
                 WriteInt(headBytes, i * 0x10, weaponModels[i].id);
 
-                MobyModel g = (MobyModel)weaponModels[i];
+                MobyModel g = (MobyModel) weaponModels[i];
                 if (!g.isModel)
                     continue;
 
@@ -271,13 +271,14 @@ namespace LibReplanetizer.Serializers
         private byte[] WriteTies(List<Tie> ties, int offset)
         {
             offset += ties.Count * 0x70;
+            int hack = DistToFile80(offset);
 
             var headBytes = new byte[ties.Count * 0x70];
             var colorBytes = new List<byte>();
 
             for (int i = 0; i < ties.Count; i++)
             {
-                ties[i].ToByteArray(offset + colorBytes.Count).CopyTo(headBytes, i * 0x70);
+                ties[i].ToByteArray(offset + hack + colorBytes.Count).CopyTo(headBytes, i * 0x70);
                 byte[] colByte = ties[i].colorBytes;
                 colorBytes.AddRange(colByte);
 
@@ -291,7 +292,6 @@ namespace LibReplanetizer.Serializers
 
             }
 
-            int hack = DistToFile80(offset);
             var outBytes = new byte[headBytes.Length + hack + colorBytes.Count];
             headBytes.CopyTo(outBytes, 0);
             colorBytes.CopyTo(outBytes, headBytes.Length + hack);
@@ -341,7 +341,7 @@ namespace LibReplanetizer.Serializers
 
             for (int i = 0; i < tiemodels.Count; i++)
             {
-                TieModel g = (TieModel)tiemodels[i];
+                TieModel g = (TieModel) tiemodels[i];
                 byte[] tieByte = g.SerializeHead(offset);
                 byte[] bodBytes = g.SerializeBody(offset);
                 bodyBytes.AddRange(bodBytes);
@@ -365,7 +365,7 @@ namespace LibReplanetizer.Serializers
 
             for (int i = 0; i < shrubmodels.Count; i++)
             {
-                ShrubModel g = (ShrubModel)shrubmodels[i];
+                ShrubModel g = (ShrubModel) shrubmodels[i];
                 byte[] tieByte = g.SerializeHead(offset);
                 byte[] bodBytes = g.SerializeBody(offset);
                 bodyBytes.AddRange(bodBytes);

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -206,9 +206,9 @@ namespace Replanetizer.Frames
                     {
                         subFrames.Add(new TextureFrame(this.wnd, this));
                     }
-                    if (ImGui.MenuItem("Light config"))
+                    if (ImGui.MenuItem("Lights"))
                     {
-                        subFrames.Add(new PropertyFrame(this.wnd, this, level.lightConfig, "Light config"));
+                        subFrames.Add(new LightsFrame(this.wnd, this, level.lights, level.lightConfig));
                     }
                     if (ImGui.MenuItem("Level variables"))
                     {

--- a/Replanetizer/Frames/LightsFrame.cs
+++ b/Replanetizer/Frames/LightsFrame.cs
@@ -1,0 +1,168 @@
+﻿using ImGuiNET;
+using LibReplanetizer.LevelObjects;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Numerics;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Replanetizer.Frames
+{
+    public class LightsFrame : Frame
+    {
+        protected sealed override string frameName { get; set; } = "Lights";
+        private List<Light> lights;
+        private LightConfig lightConfig;
+        private LevelFrame levelFrame;
+
+        private Dictionary<string, Dictionary<string, PropertyInfo>> configProperties;
+        private List<Tuple<Light, Dictionary<string, Dictionary<string, PropertyInfo>>>> lightsProperties;
+
+        public LightsFrame(Window wnd, LevelFrame levelFrame, List<Light> lights, LightConfig lightConfig) : base(wnd)
+        {
+            this.levelFrame = levelFrame;
+            this.lights = lights;
+            this.lightConfig = lightConfig;
+
+            lightsProperties = new List<Tuple<Light, Dictionary<string, Dictionary<string, PropertyInfo>>>>();
+
+            recomputeProperties();
+        }
+
+        private Dictionary<string, Dictionary<string, PropertyInfo>> recomputeSinglePropertiesSet(object o)
+        {
+            Dictionary<string, Dictionary<string, PropertyInfo>>  properties = new Dictionary<string, Dictionary<string, PropertyInfo>>();
+            var objProps = o.GetType().GetProperties();
+            foreach (var prop in objProps)
+            {
+                string category = prop.GetCustomAttribute<CategoryAttribute>()?.Category;
+                if (category == null) category = "Unknowns";
+
+                string displayName = prop.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName;
+                if (displayName == null) displayName = prop.Name;
+
+                if (!properties.ContainsKey(category))
+                {
+                    properties[category] = new Dictionary<string, PropertyInfo>();
+                }
+
+                properties[category][displayName] = prop;
+            }
+
+            return properties;
+        }
+
+        private void recomputeProperties()
+        {
+            configProperties = recomputeSinglePropertiesSet(lightConfig);
+
+            foreach (Light light in lights)
+            {
+                lightsProperties.Add(new Tuple<Light, Dictionary<string, Dictionary<string, PropertyInfo>>>(light, recomputeSinglePropertiesSet(light)));
+            }
+        }
+
+        private void UpdateLevelFrame()
+        {
+            if (levelFrame != null) levelFrame.InvalidateView();
+        }
+
+        public override void Render(float deltaTime)
+        {
+            if (ImGui.CollapsingHeader("Light Config"))
+            {
+                foreach (var categoryPair in configProperties)
+                {
+                    foreach (var (key, value) in categoryPair.Value)
+                    {
+                        float v = (float)value.GetValue(lightConfig);
+                        if (ImGui.InputFloat(key, ref v))
+                        {
+                            value.SetValue(lightConfig, v);
+                            UpdateLevelFrame();
+                        }
+                    }
+                }
+            }
+            
+            if (ImGui.CollapsingHeader("Lights"))
+            {
+                for (int i = 0; i < lightsProperties.Count; i++)
+                {
+                    var t = lightsProperties[i];
+
+                    if (ImGui.TreeNode("Light " + i))
+                    {
+                        foreach (var categoryPair in t.Item2)
+                        {
+                            var value1 = categoryPair.Value["Color 1"];
+                            OpenTK.Mathematics.Vector4 v1 = (OpenTK.Mathematics.Vector4)value1.GetValue(t.Item1);
+
+                            Vector3 color1 = new Vector3(v1.X, v1.Y, v1.Z);
+
+                            if (ImGui.ColorEdit3("Color 1", ref color1))
+                            {
+                                v1.X = color1.X;
+                                v1.Y = color1.Y;
+                                v1.Z = color1.Z;
+
+                                value1.SetValue(t.Item1, v1);
+                                UpdateLevelFrame();
+                            }
+
+                            var value2 = categoryPair.Value["Direction 1"];
+                            OpenTK.Mathematics.Vector4 v2 = (OpenTK.Mathematics.Vector4)value2.GetValue(t.Item1);
+
+                            Vector3 dir1 = new Vector3(v2.X, v2.Y, v2.Z);
+
+                            if (ImGui.SliderFloat3("Direction 1", ref dir1, -1.0f, 1.0f))
+                            {
+                                v2.X = dir1.X;
+                                v2.Y = dir1.Y;
+                                v2.Z = dir1.Z;
+
+                                value2.SetValue(t.Item1, v2);
+                                UpdateLevelFrame();
+                            }
+
+                            var value3 = categoryPair.Value["Color 2"];
+                            OpenTK.Mathematics.Vector4 v3 = (OpenTK.Mathematics.Vector4)value3.GetValue(t.Item1);
+
+                            Vector3 color2 = new Vector3(v3.X, v3.Y, v3.Z);
+
+                            if (ImGui.ColorEdit3("Color 2", ref color2))
+                            {
+                                v3.X = color2.X;
+                                v3.Y = color2.Y;
+                                v3.Z = color2.Z;
+
+                                value3.SetValue(t.Item1, v3);
+                                UpdateLevelFrame();
+                            }
+
+                            var value4 = categoryPair.Value["Direction 2"];
+                            OpenTK.Mathematics.Vector4 v4 = (OpenTK.Mathematics.Vector4)value4.GetValue(t.Item1);
+
+                            Vector3 dir2 = new Vector3(v4.X, v4.Y, v4.Z);
+
+                            if (ImGui.SliderFloat3("Direction 2", ref dir2, -1.0f, 1.0f))
+                            {
+                                v4.X = dir2.X;
+                                v4.Y = dir2.Y;
+                                v4.Z = dir2.Z;
+
+                                value4.SetValue(t.Item1, v4);
+                                UpdateLevelFrame();
+                            }
+                        }
+
+                        ImGui.TreePop();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This replaces the light config frame with a lights frame. The lights frame additionally allows to modify all directional lights.

- Named directional light index variables in ties and shrubs.
- Fixed serialization of engine collision, shrubs and ties.

As far as I can tell, the engine file for RaC 1 should now get serialized 100% accurately.
