### PR TITLE
Fix normals in export

### DIFF
--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -512,7 +512,7 @@ namespace LibReplanetizer
             if (settings.exportMTLFile) MTLfs.Dispose();
         }
 
-        private static int SeparateModelObjectByMaterial(ModelObject t, List<Tuple<int, int, int>>[] faces, List<Vector3> vertices, List<Vector3> normals, List<Vector2> uvs, int faceOffset)
+        private static int SeparateModelObjectByMaterial(ModelObject t, List<Tuple<int, int, int>>[] faces, List<Vector3> vertices, List<Vector2> uvs, int faceOffset)
         {
             Model model = t.model;
 
@@ -540,7 +540,6 @@ namespace LibReplanetizer
                     model.vertexBuffer[(x * 0x08) + 0x5],
                     1.0f);
                 normal *= matrixOnlyRot;
-                normals.Add(normal.Xyz);
                 thisNormals[x] = normal.Xyz;
 
                 uvs.Add(new Vector2(
@@ -602,11 +601,11 @@ namespace LibReplanetizer
             }
 
             List<Vector3> vertices = new List<Vector3>();
-            List<Vector3> normals = new List<Vector3>();
             List<Vector2> uvs = new List<Vector2>();
 
             int faceOffset = 0;
 
+            List<Vector3> terrainNormals = new List<Vector3>();
             foreach (TerrainFragment t in terrain)
             {
                 Model model = t.model;
@@ -620,7 +619,7 @@ namespace LibReplanetizer
                         model.vertexBuffer[(x * 0x08) + 0x1],
                         model.vertexBuffer[(x * 0x08) + 0x2]));
 
