### PR TITLE
MSAA support

### DIFF
--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -405,7 +405,7 @@ namespace Replanetizer.Frames
                 });
                 invalidate = false;
             }
-            ImGui.Image((IntPtr) renderer.targetTexture, new System.Numerics.Vector2(Width, Height),
+            ImGui.Image((IntPtr) renderer.outputTexture, new System.Numerics.Vector2(Width, Height),
                     System.Numerics.Vector2.UnitY, System.Numerics.Vector2.UnitX);
         }
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -51,6 +51,10 @@ namespace Replanetizer.Frames
         private int currentSplineVertex;
         public LevelObject selectedObject;
 
+        private int antialiasing = 1;
+        private string[] antialiasing_options = { "Off", "2x MSAA", "4x MSAA", "8x MSAA", "16x MSAA", "32x MSAA", "64x MSAA", "128x MSAA", "256x MSAA", "512x MSAA" };
+        private int max_antialiasing = 4;
+
         private Vector2 mousePos;
         private Vector3 prevMouseRay;
         private Rectangle contentRegion;
@@ -93,6 +97,9 @@ namespace Replanetizer.Frames
             selectionCallbacks = new List<Action<LevelObject>>();
             bufferTable = new ConditionalWeakTable<IRenderable, BufferContainer>();
             camera = new Camera();
+
+            max_antialiasing = (int) Math.Log2((double) GL.GetInteger(GetPName.MaxSamples));
+
             UpdateWindowSize();
             OnResize();
         }
@@ -227,6 +234,13 @@ namespace Replanetizer.Frames
                     if (ImGui.Checkbox("Distance Culling", ref enableDistanceCulling)) InvalidateView();
                     if (ImGui.Checkbox("Frustum Culling", ref enableFrustumCulling)) InvalidateView();
                     if (ImGui.Checkbox("Fog", ref enableFog)) InvalidateView();
+                    ImGui.PushItemWidth(90.0f);
+                    if (ImGui.Combo("Antialiasing", ref antialiasing, antialiasing_options, 1 + max_antialiasing))
+                    {
+                        UpdateAALevel();
+                        InvalidateView();
+                    }
+                    ImGui.PopItemWidth();
                     ImGui.Separator();
                     ImGui.Checkbox("Camera Info", ref enableCameraInfo);
 
@@ -1040,6 +1054,16 @@ namespace Replanetizer.Frames
             Logger.Debug("Compiled shader from {0}, log: {1}", filename, GL.GetShaderInfoLog(address));
         }
 
+        private void UpdateAALevel()
+        {
+            if (antialiasing == 0)
+                GL.Disable(EnableCap.Multisample);
+            else
+                GL.Enable(EnableCap.Multisample);
+
+            FramebufferRenderer.MSAA_LEVEL = 1 << antialiasing;
+        }
+
         protected void OnResize()
         {
             if (!initialized) return;
@@ -1049,6 +1073,7 @@ namespace Replanetizer.Frames
 
             renderer?.Dispose();
             renderer = new FramebufferRenderer(Width, Height);
+            UpdateAALevel();
         }
 
         public LevelObject GetObjectAtScreenPosition(Vector2 pos)

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -165,7 +165,7 @@ namespace Replanetizer.Frames
                 });
                 invalidate = false;
             }