-                    normals.Add(new Vector3(
+                    terrainNormals.Add(new Vector3(
                         model.vertexBuffer[(x * 0x08) + 0x3],
                         model.vertexBuffer[(x * 0x08) + 0x4],
                         model.vertexBuffer[(x * 0x08) + 0x5]));
@@ -655,7 +654,7 @@ namespace LibReplanetizer
                     var v2 = model.indexBuffer[triIndex + 1];
                     var v3 = model.indexBuffer[triIndex + 2];
 
-                    if (shouldReverseWinding(vertices, normals, v1, v2, v3))
+                    if (shouldReverseWinding(vertices, terrainNormals, v1, v2, v3))
                         (v2, v3) = (v3, v2);
 
                     faces[materialID].Add(new Tuple<int, int, int>(
@@ -671,7 +670,7 @@ namespace LibReplanetizer
             {
                 foreach (Tie t in level.ties)
                 {
-                    faceOffset += SeparateModelObjectByMaterial(t, faces, vertices, normals, uvs, faceOffset);
+                    faceOffset += SeparateModelObjectByMaterial(t, faces, vertices, uvs, faceOffset);
                 }
             }
 
@@ -679,7 +678,7 @@ namespace LibReplanetizer
             {
                 foreach (Shrub t in level.shrubs)
                 {
-                    faceOffset += SeparateModelObjectByMaterial(t, faces, vertices, normals, uvs, faceOffset);
+                    faceOffset += SeparateModelObjectByMaterial(t, faces, vertices, uvs, faceOffset);
                 }
             }
 
@@ -687,7 +686,7 @@ namespace LibReplanetizer
             {
                 foreach (Moby t in level.mobs)
                 {
-                    faceOffset += SeparateModelObjectByMaterial(t, faces, vertices, normals, uvs, faceOffset);
+                    faceOffset += SeparateModelObjectByMaterial(t, faces, vertices, uvs, faceOffset);
                 }
             }
 
@@ -712,11 +711,6 @@ namespace LibReplanetizer
                 foreach (Vector3 v in vertices)
                 {
                     OBJfs.WriteLine($"v {v.X:F6} {v.Y:F6} {v.Z:F6}");
-                }
-
-                foreach (Vector3 vn in normals)
-                {
-                    OBJfs.WriteLine($"v {vn.X:F6} {vn.Y:F6} {vn.Z:F6}");
                 }
 
                 foreach (Vector2 vt in uvs)

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -13,23 +13,27 @@ namespace LibReplanetizer
     {
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
+        private static void writeObjectMaterial(StreamWriter MTLfs, string id)
+        {
+            MTLfs.WriteLine($"newmtl mtl_{id}");
+            MTLfs.WriteLine("Ns 1000");
+            MTLfs.WriteLine("Ka 1.000000 1.000000 1.000000");
+            MTLfs.WriteLine("Kd 1.000000 1.000000 1.000000");
+            MTLfs.WriteLine("Ni 1.000000");
+            MTLfs.WriteLine("d 1.000000");
+            MTLfs.WriteLine("illum 1");
+            MTLfs.WriteLine($"map_Kd {id}.png");
+        }
+
         private static void writeObjectMaterial(StreamWriter MTLfs, Model model, List<int> usedMtls)
         {
             for (int i = 0; i < model.textureConfig.Count; i++)
             {
                 int modelTextureID = model.textureConfig[i].ID;
-                if (!usedMtls.Contains(modelTextureID))
-                {
-                    MTLfs.WriteLine("newmtl mtl_" + modelTextureID);
-                    MTLfs.WriteLine("Ns 1000");
-                    MTLfs.WriteLine("Ka 1.000000 1.000000 1.000000");
-                    MTLfs.WriteLine("Kd 1.000000 1.000000 1.000000");
-                    MTLfs.WriteLine("Ni 1.000000");
-                    MTLfs.WriteLine("d 1.000000");
-                    MTLfs.WriteLine("illum 1");
-                    MTLfs.WriteLine("map_Kd " + modelTextureID + ".png");
-                    usedMtls.Add(modelTextureID);
-                }
+                if (usedMtls.Contains(modelTextureID))
+                    continue;
+                writeObjectMaterial(MTLfs, modelTextureID.ToString());
+                usedMtls.Add(modelTextureID);
             }
         }
 

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -226,8 +226,7 @@ namespace LibReplanetizer
 
                 // Faces
                 int textureNum = 0;
-                var lastVn = 0;
-                var windingOrder = false;
+                HashSet<(int, int)> visitedEdges = new();
                 for (int i = 0; i < model.indexBuffer.Length / 3; i++)
                 {
                     int triIndex = i * 3;
@@ -246,14 +245,19 @@ namespace LibReplanetizer
                     int vt = indexToUVs[i] + 1;
                     int vn = indexToNormals[i] + 1;
 
-                    // Flip the winding order if the vertex normals didn't change
-                    windingOrder = (vn == lastVn) ? !windingOrder : false;
+                    if (visitedEdges.Contains((v1, v2)) ||
+                        visitedEdges.Contains((v2, v3)) ||
+                        visitedEdges.Contains((v3, v1)))
+                    {
+                        (v2, v3) = (v3, v2);
+                    }
+
                     OBJfs.WriteLine(
-                        windingOrder
-                        ? $"f {v1}/{vt}/{vn} {v3}/{vt}/{vn} {v2}/{vt}/{vn}"
-                        : $"f {v1}/{vt}/{vn} {v2}/{vt}/{vn} {v3}/{vt}/{vn}"
+                        $"f {v1}/{vt}/{vn} {v3}/{vt}/{vn} {v2}/{vt}/{vn}"
                     );
-                    lastVn = vn;
+                    visitedEdges.Add((v1, v2));
+                    visitedEdges.Add((v2, v3));
+                    visitedEdges.Add((v3, v1));
                 }
             }
 

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -218,6 +218,8 @@ namespace LibReplanetizer
 
                 // Faces
                 int textureNum = 0;
+                var lastVn = 0;
+                var windingOrder = false;
                 for (int i = 0; i < model.indexBuffer.Length / 3; i++)
                 {
                     int triIndex = i * 3;
@@ -236,9 +238,14 @@ namespace LibReplanetizer
                     int vt = indexToUVs[i] + 1;
                     int vn = indexToNormals[i] + 1;
 
+                    // Flip the winding order if the vertex normals didn't change
+                    windingOrder = (vn == lastVn) ? !windingOrder : false;
                     OBJfs.WriteLine(
-                        $"f {v1}/{vt}/{vn} {v2}/{vt}/{vn} {v3}/{vt}/{vn}"
+                        windingOrder
+                        ? $"f {v1}/{vt}/{vn} {v3}/{vt}/{vn} {v2}/{vt}/{vn}"
+                        : $"f {v1}/{vt}/{vn} {v2}/{vt}/{vn} {v3}/{vt}/{vn}"
                     );
+                    lastVn = vn;
                 }
             }
 

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -651,10 +651,17 @@ namespace LibReplanetizer
                         materialID = 0;
                     }
 
+                    var v1 = model.indexBuffer[triIndex + 0];
+                    var v2 = model.indexBuffer[triIndex + 1];
+                    var v3 = model.indexBuffer[triIndex + 2];
+
+                    if (shouldReverseWinding(vertices, normals, v1, v2, v3))
+                        (v2, v3) = (v3, v2);
+
                     faces[materialID].Add(new Tuple<int, int, int>(
-                        model.indexBuffer[triIndex + 0] + 1 + faceOffset,
-                        model.indexBuffer[triIndex + 1] + 1 + faceOffset,
-                        model.indexBuffer[triIndex + 2] + 1 + faceOffset));
+                        v1 + 1 + faceOffset,
+                        v2 + 1 + faceOffset,
+                        v3 + 1 + faceOffset));
                 }
 
                 faceOffset += vertexCount;

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -242,7 +242,7 @@ namespace LibReplanetizer
                     var vt2 = indexToUVs[v2] + 1;
                     var vt3 = indexToUVs[v3] + 1;
 