-            ImGui.Image((IntPtr) renderer.targetTexture, new System.Numerics.Vector2(Width, Height),
+            ImGui.Image((IntPtr) renderer.outputTexture, new System.Numerics.Vector2(Width, Height),
                 System.Numerics.Vector2.UnitY, System.Numerics.Vector2.UnitX);
 
             ImGui.NextColumn();

--- a/Replanetizer/Shaders/fs.glsl
+++ b/Replanetizer/Shaders/fs.glsl
@@ -2,8 +2,8 @@
 
 // Interpolated values from the vertex shaders
 in vec2 UV;
-in vec4 DiffuseColor;
-in vec4 BakedColor;
+in vec3 lightColor;
+in float fogBlend;
 
 // Ouput data
 layout (location = 0) out vec4 color;
@@ -11,32 +11,9 @@ layout (location = 1) out int id;
 
 // Values that stay constant for the whole mesh.
 uniform sampler2D myTextureSampler;
-uniform int useFog;
-uniform vec4 fogColor;
-uniform float fogNearDistance;
-uniform float fogFarDistance;
-uniform float fogNearIntensity;
-uniform float fogFarIntensity;
 uniform int levelObjectType;
 uniform int levelObjectNumber;
-uniform vec4 staticColor;
-
-float get_depth() {
-    float ndcDepth = (2.0 * gl_FragCoord.z - gl_DepthRange.near - gl_DepthRange.far) /
-        (gl_DepthRange.far - gl_DepthRange.near);
-    float clipDepth = ndcDepth / gl_FragCoord.w;
-    return (clipDepth * 0.5f) + 0.5f;
-}
-
-/*
- * Degree 2 Taylor Expansion of exp function
- * Closest to what is used in the game that I could figure out
- */
-float quick_exp(float x) {
-    float y = x * x;
-    float z = y * x;
-    return 1.0f + x + 0.5f * y + 0.1666f * z;
-}
+uniform vec4 fogColor;
 
 /*
  * We use one shader for all shading types.
@@ -45,53 +22,25 @@ float quick_exp(float x) {
  * Ties (3): Colorbytes + DiffuseColor
  * Mobies (4): StaticColor + DiffuseColor
  *
- * Weights of all these colors and the fog are probably not exact atm.
- *
  * Some Notes about the rendering in the game:
  * - Ratchets helmet treats light in the opposite direction, i.e.
  *   if a directional light points up, it will be treated as if it was pointing down.
  * - Ratchets helmet and the ship seem to be the only objects that
  *   have specular highlights.
- * - Terrain stores the information about which directional light is used on a per vertex
- *   basis. Replanetizer uses the light specified by the first vertex as in most cases all
- *   vertices have the same light and because the shaders are not capable of switching
- *   lights for each vertex.
  * - Fog seems to be twice as bright for ties.
+ * - Terrain does not use alpha cutoff.
+ * - In RaC 3, ties do not use alpha cutoff. Replanetizer uses the RaC 1 and 2 behaviour.
  */
 void main(){
     //color of the texture at the specified UV
     vec4 textureColor = texture(myTextureSampler, UV);
 
-    if (textureColor.w < 0.1f) discard;
+    if (textureColor.w < 0.1f && levelObjectType >= 2) discard;
 
-    vec4 ambient = vec4(1.0f);
-
-    if (levelObjectType == 2 || levelObjectType == 4) {
-        ambient = staticColor;
-    } else if (levelObjectType == 1 || levelObjectType == 3) {
-        ambient = BakedColor;
-    }
-
-    vec4 diffuse = vec4(0.0f);
-
-    if (levelObjectType >= 1 && levelObjectType <= 4) {
-        diffuse = DiffuseColor;
-    }
-
-    color.xyz = textureColor.xyz * (diffuse.xyz + ambient.xyz);
+    color.xyz = textureColor.xyz * lightColor;
     color.w = textureColor.w;
 
-    if (useFog == 1) {
-        float depth = clamp((fogFarDistance - quick_exp(get_depth())) / (fogFarDistance - fogNearDistance), 0.0f, 1.0f);
-
-        float intensity = clamp(depth * fogNearIntensity + (1.0f - depth) * fogFarIntensity, 0.0f, 1.0f);
-
-        if (levelObjectType == 3) {
-            color.xyz = mix(2.0f * fogColor.xyz, color.xyz, intensity);
-        } else {
-            color.xyz = mix(fogColor.xyz, color.xyz, intensity);
-        }
-    }
+    color.xyz = mix(color.xyz, fogColor.xyz, fogBlend);
 
     id = (levelObjectType << 24) | levelObjectNumber;
 }

--- a/Replanetizer/Utils/FramebufferRenderer.cs
+++ b/Replanetizer/Utils/FramebufferRenderer.cs
@@ -7,41 +7,61 @@ namespace Replanetizer.Utils
     {
         private bool disposed = false;
 
-        public int targetTexture { get; }
-        public int idTexture { get; }
-        private int bufferTexture;
+        private int targetTexture;
+        private int typeTexture;
+        public int outputTexture { get; }
+        public int outputTypeTexture { get; }
         private int framebufferID;
+        private int renderbufferID;
+        private int outputFramebufferID;
+
+        private int width, height;
 
         public FramebufferRenderer(int width, int height)
         {
+            this.width = width;
+            this.height = height;
+
             targetTexture = GL.GenTexture();
-            GL.BindTexture(TextureTarget.Texture2D, targetTexture);
-            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgb, width, height, 0, PixelFormat.Rgb, PixelType.UnsignedByte, (IntPtr) 0);
-            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);
-            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) TextureMagFilter.Nearest);
+            GL.BindTexture(TextureTarget.Texture2DMultisample, targetTexture);
+            GL.TexImage2DMultisample(TextureTargetMultisample.Texture2DMultisample, 16, PixelInternalFormat.Rgb, width, height, true);
 