-                    if (shouldReverseWinding(vertices, v1, v2, v3, normals[v1]))
+                    if (shouldReverseWinding(vertices, normals, v1, v2, v3))
                         (v2, v3) = (v3, v2);
 
                     OBJfs.WriteLine(
@@ -252,18 +252,33 @@ namespace LibReplanetizer
             }
         }
 
-        /// <returns>whether the face normal is facing the vertex normal</returns>
+        /// <summary>
+        /// Average a tri's vertex normals to get the target face normal, then
+        /// check whether the current winding order yields a normal facing
+        /// the target face normal
+        /// </summary>
+        /// <returns>whether to reverse the winding order</returns>
         private static bool shouldReverseWinding(
-            Vector3[] vertices, int v1Idx, int v2Idx, int v3Idx, Vector3 normal)
+            Vector3[] vertices, Vector3[] vertexNormals, int v1, int v2, int v3)
         {
-            var p1 = vertices[v1Idx];
-            var p2 = vertices[v2Idx];
-            var p3 = vertices[v3Idx];
+            var targetFaceNormal = faceNormalFromVertexNormals(vertexNormals, v1, v2, v3);
+            var p1 = vertices[v1];
+            var p2 = vertices[v2];
+            var p3 = vertices[v3];
             p2 -= p1;
             p3 -= p1;
             var faceNormal = Vector3.Cross(p2, p3);
-            var dot = Vector3.Dot(faceNormal, normal);
+            var dot = Vector3.Dot(faceNormal, targetFaceNormal);
             return dot < 0f;
+        }
+
+        private static Vector3 faceNormalFromVertexNormals(
+            Vector3[] normals, int v1, int v2, int v3)
+        {
+            var n1 = normals[v1];
+            var n2 = normals[v2];
+            var n3 = normals[v3];
+            return (n1 + n2 + n3) / 3;
         }
 
         private static void writeObjectMaterial(StreamWriter MTLfs, Model model, List<int> usedMtls)


### PR DESCRIPTION
Nooga in the discord mentioned that the normals in the batch level exports were still broken. This pull request fixes normals in single and (almost all) batch exports. The only problem is that at the moment I can't get WriteObjMaterialwise to work. I'm using my winding-order helper function `shouldReverseWinding` just like everywhere else, but it's still exporting weirdly.

I started working on this before seeing your work on this same problem, and since I already know my version really well I just continued with the batch fix. Feel free to ignore this if you'd rather keep your changes! The main idea is the normals were not rotated by the object matrices in the batch export, so that's what I did here (starting at e0d8cbe) in addition to my earlier changes.