-            bufferTexture = GL.GenTexture();
-            GL.BindTexture(TextureTarget.Texture2D, bufferTexture);
-            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.DepthComponent, width, height, 0, PixelFormat.DepthComponent, PixelType.Float, (IntPtr) 0);
-            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);
-            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) TextureMagFilter.Nearest);
+            renderbufferID = GL.GenRenderbuffer();
+            GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, renderbufferID);
+            GL.RenderbufferStorageMultisample(RenderbufferTarget.Renderbuffer, 16, RenderbufferStorage.DepthComponent, width, height);
 
-            idTexture = GL.GenTexture();
-            GL.BindTexture(TextureTarget.Texture2D, idTexture);
-            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.R32i, width, height, 0, PixelFormat.RedInteger, PixelType.Int, (IntPtr) 0);
-            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);
-            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) TextureMagFilter.Nearest);
+            typeTexture = GL.GenTexture();
+            GL.BindTexture(TextureTarget.Texture2DMultisample, typeTexture);
+            GL.TexImage2DMultisample(TextureTargetMultisample.Texture2DMultisample, 16, PixelInternalFormat.R32i, width, height, true);
 
             framebufferID = GL.GenFramebuffer();
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferID);
-            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, targetTexture, 0);
-            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, TextureTarget.Texture2D, bufferTexture, 0);
-            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2D, idTexture, 0);
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2DMultisample, targetTexture, 0);
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2DMultisample, typeTexture, 0);
+            GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, RenderbufferTarget.Renderbuffer, renderbufferID);
+
+            outputTexture = GL.GenTexture();
+            GL.BindTexture(TextureTarget.Texture2D, outputTexture);
+            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgb, width, height, 0, PixelFormat.Rgb, PixelType.UnsignedByte, (IntPtr) 0);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Linear);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) TextureMinFilter.Linear);
+
+            outputTypeTexture = GL.GenTexture();
+            GL.BindTexture(TextureTarget.Texture2D, outputTypeTexture);
+            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.R32i, width, height, 0, PixelFormat.RedInteger, PixelType.Int, (IntPtr) 0);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) TextureMinFilter.Nearest);
+
+            outputFramebufferID = GL.GenFramebuffer();
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, outputFramebufferID);
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, outputTexture, 0);
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2D, outputTypeTexture, 0);
         }
 
         public void RenderToTexture(Action renderFunction)
         {
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferID);
+            GL.Viewport(0, 0, width, height);
 
             DrawBuffersEnum[] buffers = { DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1 };
             GL.DrawBuffers(2, buffers);
@@ -54,13 +74,22 @@ namespace Replanetizer.Utils
 
             renderFunction();
 
+            GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, framebufferID);
+            GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, outputFramebufferID);
+            GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
+            GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
+            GL.BlitFramebuffer(0, 0, width, height, 0, 0, width, height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Linear);
+            GL.ReadBuffer(ReadBufferMode.ColorAttachment1);
+            GL.DrawBuffer(DrawBufferMode.ColorAttachment1);
+            GL.BlitFramebuffer(0, 0, width, height, 0, 0, width, height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+
             GL.DeleteVertexArray(VAO);
         }
 
         public void ExposeFramebuffer(Action func)
         {
-            GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferID);
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, outputFramebufferID);
 
             func();
 
@@ -82,9 +111,12 @@ namespace Replanetizer.Utils
             if (disposing)
             {
                 GL.DeleteFramebuffer(framebufferID);
-                GL.DeleteTexture(bufferTexture);
+                GL.DeleteFramebuffer(outputFramebufferID);
+                GL.DeleteRenderbuffer(renderbufferID);
                 GL.DeleteTexture(targetTexture);
-                GL.DeleteTexture(idTexture);
+                GL.DeleteTexture(typeTexture);
+                GL.DeleteTexture(outputTexture);
+                GL.DeleteTexture(outputTypeTexture);
             }
 
             disposed = true;


### PR DESCRIPTION
This adds MSAA support which is set to 2x by default. On an RTX 3070 Ti, I cannot measure any performance difference between Off and 32x MSAA.
I ask OpenGL what the maximum supported msaa level is and all supported levels are then exposed through the settings.
Part of this implementation required the fragment shader to be made as cheap as possible, this meant I moved as many computations to the vertex shader as possible. Most likely, the game did it the same way so this is fine. 
Further, I had to rewrite the fog shading since that is now done in the vertex shader. The fog looks very similar to the game now I would say. However, I said that many times before when that wasn't the case so what do I know.
The model viewer uses the same msaa level as the levelFrame.

Closes #47 