### PR TITLE
Add multi-select

### DIFF
--- a/LibReplanetizer/Level Objects/LevelObject.cs
+++ b/LibReplanetizer/Level Objects/LevelObject.cs
@@ -46,10 +46,20 @@ namespace LibReplanetizer.LevelObjects
             UpdateTransformMatrix();
         }
 
+        public void Translate(float x, float y, float z)
+        {
+            Translate(new Vector3(x, y, z));
+        }
+
         public void Rotate(Vector3 vector)
         {
             rotation *= Quaternion.FromEulerAngles(vector);
             UpdateTransformMatrix();
+        }
+
+        public void Rotate(float x, float y, float z)
+        {
+            Rotate(new Vector3(x, y, z));
         }
 
         public void Scale(Vector3 scale)
@@ -58,23 +68,15 @@ namespace LibReplanetizer.LevelObjects
             UpdateTransformMatrix();
         }
 
-
         public void Scale(float val)
-        { //To uniformly scale object
+        {
+            // To uniformly scale object
             Scale(new Vector3(val));
         }
+
         public void Scale(float x, float y, float z)
         {
             Scale(new Vector3(x, y, z));
         }
-        public void Rotate(float x, float y, float z)
-        {
-            Rotate(new Vector3(x, y, z));
-        }
-        public void Translate(float x, float y, float z)
-        {
-            Translate(new Vector3(x, y, z));
-        }
-
     }
 }

--- a/LibReplanetizer/Level Objects/LevelObject.cs
+++ b/LibReplanetizer/Level Objects/LevelObject.cs
@@ -65,7 +65,7 @@ namespace LibReplanetizer.LevelObjects
         }
         public void Scale(float x, float y, float z)
         {
-            Rotate(new Vector3(x, y, z));
+            Scale(new Vector3(x, y, z));
         }
         public void Rotate(float x, float y, float z)
         {

--- a/LibReplanetizer/Level Objects/LevelObject.cs
+++ b/LibReplanetizer/Level Objects/LevelObject.cs
@@ -40,6 +40,14 @@ namespace LibReplanetizer.LevelObjects
             modelMatrix = reflection * scaleMatrix * rot * translationMatrix;
         }
 
+        public void SetFromMatrix(Matrix4 mat)
+        {
+            position = mat.ExtractTranslation();
+            rotation = mat.ExtractRotation();
+            scale = mat.ExtractScale();
+            modelMatrix = mat;
+        }
+
         public void Translate(Vector3 vector)
         {
             position += vector;

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -262,18 +262,20 @@ namespace Replanetizer.Frames
 
                 if (ImGui.BeginMenu("Tools"))
                 {
-                    if (ImGui.MenuItem("Translate        [1]"))
+                    if (ImGui.MenuItem($"Translate        [{KEYMAP.NameOf(Keybinds.ToolTranslate)}]"))
                         toolbox.ChangeTool(ToolType.Translation);
-                    if (ImGui.MenuItem("Rotate           [2]"))
+                    if (ImGui.MenuItem($"Rotate           [{KEYMAP.NameOf(Keybinds.ToolRotation)}]"))
                         toolbox.ChangeTool(ToolType.Rotation);
-                    if (ImGui.MenuItem("Scale            [3]"))
+                    if (ImGui.MenuItem($"Scale            [{KEYMAP.NameOf(Keybinds.ToolScaling)}]"))
                         toolbox.ChangeTool(ToolType.Scaling);
-                    if (ImGui.MenuItem("Vertex translate [4]"))
+                    if (ImGui.MenuItem($"Vertex translate [{KEYMAP.NameOf(Keybinds.ToolVertexTranslator)}]"))
                         toolbox.ChangeTool(ToolType.VertexTranslation);
-                    if (ImGui.MenuItem("No tool          [5]"))
+                    if (ImGui.MenuItem($"No tool          [{KEYMAP.NameOf(Keybinds.ToolNone)}]"))
                         toolbox.ChangeTool(ToolType.None);
-                    if (ImGui.MenuItem("Delete selected  [Del]")) DeleteObject(selectedObjects);
-                    if (ImGui.MenuItem("Deselect all")) selectedObjects.Clear();
+                    if (ImGui.MenuItem($"Delete selected  [{KEYMAP.NameOf(Keybinds.DeleteObject)}]"))
+                        DeleteObject(selectedObjects);
+                    if (ImGui.MenuItem("Deselect all"))
+                        selectedObjects.Clear();
 
                     ImGui.EndMenu();
                 }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -829,7 +829,7 @@ namespace Replanetizer.Frames
             if (!selectedObjects.TryGetOne(out var obj) || obj is not Spline spline)
                 return;
 
-            int delta = (int) wnd.MouseState.ScrollDelta.Length / 120;
+            int delta = (int) wnd.MouseState.ScrollDelta.Y;
             if (delta == 0)
                 return;
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -291,12 +291,18 @@ namespace Replanetizer.Frames
                 ImGui.Separator();
 
                 if (ImGui.Button(toolbox.transformSpace.HUMAN_NAME))
+                {
                     toolbox.transformSpace++;
+                    InvalidateView();
+                }
                 if (ImGui.IsItemHovered())
                     ImGui.SetTooltip("Transform space");
 
                 if (ImGui.Button(toolbox.pivotPositioning.HUMAN_NAME))
+                {
                     toolbox.pivotPositioning++;
+                    InvalidateView();
+                }
                 if (ImGui.IsItemHovered())
                     ImGui.SetTooltip("Pivot positioning");
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -983,14 +983,16 @@ namespace Replanetizer.Frames
         {
             float xAxis = 0, yAxis = 0, zAxis = 0;
 
-            if (wnd.KeyboardState.IsKeyDown(Keys.W)) yAxis++;
-            if (wnd.KeyboardState.IsKeyDown(Keys.S)) yAxis--;
-            if (wnd.KeyboardState.IsKeyDown(Keys.A)) xAxis--;
-            if (wnd.KeyboardState.IsKeyDown(Keys.D)) xAxis++;
-            if (wnd.KeyboardState.IsKeyDown(Keys.Q)) zAxis--;
-            if (wnd.KeyboardState.IsKeyDown(Keys.E)) zAxis++;
+            if (KEYMAP.IsDown(Keybinds.MoveRight)) xAxis++;
+            if (KEYMAP.IsDown(Keybinds.MoveLeft)) xAxis--;
+            if (KEYMAP.IsDown(Keybinds.MoveForward)) yAxis++;
+            if (KEYMAP.IsDown(Keybinds.MoveBackward)) yAxis--;
+            if (KEYMAP.IsDown(Keybinds.MoveUp)) zAxis++;
+            if (KEYMAP.IsDown(Keybinds.MoveDown)) zAxis--;
 
-            return new Vector3(xAxis, yAxis, zAxis);
+            var inputAxes = new Vector3(xAxis, yAxis, zAxis);
+            inputAxes.NormalizeFast();
+            return inputAxes;
         }
 
         public void ActivateBuffersForModel(IRenderable renderable)

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -1029,7 +1029,7 @@ namespace Replanetizer.Frames
                 vertexTranslationTool.Render(spline, this);
             }
             else
-                toolbox.tool.Render(selectedObjects.median, this);
+                toolbox.tool.Render(selectedObjects, this);
 
             GL.LineWidth(1.0f);
         }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -278,14 +278,15 @@ namespace Replanetizer.Frames
                     ImGui.EndMenu();
                 }
 
-                if (selectedChunks.Length > 0)
+                if (selectedChunks.Length > 0 && ImGui.BeginMenu("Chunks"))
                 {
-                    if (ImGui.BeginMenu("Chunks"))
+                    for (int i = 0; i < selectedChunks.Length; i++)
                     {
-                        for (int i = 0; i < selectedChunks.Length; i++)
-                        {
-                            if (ImGui.Checkbox("Chunk " + i, ref selectedChunks[i])) SetSelectedChunks();
-                        }
+                        if (ImGui.Checkbox($"Chunk {i}", ref selectedChunks[i])) SetSelectedChunks();
+                    }
+
+                    ImGui.EndMenu();
+                }
 
                         ImGui.EndMenu();
                     }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -912,6 +912,7 @@ namespace Replanetizer.Frames
                 }
             }
 
+            selectedObjects.Update();
             InvalidateView();
         }
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -909,11 +909,11 @@ namespace Replanetizer.Frames
             else if (toolbox.tool is VertexTranslationTool vertexTranslationTool)
             {
                 vertexTranslationTool.Transform(selectedObjects, direction, magnitude);
-                // TODO add spline translation hook call
-                // if (hook is { hookWorking: true })
-                // {
-                //     hook.HandleSplineTranslation(level, spline, currentSplineVertex);
-                // }
+                if (hook is { hookWorking: true } &&
+                    selectedObjects.TryGetOne(out var obj) && obj is Spline spline)
+                {
+                    hook.HandleSplineTranslation(level, spline, vertexTranslationTool.currentVertex);
+                }
             }
 
             selectedObjects.SetDirty();

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -1168,7 +1168,7 @@ namespace Replanetizer.Frames
             buffer.UpdateVars();
             buffer.ComputeCulling(camera, enableDistanceCulling, enableFrustumCulling);
             GL.BindBufferBase(BufferRangeTarget.UniformBuffer, 0, lightsBufferObject);
-            buffer.Select(selectedObject);
+            buffer.Select(selectedObjects);
             buffer.Render();
         }
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -56,7 +56,6 @@ namespace Replanetizer.Frames
 
         private Matrix4 view { get; set; }
 
-        private int currentSplineVertex;
         public readonly Selection selectedObjects;
 
         private int antialiasing = 1;
@@ -811,22 +810,19 @@ namespace Replanetizer.Frames
 
         private void HandleMouseWheelChanges()
         {
-            if (toolbox.type != ToolType.VertexTranslator) return;
+            if (toolbox.tool is not VertexTranslationTool tool) return;
             if (!selectedObjects.TryGetOne(out var obj) || obj is not Spline spline)
                 return;
 
             int delta = (int) wnd.MouseState.ScrollDelta.Length / 120;
             if (delta > 0)
             {
-                if (currentSplineVertex < spline.GetVertexCount() - 1)
-                {
-                    currentSplineVertex += 1;
-                }
+                if (tool.currentVertex < spline.GetVertexCount() - 1)
+                    tool.currentVertex++;
             }
-            else if (currentSplineVertex > 0)
-            {
-                currentSplineVertex -= 1;
-            }
+            else if (tool.currentVertex > 0)
+                tool.currentVertex--;
+
             InvalidateView();
         }
 
@@ -897,7 +893,7 @@ namespace Replanetizer.Frames
                 basicTool.Transform(selectedObjects, direction, magnitude);
             else if (toolbox.tool is VertexTranslationTool vertexTranslationTool)
             {
-                vertexTranslationTool.Transform(selectedObjects, direction, magnitude, currentSplineVertex);
+                vertexTranslationTool.Transform(selectedObjects, direction, magnitude);
                 // TODO add spline translation hook call
                 // if (hook is { hookWorking: true })
                 // {
@@ -1019,9 +1015,9 @@ namespace Replanetizer.Frames
             GL.LineWidth(5.0f);
 
             if (selectedObjects.TryGetOne(out var obj) && obj is Spline spline &&
-                toolbox.tool is VertexTranslationTool)
+                toolbox.tool is VertexTranslationTool vertexTranslationTool)
             {
-                toolbox.tool.Render(spline.GetVertex(currentSplineVertex), this);
+                vertexTranslationTool.Render(spline, this);
             }
             else
                 toolbox.tool.Render(selectedObjects.pivot, this);

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -283,10 +283,8 @@ namespace Replanetizer.Frames
                 if (selectedChunks.Length > 0 && ImGui.BeginMenu("Chunks"))
                 {
                     for (int i = 0; i < selectedChunks.Length; i++)
-                    {
-                        if (ImGui.Checkbox($"Chunk {i}", ref selectedChunks[i])) SetSelectedChunks();
-                    }
-
+                        if (ImGui.Checkbox($"Chunk {i}", ref selectedChunks[i]))
+                            SetSelectedChunks();
                     ImGui.EndMenu();
                 }
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -266,8 +266,8 @@ namespace Replanetizer.Frames
                     if (ImGui.MenuItem("Scale            [3]")) SelectTool(scalingTool);
                     if (ImGui.MenuItem("Vertex translate [4]")) SelectTool(vertexTranslator);
                     if (ImGui.MenuItem("No tool          [5]")) SelectTool(null);
-                    if (ImGui.MenuItem("Delete object  [Del]")) DeleteObject(selectedObject);
-                    if (ImGui.MenuItem("Deselect object")) SelectObject(null);
+                    if (ImGui.MenuItem("Delete selected  [Del]")) DeleteObject(selectedObjects);
+                    if (ImGui.MenuItem("Deselect all")) selectedObjects.Clear();
 
                     ImGui.EndMenu();
                 }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -891,25 +891,18 @@ namespace Replanetizer.Frames
 
         private void HandleToolUpdates(Vector3 mouseRay, Vector3 direction)
         {
-            float magnitudeMultiplier = 50;
-            Vector3 magnitude = (mouseRay - prevMouseRay) * magnitudeMultiplier;
+            Vector3 magnitude = mouseRay - prevMouseRay;
 
-            foreach (var obj in selectedObjects)
+            if (currentTool is BasicTransformTool basicTool)
+                basicTool.Transform(selectedObjects, direction, magnitude);
+            else if (currentTool is VertexTranslationTool vertexTranslationTool)
             {
-                if (currentTool is TranslationTool)
-                    obj.Translate(direction * magnitude);
-                else if (currentTool is RotationTool)
-                    obj.Rotate(direction * magnitude);
-                else if (currentTool is ScalingTool)
-                    obj.Scale(direction * magnitude + Vector3.One);
-                else if (currentTool is VertexTranslationTool && obj is Spline spline)
-                {
-                    spline.TranslateVertex(currentSplineVertex, direction * magnitude);
-                    if (hook is { hookWorking: true })
-                    {
-                        hook.HandleSplineTranslation(level, spline, currentSplineVertex);
-                    }
-                }
+                vertexTranslationTool.Transform(selectedObjects, direction, magnitude, currentSplineVertex);
+                // TODO add spline translation hook call
+                // if (hook is { hookWorking: true })
+                // {
+                //     hook.HandleSplineTranslation(level, spline, currentSplineVertex);
+                // }
             }
 
             selectedObjects.SetDirty();

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -83,10 +83,6 @@ namespace Replanetizer.Frames
         public Camera camera;
 
         private Toolbox toolbox = new();
-        private int transformSpace;
-        private int pivotPositioning;
-        private string[] transformSpaceOptions = Enum.GetNames<TransformSpace>();
-        private string[] pivotPositioningOptions = Enum.GetNames<PivotPositioning>();
 
         private ConditionalWeakTable<IRenderable, BufferContainer> bufferTable;
         public Dictionary<Texture, int> textureIds;
@@ -281,18 +277,6 @@ namespace Replanetizer.Frames
                         DeleteObject(selectedObjects);
                     if (ImGui.MenuItem("Deselect all"))
                         selectedObjects.Clear();
-
-                    ImGui.Separator();
-
-                    if (ImGui.Combo("Transform space", ref transformSpace, transformSpaceOptions, transformSpaceOptions.Length))
-                    {
-                        toolbox.transformSpace = (TransformSpace) transformSpace;
-                    }
-                    if (ImGui.Combo("Pivot positioning", ref pivotPositioning, pivotPositioningOptions, pivotPositioningOptions.Length))
-                    {
-                        toolbox.pivotPositioning = (PivotPositioning) pivotPositioning;
-                    }
-
                     ImGui.EndMenu();
                 }
 
@@ -303,6 +287,18 @@ namespace Replanetizer.Frames
                             SetSelectedChunks();
                     ImGui.EndMenu();
                 }
+
+                ImGui.Separator();
+
+                if (ImGui.Button(toolbox.transformSpace.HUMAN_NAME))
+                    toolbox.transformSpace++;
+                if (ImGui.IsItemHovered())
+                    ImGui.SetTooltip("Transform space");
+
+                if (ImGui.Button(toolbox.pivotPositioning.HUMAN_NAME))
+                    toolbox.pivotPositioning++;
+                if (ImGui.IsItemHovered())
+                    ImGui.SetTooltip("Pivot positioning");
 
                 ImGui.EndMenuBar();
             }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -830,12 +830,12 @@ namespace Replanetizer.Frames
                 return;
 
             int delta = (int) wnd.MouseState.ScrollDelta.Length / 120;
-            if (delta > 0)
-            {
-                if (tool.currentVertex < spline.GetVertexCount() - 1)
-                    tool.currentVertex++;
-            }
-            else if (tool.currentVertex > 0)
+            if (delta == 0)
+                return;
+
+            if (delta > 0 && tool.currentVertex < spline.GetVertexCount() - 1)
+                tool.currentVertex++;
+            else if (delta < 0 && tool.currentVertex > 0)
                 tool.currentVertex--;
 
             InvalidateView();

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -1029,7 +1029,7 @@ namespace Replanetizer.Frames
                 vertexTranslationTool.Render(spline, this);
             }
             else
-                toolbox.tool.Render(selectedObjects.pivot, this);
+                toolbox.tool.Render(selectedObjects.median, this);
 
             GL.LineWidth(1.0f);
         }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -72,6 +72,7 @@ namespace Replanetizer.Frames
         {
             mouseButton = MouseButton.Right
         };
+        public readonly Keymap KEYMAP;
 
         public bool initialized, invalidate;
         public bool[] selectedChunks;
@@ -105,6 +106,8 @@ namespace Replanetizer.Frames
             camera = new Camera();
 
             maxAntialiasing = (int) Math.Log2((double) GL.GetInteger(GetPName.MaxSamples));
+
+            KEYMAP = new Keymap(wnd, Keymap.DEFAULT_KEYMAP);
 
             selectedObjects = new Selection();
             selectedObjects.CollectionChanged += SelectedObjectsOnCollectionChanged;

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -288,8 +288,21 @@ namespace Replanetizer.Frames
                     ImGui.EndMenu();
                 }
 
-                        ImGui.EndMenu();
-                    }
+                // Tool options
+                ImGui.Separator();
+
+                if (ImGui.BeginMenu($"Transform space ({Enum.GetName(toolbox.transformationSpace)})"))
+                {
+                    if (ImGui.MenuItem("Global")) toolbox.transformationSpace = TransformationSpace.Global;
+                    if (ImGui.MenuItem("Local")) toolbox.transformationSpace = TransformationSpace.Local;
+                    ImGui.EndMenu();
+                }
+
+                if (ImGui.BeginMenu($"Pivot positioning ({Enum.GetName(toolbox.pivotPositioning)})"))
+                {
+                    if (ImGui.MenuItem("Median")) toolbox.pivotPositioning = PivotPositioning.Median;
+                    if (ImGui.MenuItem("Individual Origins")) toolbox.pivotPositioning = PivotPositioning.IndividualOrigins;
+                    ImGui.EndMenu();
                 }
 
                 ImGui.EndMenuBar();

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -912,7 +912,7 @@ namespace Replanetizer.Frames
                 }
             }
 
-            selectedObjects.Update();
+            selectedObjects.SetDirty();
             InvalidateView();
         }
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -840,12 +840,12 @@ namespace Replanetizer.Frames
 
         private void HandleKeyboardShortcuts()
         {
-            if (wnd.IsKeyPressed(Keys.D1)) SelectTool(translateTool);
-            if (wnd.IsKeyPressed(Keys.D2)) SelectTool(rotationTool);
-            if (wnd.IsKeyPressed(Keys.D3)) SelectTool(scalingTool);
-            if (wnd.IsKeyPressed(Keys.D4)) SelectTool(vertexTranslator);
-            if (wnd.IsKeyPressed(Keys.D5)) SelectTool();
-            if (wnd.IsKeyPressed(Keys.Delete)) DeleteObject(selectedObjects);
+            if (KEYMAP.IsPressed(Keybinds.ToolNone)) SelectTool();
+            if (KEYMAP.IsPressed(Keybinds.ToolTranslate)) SelectTool(translateTool);
+            if (KEYMAP.IsPressed(Keybinds.ToolRotation)) SelectTool(rotationTool);
+            if (KEYMAP.IsPressed(Keybinds.ToolScaling)) SelectTool(scalingTool);
+            if (KEYMAP.IsPressed(Keybinds.ToolVertexTranslator)) SelectTool(vertexTranslator);
+            if (KEYMAP.IsPressed(Keybinds.DeleteObject)) DeleteObject(selectedObjects);
         }
 
         public void SelectTool(Tool tool = null)
@@ -878,7 +878,7 @@ namespace Replanetizer.Frames
 
         private void CheckForMovementInput(float deltaTime)
         {
-            float moveSpeed = wnd.IsKeyDown(Keys.LeftShift) ? 40 : 10;
+            float moveSpeed = KEYMAP.IsDown(Keybinds.MoveFastModifier) ? 40 : 10;
             Vector3 moveDir = GetInputAxes();
             if (moveDir.Length > 0)
             {

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -206,10 +206,12 @@ namespace Replanetizer.Frames
                 {
                     if (ImGui.MenuItem("Object properties"))
                     {
-                        var newFrame = new PropertyFrame(this.wnd, this, selectedObjects, listenToCallbacks: true);
-                        // TODO callbacks
-                        // RegisterCallback(newFrame.SelectionCallback);
-                        subFrames.Add(newFrame);
+                        subFrames.Add(
+                            new PropertyFrame(this.wnd, this, listenToCallbacks: true)
+                            {
+                                selection = selectedObjects
+                            }
+                        );
                     }
                     if (ImGui.MenuItem("Model viewer"))
                     {
@@ -225,7 +227,12 @@ namespace Replanetizer.Frames
                     }
                     if (ImGui.MenuItem("Level variables"))
                     {
-                        subFrames.Add(new PropertyFrame(this.wnd, this, level.levelVariables, "Level variables"));
+                        subFrames.Add(
+                            new PropertyFrame(this.wnd, this, "Level variables")
+                            {
+                                selectedObject = level.levelVariables
+                            }
+                        );
                     }
                     ImGui.EndMenu();
                 }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -81,7 +81,12 @@ namespace Replanetizer.Frames
             enableDistanceCulling = true, enableFrustumCulling = true, enableFog = true, enableCameraInfo = true;
 
         public Camera camera;
+
         private Toolbox toolbox = new();
+        private int transformSpace;
+        private int pivotPositioning;
+        private string[] transformSpaceOptions = Enum.GetNames<TransformSpace>();
+        private string[] pivotPositioningOptions = Enum.GetNames<PivotPositioning>();
 
         private ConditionalWeakTable<IRenderable, BufferContainer> bufferTable;
         public Dictionary<Texture, int> textureIds;
@@ -277,6 +282,17 @@ namespace Replanetizer.Frames
                     if (ImGui.MenuItem("Deselect all"))
                         selectedObjects.Clear();
 
+                    ImGui.Separator();
+
+                    if (ImGui.Combo("Transform space", ref transformSpace, transformSpaceOptions, transformSpaceOptions.Length))
+                    {
+                        toolbox.transformSpace = (TransformSpace) transformSpace;
+                    }
+                    if (ImGui.Combo("Pivot positioning", ref pivotPositioning, pivotPositioningOptions, pivotPositioningOptions.Length))
+                    {
+                        toolbox.pivotPositioning = (PivotPositioning) pivotPositioning;
+                    }
+
                     ImGui.EndMenu();
                 }
 
@@ -285,23 +301,6 @@ namespace Replanetizer.Frames
                     for (int i = 0; i < selectedChunks.Length; i++)
                         if (ImGui.Checkbox($"Chunk {i}", ref selectedChunks[i]))
                             SetSelectedChunks();
-                    ImGui.EndMenu();
-                }
-
-                // Tool options
-                ImGui.Separator();
-
-                if (ImGui.BeginMenu($"Transform space ({Enum.GetName(toolbox.transformationSpace)})"))
-                {
-                    if (ImGui.MenuItem("Global")) toolbox.transformationSpace = TransformationSpace.Global;
-                    if (ImGui.MenuItem("Local")) toolbox.transformationSpace = TransformationSpace.Local;
-                    ImGui.EndMenu();
-                }
-
-                if (ImGui.BeginMenu($"Pivot positioning ({Enum.GetName(toolbox.pivotPositioning)})"))
-                {
-                    if (ImGui.MenuItem("Median")) toolbox.pivotPositioning = PivotPositioning.Median;
-                    if (ImGui.MenuItem("Individual Origins")) toolbox.pivotPositioning = PivotPositioning.IndividualOrigins;
                     ImGui.EndMenu();
                 }
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -263,13 +263,13 @@ namespace Replanetizer.Frames
                 if (ImGui.BeginMenu("Tools"))
                 {
                     if (ImGui.MenuItem("Translate        [1]"))
-                        toolbox.ChangeTool(ToolType.Translate);
+                        toolbox.ChangeTool(ToolType.Translation);
                     if (ImGui.MenuItem("Rotate           [2]"))
-                        toolbox.ChangeTool(ToolType.Rotate);
+                        toolbox.ChangeTool(ToolType.Rotation);
                     if (ImGui.MenuItem("Scale            [3]"))
-                        toolbox.ChangeTool(ToolType.Scale);
+                        toolbox.ChangeTool(ToolType.Scaling);
                     if (ImGui.MenuItem("Vertex translate [4]"))
-                        toolbox.ChangeTool(ToolType.VertexTranslator);
+                        toolbox.ChangeTool(ToolType.VertexTranslation);
                     if (ImGui.MenuItem("No tool          [5]"))
                         toolbox.ChangeTool(ToolType.None);
                     if (ImGui.MenuItem("Delete selected  [Del]")) DeleteObject(selectedObjects);
@@ -757,7 +757,7 @@ namespace Replanetizer.Frames
 
         public void SelectedObjectsOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            if (!selectedObjects.isOnlySplines && toolbox.type == ToolType.VertexTranslator)
+            if (!selectedObjects.isOnlySplines && toolbox.type == ToolType.VertexTranslation)
                 toolbox.ChangeTool(ToolType.None);
             InvalidateView();
         }
@@ -840,13 +840,13 @@ namespace Replanetizer.Frames
             if (KEYMAP.IsPressed(Keybinds.ToolNone))
                 toolbox.ChangeTool(ToolType.None);
             if (KEYMAP.IsPressed(Keybinds.ToolTranslate))
-                toolbox.ChangeTool(ToolType.Translate);
+                toolbox.ChangeTool(ToolType.Translation);
             if (KEYMAP.IsPressed(Keybinds.ToolRotation))
-                toolbox.ChangeTool(ToolType.Rotate);
+                toolbox.ChangeTool(ToolType.Rotation);
             if (KEYMAP.IsPressed(Keybinds.ToolScaling))
-                toolbox.ChangeTool(ToolType.Scale);
+                toolbox.ChangeTool(ToolType.Scaling);
             if (KEYMAP.IsPressed(Keybinds.ToolVertexTranslator))
-                toolbox.ChangeTool(ToolType.VertexTranslator);
+                toolbox.ChangeTool(ToolType.VertexTranslation);
             if (KEYMAP.IsPressed(Keybinds.DeleteObject))
                 DeleteObject(selectedObjects);
         }

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -251,7 +251,7 @@ namespace Replanetizer.Frames
         {
             scale = Matrix4.CreateScale(selectedModel.size);
             invalidate = true;
-            propertyFrame.SelectionCallback(selectedModel);
+            propertyFrame.selectedObject = selectedModel;
             UpdateTextures();
 
             container = BufferContainer.FromRenderable(selectedModel);

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -35,6 +35,7 @@ namespace Replanetizer.Frames
                 if (value != null)
                     value.CollectionChanged += SelectionOnCollectionChanged;
                 _selection = value;
+                UpdateFromSelection();
             }
         }
 
@@ -70,18 +71,23 @@ namespace Replanetizer.Frames
             this.hideCallbackButton = hideCallbackButton;
         }
 
+        private void UpdateLevelFrame()
+        {
+            levelFrame?.InvalidateView();
+        }
+
         private void SelectionOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            UpdateFromSelection();
+        }
+
+        private void UpdateFromSelection()
         {
             if (selection == null)
                 // This shouldn't happen
                 return;
             selection.TryGetOne(out var obj);
             selectedObject = obj;
-        }
-
-        private void UpdateLevelFrame()
-        {
-            levelFrame?.InvalidateView();
         }
 
         private void RecomputeProperties()

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -45,6 +45,8 @@ namespace Replanetizer.Frames
             get => _selectedObject;
             set
             {
+                if (!listenToCallbacks)
+                    return;
                 _selectedObject = value;
                 RecomputeProperties();
             }
@@ -74,13 +76,6 @@ namespace Replanetizer.Frames
                 // This shouldn't happen
                 return;
             selection.TryGetOne(out var obj);
-            SelectionCallback(obj);
-        }
-
-        public void SelectionCallback(object? obj)
-        {
-            if (!listenToCallbacks)
-                return;
             selectedObject = obj;
         }
 

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Numerics;
 using System.Reflection;
@@ -14,66 +15,98 @@ using System.Text;
 using System.Drawing;
 using ImGuiNET;
 using LibReplanetizer.LevelObjects;
+using Replanetizer.Utils;
 
 namespace Replanetizer.Frames
 {
     public class PropertyFrame : Frame
     {
         protected sealed override string frameName { get; set; } = "Properties";
-        private object selectedObject;
-        private bool listenToCallbacks;
-        private bool hideCallbackButton = false;
-        private LevelFrame levelFrame;
 
-        private Dictionary<string, Dictionary<string, PropertyInfo>> properties;
+        private Selection? _selection;
 
-        public PropertyFrame(Window wnd, LevelFrame levelFrame = null, object selectedObject = null, string overrideFrameName = null, bool listenToCallbacks = false, bool hideCallbackButton = false) : base(wnd)
+        public Selection? selection
         {
-            if (overrideFrameName != null && overrideFrameName.Length > 0)
+            get => _selection;
+            set
             {
-                frameName = overrideFrameName;
+                if (_selection != null)
+                    _selection.CollectionChanged -= SelectionOnCollectionChanged;
+                if (value != null)
+                    value.CollectionChanged += SelectionOnCollectionChanged;
+                _selection = value;
             }
-
-            this.levelFrame = levelFrame;
-            this.selectedObject = selectedObject;
-            this.listenToCallbacks = listenToCallbacks;
-            this.hideCallbackButton = hideCallbackButton;
-            if (selectedObject != null) RecomputeProperties();
         }
 
-        public void SelectionCallback(object o)
+        private object? _selectedObject;
+
+        public object? selectedObject
         {
-            if (!listenToCallbacks) return;
-            if (o == null)
+            get => _selectedObject;
+            set
             {
-                isOpen = false;
-                return;
+                _selectedObject = value;
+                RecomputeProperties();
             }
-            selectedObject = o;
-            RecomputeProperties();
+        }
+
+        private bool listenToCallbacks;
+        private bool hideCallbackButton;
+        private LevelFrame? levelFrame;
+
+        private Dictionary<string, Dictionary<string, PropertyInfo>> properties = new();
+
+        public PropertyFrame(
+            Window wnd, LevelFrame? levelFrame = null, string? overrideFrameName = null,
+            bool listenToCallbacks = false, bool hideCallbackButton = false) : base(wnd)
+        {
+            if (overrideFrameName is { Length: > 0 })
+                frameName = overrideFrameName;
+
+            this.levelFrame = levelFrame;
+            this.listenToCallbacks = listenToCallbacks;
+            this.hideCallbackButton = hideCallbackButton;
+        }
+
+        private void SelectionOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (selection == null)
+                // This shouldn't happen
+                return;
+            selection.TryGetOne(out var obj);
+            SelectionCallback(obj);
+        }
+
+        public void SelectionCallback(object? obj)
+        {
+            if (!listenToCallbacks)
+                return;
+            selectedObject = obj;
         }
 
         private void UpdateLevelFrame()
         {
-            if (levelFrame != null) levelFrame.InvalidateView();
+            levelFrame?.InvalidateView();
         }
 
         private void RecomputeProperties()
         {
-            properties = new Dictionary<string, Dictionary<string, PropertyInfo>>();
+            properties.Clear();
+
+            if (selectedObject == null)
+                return;
+
             var objProps = selectedObject.GetType().GetProperties();
             foreach (var prop in objProps)
             {
-                string category = prop.GetCustomAttribute<CategoryAttribute>()?.Category;
-                if (category == null) category = "Unknowns";
+                string category =
+                    prop.GetCustomAttribute<CategoryAttribute>()?.Category ?? "Unknowns";
 
-                string displayName = prop.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName;
-                if (displayName == null) displayName = prop.Name;
+                string displayName =
+                    prop.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? prop.Name;
 
                 if (!properties.ContainsKey(category))
-                {
                     properties[category] = new Dictionary<string, PropertyInfo>();
-                }
 
                 properties[category][displayName] = prop;
             }
@@ -90,9 +123,12 @@ namespace Replanetizer.Frames
 
         public override void Render(float deltaTime)
         {
-            if (properties == null)
+            if (selectedObject == null)
             {
-                ImGui.Text("Select an object");
+                if (selection is { Count: > 1 })
+                    ImGui.Text("Multiple objects selected");
+                else
+                    ImGui.Text("Select an object");
                 return;
             }
 
@@ -103,226 +139,222 @@ namespace Replanetizer.Frames
                     listenToCallbacks = false;
                 }
             }
-            foreach (var categoryPair in properties)
+
+            foreach (var (categoryName, categoryItems) in properties)
             {
-                if (ImGui.CollapsingHeader(categoryPair.Key, ImGuiTreeNodeFlags.DefaultOpen))
+                RenderCategory(categoryName, categoryItems);
+            }
+        }
+
+        private void RenderCategory(string categoryName, Dictionary<string, PropertyInfo> categoryItems)
+        {
+            if (ImGui.CollapsingHeader(categoryName, ImGuiTreeNodeFlags.DefaultOpen))
+            {
+                foreach (var (key, value) in categoryItems)
+                    RenderCategoryItem(key, value);
+            }
+        }
+
+        private void RenderCategoryItem(string propertyName, PropertyInfo propertyInfo)
+        {
+            object? val = propertyInfo.GetValue(selectedObject);
+            Type? type = propertyInfo.GetSetMethod() == null ? null : propertyInfo.PropertyType;
+
+            if (val == null)
+            {
+                ImGui.LabelText(propertyName, "null");
+            }
+            else if (type == typeof(string))
+            {
+                byte[] v = Encoding.ASCII.GetBytes(val as string ?? string.Empty);
+                if (ImGui.InputText(propertyName, v, (uint)v.Length))
                 {
-                    foreach (var (key, value) in categoryPair.Value)
-                    {
-                        var val = value.GetValue(selectedObject);
-                        var type = value.PropertyType;
-                        if (value.GetSetMethod() == null) type = null;
-
-                        if (val == null)
-                        {
-                            ImGui.LabelText(key, "null");
-                        }
-                        else if (type == typeof(string))
-                        {
-                            var v = Encoding.ASCII.GetBytes((string) val ?? string.Empty);
-                            if (ImGui.InputText(key, v, (uint) v.Length))
-                            {
-                                value.SetValue(selectedObject, Encoding.ASCII.GetString(v));
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type == typeof(int))
-                        {
-                            int v = (int) val;
-                            if (ImGui.InputInt(key, ref v))
-                            {
-                                value.SetValue(selectedObject, v);
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type == typeof(uint))
-                        {
-                            int v = unchecked((int) (uint) val);
-                            if (ImGui.InputInt(key, ref v))
-                            {
-                                value.SetValue(selectedObject, unchecked((uint) v));
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type == typeof(short))
-                        {
-                            int v = Convert.ToInt32(val);
-                            if (ImGui.InputInt(key, ref v))
-                            {
-                                value.SetValue(selectedObject, (short) (v & 0xffff));
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type == typeof(ushort))
-                        {
-                            int v = unchecked((ushort) val);
-                            if (ImGui.InputInt(key, ref v))
-                            {
-                                value.SetValue(selectedObject, unchecked((ushort) (v & 0xffff)));
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type == typeof(float))
-                        {
-                            var v = (float) val;
-                            if (ImGui.InputFloat(key, ref v))
-                            {
-                                value.SetValue(selectedObject, v);
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type == typeof(Color))
-                        {
-                            Color c = (Color) val;
-                            Vector3 v = new Vector3(c.R / 255.0f, c.G / 255.0f, c.B / 255.0f);
-                            if (ImGui.ColorEdit3(key, ref v))
-                            {
-                                Color newColor = Color.FromArgb((int) (v.X * 255.0f), (int) (v.Y * 255.0f), (int) (v.Z * 255.0f));
-                                value.SetValue(selectedObject, newColor);
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type == typeof(OpenTK.Mathematics.Vector3))
-                        {
-                            OpenTK.Mathematics.Vector3 origV = (OpenTK.Mathematics.Vector3) val;
-                            Vector3 v = new Vector3(origV.X, origV.Y, origV.Z);
-                            if (ImGui.InputFloat3(key, ref v))
-                            {
-                                origV.X = v.X;
-                                origV.Y = v.Y;
-                                origV.Z = v.Z;
-                                value.SetValue(selectedObject, origV);
-
-                                if (selectedObject is LevelObject)
-                                {
-                                    ((LevelObject) selectedObject).UpdateTransformMatrix();
-                                }
-
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type == typeof(OpenTK.Mathematics.Quaternion))
-                        {
-                            OpenTK.Mathematics.Vector3 origRot = ((OpenTK.Mathematics.Quaternion) val).ToEulerAngles();
-                            Vector3 v = new Vector3(origRot.X, origRot.Y, origRot.Z);
-                            if (ImGui.InputFloat3(key, ref v))
-                            {
-                                origRot.X = v.X;
-                                origRot.Y = v.Y;
-                                origRot.Z = v.Z;
-                                value.SetValue(selectedObject, new OpenTK.Mathematics.Quaternion(origRot.X, origRot.Y, origRot.Z));
-
-                                if (selectedObject is LevelObject)
-                                {
-                                    ((LevelObject) selectedObject).UpdateTransformMatrix();
-                                }
-
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type == typeof(OpenTK.Mathematics.Matrix4))
-                        {
-                            OpenTK.Mathematics.Matrix4 mat = (OpenTK.Mathematics.Matrix4) val;
-                            Vector4 v1 = new Vector4(mat.M11, mat.M12, mat.M13, mat.M14);
-                            Vector4 v2 = new Vector4(mat.M21, mat.M22, mat.M23, mat.M24);
-                            Vector4 v3 = new Vector4(mat.M31, mat.M32, mat.M33, mat.M34);
-                            Vector4 v4 = new Vector4(mat.M41, mat.M42, mat.M43, mat.M44);
-
-                            bool change = false;
-
-                            if (ImGui.InputFloat4(key + " Row 1", ref v1))
-                            {
-                                change = true;
-                                mat.M11 = v1.X;
-                                mat.M12 = v1.Y;
-                                mat.M13 = v1.Z;
-                                mat.M14 = v1.W;
-                            }
-
-                            if (ImGui.InputFloat4(key + " Row 2", ref v2))
-                            {
-                                change = true;
-                                mat.M21 = v2.X;
-                                mat.M22 = v2.Y;
-                                mat.M23 = v2.Z;
-                                mat.M24 = v2.W;
-                            }
-
-                            if (ImGui.InputFloat4(key + " Row 3", ref v3))
-                            {
-                                change = true;
-                                mat.M31 = v3.X;
-                                mat.M32 = v3.Y;
-                                mat.M33 = v3.Z;
-                                mat.M34 = v3.W;
-                            }
-
-                            if (ImGui.InputFloat4(key + " Row 4", ref v4))
-                            {
-                                change = true;
-                                mat.M41 = v4.X;
-                                mat.M42 = v4.Y;
-                                mat.M43 = v4.Z;
-                                mat.M44 = v4.W;
-                            }
-
-                            if (change)
-                            {
-                                value.SetValue(selectedObject, mat);
-
-                                if (selectedObject is LevelObject)
-                                {
-                                    ((LevelObject) selectedObject).UpdateTransformMatrix();
-                                }
-
-                                UpdateLevelFrame();
-                            }
-                        }
-                        else if (type.IsArray)
-                        {
-                            if (ImGui.CollapsingHeader(key))
-                            {
-                                Array array = (Array) val;
-
-                                foreach (object o in array)
-                                {
-                                    ImGui.Text(Convert.ToString(o));
-                                }
-                            }
-                        }
-                        else if (type.IsEnum)
-                        {
-                            Array values = Enum.GetValues(type);
-
-                            string[] strings = new string[values.Length];
-
-                            for (int i = 0; i < values.Length; i++)
-                            {
-                                strings[i] = Convert.ToString(values.GetValue(i));
-                            }
-
-                            int index = (int) val;
-
-                            if (index < values.Length)
-                            {
-                                if (ImGui.Combo(key, ref index, strings, values.Length))
-                                {
-                                    value.SetValue(selectedObject, index);
-                                    UpdateLevelFrame();
-                                }
-                            }
-                            else
-                            {
-                                ImGui.LabelText(key, "[Out of Range] " + Convert.ToString(index));
-                            }
-                        }
-                        else
-                        {
-                            ImGui.LabelText(key, Convert.ToString(val));
-                        }
-                    }
+                    propertyInfo.SetValue(selectedObject, Encoding.ASCII.GetString(v));
+                    UpdateLevelFrame();
                 }
             }
+            else if (type == typeof(int))
+            {
+                int v = (int) val;
+                if (ImGui.InputInt(propertyName, ref v))
+                {
+                    propertyInfo.SetValue(selectedObject, v);
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type == typeof(uint))
+            {
+                int v = unchecked((int) (uint) val);
+                if (ImGui.InputInt(propertyName, ref v))
+                {
+                    propertyInfo.SetValue(selectedObject, unchecked((uint)v));
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type == typeof(short))
+            {
+                int v = Convert.ToInt32(val);
+                if (ImGui.InputInt(propertyName, ref v))
+                {
+                    propertyInfo.SetValue(selectedObject, (short)(v & 0xffff));
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type == typeof(ushort))
+            {
+                int v = (ushort) val;
+                if (ImGui.InputInt(propertyName, ref v))
+                {
+                    propertyInfo.SetValue(selectedObject, unchecked((ushort)(v & 0xffff)));
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type == typeof(float))
+            {
+                float v = (float) val;
+                if (ImGui.InputFloat(propertyName, ref v))
+                {
+                    propertyInfo.SetValue(selectedObject, v);
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type == typeof(Color))
+            {
+                var c = (Color) val;
+                var v = new Vector3(c.R / 255.0f, c.G / 255.0f, c.B / 255.0f);
+                if (ImGui.ColorEdit3(propertyName, ref v))
+                {
+                    Color newColor = Color.FromArgb(
+                        (int) (v.X * 255.0f), (int) (v.Y * 255.0f), (int) (v.Z * 255.0f)
+                    );
+                    propertyInfo.SetValue(selectedObject, newColor);
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type == typeof(OpenTK.Mathematics.Vector3))
+            {
+                var origV = (OpenTK.Mathematics.Vector3) val;
+                var v = new Vector3(origV.X, origV.Y, origV.Z);
+                if (ImGui.InputFloat3(propertyName, ref v))
+                {
+                    origV.X = v.X;
+                    origV.Y = v.Y;
+                    origV.Z = v.Z;
+                    propertyInfo.SetValue(selectedObject, origV);
+
+                    if (selectedObject is LevelObject levelObject)
+                        levelObject.UpdateTransformMatrix();
+
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type == typeof(OpenTK.Mathematics.Quaternion))
+            {
+                var origRot = ((OpenTK.Mathematics.Quaternion) val).ToEulerAngles();
+                var v = new Vector3(origRot.X, origRot.Y, origRot.Z);
+                if (ImGui.InputFloat3(propertyName, ref v))
+                {
+                    origRot.X = v.X;
+                    origRot.Y = v.Y;
+                    origRot.Z = v.Z;
+                    propertyInfo.SetValue(
+                        selectedObject,
+                        new OpenTK.Mathematics.Quaternion(origRot.X, origRot.Y, origRot.Z)
+                    );
+
+                    if (selectedObject is LevelObject levelObject)
+                        levelObject.UpdateTransformMatrix();
+
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type == typeof(OpenTK.Mathematics.Matrix4))
+            {
+                var mat = (OpenTK.Mathematics.Matrix4) val;
+                var v1 = new Vector4(mat.M11, mat.M12, mat.M13, mat.M14);
+                var v2 = new Vector4(mat.M21, mat.M22, mat.M23, mat.M24);
+                var v3 = new Vector4(mat.M31, mat.M32, mat.M33, mat.M34);
+                var v4 = new Vector4(mat.M41, mat.M42, mat.M43, mat.M44);
+
+                bool change = false;
+
+                if (ImGui.InputFloat4($"{propertyName} Row 1", ref v1))
+                {
+                    change = true;
+                    mat.M11 = v1.X;
+                    mat.M12 = v1.Y;
+                    mat.M13 = v1.Z;
+                    mat.M14 = v1.W;
+                }
+
+                if (ImGui.InputFloat4($"{propertyName} Row 2", ref v2))
+                {
+                    change = true;
+                    mat.M21 = v2.X;
+                    mat.M22 = v2.Y;
+                    mat.M23 = v2.Z;
+                    mat.M24 = v2.W;
+                }
+
+                if (ImGui.InputFloat4($"{propertyName} Row 3", ref v3))
+                {
+                    change = true;
+                    mat.M31 = v3.X;
+                    mat.M32 = v3.Y;
+                    mat.M33 = v3.Z;
+                    mat.M34 = v3.W;
+                }
+
+                if (ImGui.InputFloat4($"{propertyName} Row 4", ref v4))
+                {
+                    change = true;
+                    mat.M41 = v4.X;
+                    mat.M42 = v4.Y;
+                    mat.M43 = v4.Z;
+                    mat.M44 = v4.W;
+                }
+
+                if (change)
+                {
+                    propertyInfo.SetValue(selectedObject, mat);
+
+                    if (selectedObject is LevelObject levelObject)
+                        levelObject.UpdateTransformMatrix();
+
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type is { IsArray: true })
+            {
+                if (ImGui.CollapsingHeader(propertyName))
+                {
+                    Array array = (Array) val;
+
+                    foreach (object o in array)
+                        ImGui.Text(Convert.ToString(o));
+                }
+            }
+            else if (type is { IsEnum: true })
+            {
+                Array values = Enum.GetValues(type);
+                string[] strings = new string[values.Length];
+                for (int i = 0; i < values.Length; i++)
+                    strings[i] = Convert.ToString(values.GetValue(i)) ?? string.Empty;
+
+                int index = (int) val;
+                if (index < values.Length)
+                {
+                    if (ImGui.Combo(propertyName, ref index, strings, values.Length))
+                    {
+                        propertyInfo.SetValue(selectedObject, index);
+                        UpdateLevelFrame();
+                    }
+                }
+                else
+                    ImGui.LabelText(propertyName, "[Out of Range] " + Convert.ToString(index));
+            }
+            else
+                ImGui.LabelText(propertyName, Convert.ToString(val));
         }
     }
 }

--- a/Replanetizer/Tools/BasicTransformTool.cs
+++ b/Replanetizer/Tools/BasicTransformTool.cs
@@ -13,18 +13,24 @@ namespace Replanetizer.Tools
 {
     public abstract class BasicTransformTool : Tool
     {
-        public abstract void Transform(LevelObject obj, Vector3 vec);
+        public abstract void Transform(LevelObject obj, Vector3 vec, Vector3 pivot);
 
-        public void Transform(LevelObject obj, Vector3 direction, Vector3 magnitude)
+        public void Transform(
+            LevelObject obj, Vector3 direction, Vector3 magnitude, Vector3 pivot)
         {
-            Transform(obj, ProcessVec(direction, magnitude));
+            Transform(obj, ProcessVec(direction, magnitude), pivot);
         }
 
         public void Transform(Selection selection, Vector3 direction, Vector3 magnitude)
         {
             Vector3 vec = ProcessVec(direction, magnitude);
+            Vector3 pivot = selection.pivot;
             foreach (var obj in selection)
-                Transform(obj, vec);
+            {
+                if (pivotPositioning == PivotPositioning.INDIVIDUAL_ORIGINS)
+                    pivot = obj.position;
+                Transform(obj, vec, pivot);
+            }
         }
     }
 }

--- a/Replanetizer/Tools/BasicTransformTool.cs
+++ b/Replanetizer/Tools/BasicTransformTool.cs
@@ -13,6 +13,10 @@ namespace Replanetizer.Tools
 {
     public abstract class BasicTransformTool : Tool
     {
+        protected BasicTransformTool(Toolbox toolbox) : base(toolbox)
+        {
+        }
+
         public abstract void Transform(LevelObject obj, Vector3 vec, Vector3 pivot);
 
         public void Transform(
@@ -27,7 +31,7 @@ namespace Replanetizer.Tools
             Vector3 pivot = selection.pivot;
             foreach (var obj in selection)
             {
-                if (pivotPositioning == PivotPositioning.IndividualOrigins)
+                if (toolbox.pivotPositioning == PivotPositioning.IndividualOrigins)
                     pivot = obj.position;
                 Transform(obj, vec, pivot);
             }

--- a/Replanetizer/Tools/BasicTransformTool.cs
+++ b/Replanetizer/Tools/BasicTransformTool.cs
@@ -27,7 +27,7 @@ namespace Replanetizer.Tools
             Vector3 pivot = selection.pivot;
             foreach (var obj in selection)
             {
-                if (pivotPositioning == PivotPositioning.INDIVIDUAL_ORIGINS)
+                if (pivotPositioning == PivotPositioning.IndividualOrigins)
                     pivot = obj.position;
                 Transform(obj, vec, pivot);
             }

--- a/Replanetizer/Tools/BasicTransformTool.cs
+++ b/Replanetizer/Tools/BasicTransformTool.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using LibReplanetizer.LevelObjects;
+using OpenTK.Mathematics;
+using Replanetizer.Utils;
+
+namespace Replanetizer.Tools
+{
+    public abstract class BasicTransformTool : Tool
+    {
+        public abstract void Transform(LevelObject obj, Vector3 vec);
+
+        public void Transform(LevelObject obj, Vector3 direction, Vector3 magnitude)
+        {
+            Transform(obj, ProcessVec(direction, magnitude));
+        }
+
+        public void Transform(Selection selection, Vector3 direction, Vector3 magnitude)
+        {
+            Vector3 vec = ProcessVec(direction, magnitude);
+            foreach (var obj in selection)
+                Transform(obj, vec);
+        }
+    }
+}

--- a/Replanetizer/Tools/BasicTransformTool.cs
+++ b/Replanetizer/Tools/BasicTransformTool.cs
@@ -32,7 +32,7 @@ namespace Replanetizer.Tools
         public void Transform(Selection selection, Vector3 direction, Vector3 magnitude)
         {
             Vector3 vec = ProcessVec(direction, magnitude);
-            Vector3 pivot = selection.pivot;
+            Vector3 pivot = selection.median;
             foreach (var obj in selection)
             {
                 if (toolbox.pivotPositioning == PivotPositioning.IndividualOrigins)

--- a/Replanetizer/Tools/BasicTransformTool.cs
+++ b/Replanetizer/Tools/BasicTransformTool.cs
@@ -17,6 +17,10 @@ namespace Replanetizer.Tools
         {
         }
 
+        // TODO transforms are not stable unless we store the original matrix
+        //   and pivot throughout the entire user interaction. This can also
+        //   help in optimizing matrix operations, as we can combine matrices
+        //   once and reuse them.
         public abstract void Transform(LevelObject obj, Vector3 vec, Vector3 pivot);
 
         public void Transform(

--- a/Replanetizer/Tools/PivotPositioning.cs
+++ b/Replanetizer/Tools/PivotPositioning.cs
@@ -9,7 +9,7 @@ namespace Replanetizer.Tools
 {
     public enum PivotPositioning
     {
-        MEDIAN,
-        INDIVIDUAL_ORIGINS
+        Median = 0,
+        IndividualOrigins
     }
 }

--- a/Replanetizer/Tools/PivotPositioning.cs
+++ b/Replanetizer/Tools/PivotPositioning.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+namespace Replanetizer.Tools
+{
+    public enum PivotPositioning
+    {
+        MEDIAN,
+        INDIVIDUAL_ORIGINS
+    }
+}

--- a/Replanetizer/Tools/PivotPositioning.cs
+++ b/Replanetizer/Tools/PivotPositioning.cs
@@ -12,7 +12,7 @@ namespace Replanetizer.Tools
     public class PivotPositioning : EnhancedEnum<PivotPositioning>
     {
         public static readonly PivotPositioning Median = new(0, "Median");
-        public static readonly PivotPositioning IndividualOrigins = new(1, "Individual Origins");
+        public static readonly PivotPositioning IndividualOrigins = new(1, "Individual origins");
 
         public PivotPositioning(int key, string humanName) : base(key, humanName)
         {

--- a/Replanetizer/Tools/PivotPositioning.cs
+++ b/Replanetizer/Tools/PivotPositioning.cs
@@ -5,11 +5,17 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using Replanetizer.Utils;
+
 namespace Replanetizer.Tools
 {
-    public enum PivotPositioning
+    public class PivotPositioning : EnhancedEnum<PivotPositioning>
     {
-        Median = 0,
-        IndividualOrigins
+        public static readonly PivotPositioning Median = new(0, "Median");
+        public static readonly PivotPositioning IndividualOrigins = new(1, "Individual Origins");
+
+        public PivotPositioning(int key, string humanName) : base(key, humanName)
+        {
+        }
     }
 }

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -50,7 +50,7 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
         }
 
-        public override void Transform(LevelObject obj, Vector3 vec)
+        public override void Transform(LevelObject obj, Vector3 vec, Vector3 pivot)
         {
             obj.Rotate(vec);
         }

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -5,19 +5,22 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using LibReplanetizer.LevelObjects;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using Replanetizer.Frames;
 
 namespace Replanetizer.Tools
 {
-    class RotationTool : Tool
+    class RotationTool : BasicTransformTool
     {
+        public override ToolType toolType => ToolType.Rotate;
+
         public RotationTool()
         {
-            float length = 1.5f;
+            const float length = 1.5f;
 
-            vb = new float[]{
+            vb = new[]{
                 -length,    0,          0,
                 length,     0,          0,
                 0,          -length,    0,
@@ -46,9 +49,10 @@ namespace Replanetizer.Tools
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(0, 0, 1, 1));
             GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
         }
-        public override ToolType GetToolType()
+
+        public override void Transform(LevelObject obj, Vector3 vec)
         {
-            return ToolType.Rotate;
+            obj.Rotate(vec);
         }
     }
 }

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -34,7 +34,7 @@ namespace Replanetizer.Tools
         {
             GetVbo();
 
-            Matrix4 modelMatrix = Matrix4.CreateTranslation(position);
+            var modelMatrix = GetModelMatrix(position, frame);
             GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref modelMatrix);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -14,7 +14,7 @@ namespace Replanetizer.Tools
 {
     class RotationTool : BasicTransformTool
     {
-        public override ToolType toolType => ToolType.Rotate;
+        public override ToolType toolType => ToolType.Rotation;
 
         public RotationTool(Toolbox toolbox) : base(toolbox)
         {

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -30,12 +30,11 @@ namespace Replanetizer.Tools
             };
         }
 
-        public override void Render(Vector3 position, LevelFrame frame)
+        public override void Render(Matrix4 mat, LevelFrame frame)
         {
             GetVbo();
 
-            var modelMatrix = GetModelMatrix(position, frame);
-            GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref modelMatrix);
+            GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref mat);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(1, 0, 0, 1));

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -52,7 +52,19 @@ namespace Replanetizer.Tools
 
         public override void Transform(LevelObject obj, Vector3 vec, Vector3 pivot)
         {
-            obj.Rotate(vec);
+            if (transformationSpace == TransformationSpace.GLOBAL)
+            {
+                var mat = obj.modelMatrix;
+                var trans = Matrix4.CreateTranslation(pivot);
+                var rot = Matrix4.CreateFromQuaternion(Quaternion.FromEulerAngles(vec));
+                mat = mat * trans.Inverted() * rot * trans;
+                obj.SetFromMatrix(mat);
+            }
+            else if (transformationSpace == TransformationSpace.LOCAL)
+            {
+                // Not implemented yet. This should rotate about the pivot
+                // point in the object's local space
+            }
         }
     }
 }

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -55,12 +55,12 @@ namespace Replanetizer.Tools
             var mat = obj.modelMatrix;
             var rotPivot = Matrix4.CreateFromQuaternion(Quaternion.FromEulerAngles(vec));
 
-            if (toolbox.transformationSpace == TransformationSpace.Global)
+            if (toolbox.transformSpace == TransformSpace.Global)
             {
                 var transPivot = Matrix4.CreateTranslation(pivot);
                 mat = mat * transPivot.Inverted() * rotPivot * transPivot;
             }
-            else if (toolbox.transformationSpace == TransformationSpace.Local)
+            else if (toolbox.transformSpace == TransformSpace.Local)
             {
                 // TODO this is not stable. we need to store the pivot through the
                 //   duration of a transformation action

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -62,8 +62,6 @@ namespace Replanetizer.Tools
             }
             else if (toolbox.transformSpace == TransformSpace.Local)
             {
-                // TODO this is not stable. we need to store the pivot through the
-                //   duration of a transformation action
                 var transPivotOffset = Matrix4.CreateTranslation(obj.position - pivot);
                 var transObj = Matrix4.CreateTranslation(obj.position);
                 var rotObj = Matrix4.CreateFromQuaternion(obj.rotation);

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -55,12 +55,12 @@ namespace Replanetizer.Tools
             var mat = obj.modelMatrix;
             var rotPivot = Matrix4.CreateFromQuaternion(Quaternion.FromEulerAngles(vec));
 
-            if (transformationSpace == TransformationSpace.GLOBAL)
+            if (transformationSpace == TransformationSpace.Global)
             {
                 var transPivot = Matrix4.CreateTranslation(pivot);
                 mat = mat * transPivot.Inverted() * rotPivot * transPivot;
             }
-            else if (transformationSpace == TransformationSpace.LOCAL)
+            else if (transformationSpace == TransformationSpace.Local)
             {
                 var transPivotOffset = Matrix4.CreateTranslation(obj.position - pivot);
                 var transObj = Matrix4.CreateTranslation(obj.position);

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -16,7 +16,7 @@ namespace Replanetizer.Tools
     {
         public override ToolType toolType => ToolType.Rotate;
 
-        public RotationTool()
+        public RotationTool(Toolbox toolbox) : base(toolbox)
         {
             const float length = 1.5f;
 
@@ -55,13 +55,15 @@ namespace Replanetizer.Tools
             var mat = obj.modelMatrix;
             var rotPivot = Matrix4.CreateFromQuaternion(Quaternion.FromEulerAngles(vec));
 
-            if (transformationSpace == TransformationSpace.Global)
+            if (toolbox.transformationSpace == TransformationSpace.Global)
             {
                 var transPivot = Matrix4.CreateTranslation(pivot);
                 mat = mat * transPivot.Inverted() * rotPivot * transPivot;
             }
-            else if (transformationSpace == TransformationSpace.Local)
+            else if (toolbox.transformationSpace == TransformationSpace.Local)
             {
+                // TODO this is not stable. we need to store the pivot through the
+                //   duration of a transformation action
                 var transPivotOffset = Matrix4.CreateTranslation(obj.position - pivot);
                 var transObj = Matrix4.CreateTranslation(obj.position);
                 var rotObj = Matrix4.CreateFromQuaternion(obj.rotation);

--- a/Replanetizer/Tools/ScalingTool.cs
+++ b/Replanetizer/Tools/ScalingTool.cs
@@ -52,7 +52,7 @@ namespace Replanetizer.Tools
 
         public override void Transform(LevelObject obj, Vector3 vec)
         {
-            obj.Scale(vec + Vector3.One);
+            obj.Scale(vec);
         }
 
         protected override Vector3 ProcessVec(Vector3 direction, Vector3 magnitude)

--- a/Replanetizer/Tools/ScalingTool.cs
+++ b/Replanetizer/Tools/ScalingTool.cs
@@ -34,7 +34,7 @@ namespace Replanetizer.Tools
         {
             GetVbo();
 
-            Matrix4 modelMatrix = Matrix4.CreateTranslation(position);
+            var modelMatrix = GetModelMatrix(position, frame);
             GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref modelMatrix);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);

--- a/Replanetizer/Tools/ScalingTool.cs
+++ b/Replanetizer/Tools/ScalingTool.cs
@@ -30,12 +30,11 @@ namespace Replanetizer.Tools
             };
         }
 
-        public override void Render(Vector3 position, LevelFrame frame)
+        public override void Render(Matrix4 mat, LevelFrame frame)
         {
             GetVbo();
 
-            var modelMatrix = GetModelMatrix(position, frame);
-            GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref modelMatrix);
+            GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref mat);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(1, 0, 0, 1));

--- a/Replanetizer/Tools/ScalingTool.cs
+++ b/Replanetizer/Tools/ScalingTool.cs
@@ -50,7 +50,7 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
         }
 
-        public override void Transform(LevelObject obj, Vector3 vec)
+        public override void Transform(LevelObject obj, Vector3 vec, Vector3 pivot)
         {
             obj.Scale(vec);
         }

--- a/Replanetizer/Tools/ScalingTool.cs
+++ b/Replanetizer/Tools/ScalingTool.cs
@@ -16,7 +16,7 @@ namespace Replanetizer.Tools
     {
         public override ToolType toolType => ToolType.Scale;
 
-        public ScalingTool()
+        public ScalingTool(Toolbox toolbox) : base(toolbox)
         {
             const float length = 1f;
 

--- a/Replanetizer/Tools/ScalingTool.cs
+++ b/Replanetizer/Tools/ScalingTool.cs
@@ -14,7 +14,7 @@ namespace Replanetizer.Tools
 {
     class ScalingTool : BasicTransformTool
     {
-        public override ToolType toolType => ToolType.Scale;
+        public override ToolType toolType => ToolType.Scaling;
 
         public ScalingTool(Toolbox toolbox) : base(toolbox)
         {

--- a/Replanetizer/Tools/ScalingTool.cs
+++ b/Replanetizer/Tools/ScalingTool.cs
@@ -5,19 +5,22 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using LibReplanetizer.LevelObjects;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using Replanetizer.Frames;
 
 namespace Replanetizer.Tools
 {
-    class ScalingTool : Tool
+    class ScalingTool : BasicTransformTool
     {
+        public override ToolType toolType => ToolType.Scale;
+
         public ScalingTool()
         {
-            float length = 1f;
+            const float length = 1f;
 
-            vb = new float[]{
+            vb = new[]{
                 -length,    0,          0,
                 length,     0,          0,
                 0,          -length,    0,
@@ -47,9 +50,14 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
         }
 
-        public override ToolType GetToolType()
+        public override void Transform(LevelObject obj, Vector3 vec)
         {
-            return ToolType.Scale;
+            obj.Scale(vec + Vector3.One);
+        }
+
+        protected override Vector3 ProcessVec(Vector3 direction, Vector3 magnitude)
+        {
+            return base.ProcessVec(direction, magnitude) + Vector3.One;
         }
     }
 }

--- a/Replanetizer/Tools/SpecialTransformTool.cs
+++ b/Replanetizer/Tools/SpecialTransformTool.cs
@@ -9,5 +9,8 @@ namespace Replanetizer.Tools
 {
     public abstract class SpecialTransformTool : Tool
     {
+        protected SpecialTransformTool(Toolbox toolbox) : base(toolbox)
+        {
+        }
     }
 }

--- a/Replanetizer/Tools/SpecialTransformTool.cs
+++ b/Replanetizer/Tools/SpecialTransformTool.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+namespace Replanetizer.Tools
+{
+    public abstract class SpecialTransformTool : Tool
+    {
+    }
+}

--- a/Replanetizer/Tools/Tool.cs
+++ b/Replanetizer/Tools/Tool.cs
@@ -28,6 +28,7 @@ namespace Replanetizer.Tools
 
         protected int vbo;
         protected float[] vb;
+        private const float SCREEN_SPACE_SCALE = 0.06f;
 
         protected void GetVbo()
         {
@@ -43,6 +44,15 @@ namespace Replanetizer.Tools
             }
 
             GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, sizeof(float) * 3, 0);
+        }
+
+        /// <summary>
+        /// Get the model matrix, scaled by camera distance
+        /// </summary>
+        protected Matrix4 GetModelMatrix(Vector3 position, LevelFrame frame)
+        {
+            float camDist = (frame.camera.position - position).LengthFast;
+            return Matrix4.CreateScale(camDist * SCREEN_SPACE_SCALE) * Matrix4.CreateTranslation(position);
         }
 
         public abstract ToolType toolType { get; }

--- a/Replanetizer/Tools/Tool.cs
+++ b/Replanetizer/Tools/Tool.cs
@@ -13,15 +13,6 @@ namespace Replanetizer.Tools
 {
     public abstract class Tool
     {
-        public enum ToolType
-        {
-            None,
-            Translate,
-            Rotate,
-            Scale,
-            VertexTranslator
-        }
-
         public float transformMultipier { get; set; } = 50f;
         public TransformationSpace transformationSpace { get; set; } = TransformationSpace.Global;
         public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.Median;

--- a/Replanetizer/Tools/Tool.cs
+++ b/Replanetizer/Tools/Tool.cs
@@ -14,12 +14,17 @@ namespace Replanetizer.Tools
     public abstract class Tool
     {
         public float transformMultiplier { get; set; } = 50f;
-        public TransformationSpace transformationSpace { get; set; } = TransformationSpace.Global;
-        public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.Median;
+
+        protected Toolbox toolbox { get; set; }
 
         protected int vbo;
         protected float[] vb;
         private const float SCREEN_SPACE_SCALE = 0.06f;
+
+        public Tool(Toolbox toolbox)
+        {
+            this.toolbox = toolbox;
+        }
 
         protected void GetVbo()
         {

--- a/Replanetizer/Tools/Tool.cs
+++ b/Replanetizer/Tools/Tool.cs
@@ -13,7 +13,7 @@ namespace Replanetizer.Tools
 {
     public abstract class Tool
     {
-        public float transformMultipier { get; set; } = 50f;
+        public float transformMultiplier { get; set; } = 50f;
         public TransformationSpace transformationSpace { get; set; } = TransformationSpace.Global;
         public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.Median;
 
@@ -51,7 +51,7 @@ namespace Replanetizer.Tools
 
         protected virtual Vector3 ProcessVec(Vector3 direction, Vector3 magnitude)
         {
-            return direction * magnitude * transformMultipier;
+            return direction * magnitude * transformMultiplier;
         }
 
         public virtual void Reset()

--- a/Replanetizer/Tools/Tool.cs
+++ b/Replanetizer/Tools/Tool.cs
@@ -23,8 +23,8 @@ namespace Replanetizer.Tools
         }
 
         public float transformMultipier { get; set; } = 50f;
-        public TransformationSpace transformationSpace { get; set; } = TransformationSpace.GLOBAL;
-        public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.MEDIAN;
+        public TransformationSpace transformationSpace { get; set; } = TransformationSpace.Global;
+        public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.Median;
 
         protected int vbo;
         protected float[] vb;

--- a/Replanetizer/Tools/Tool.cs
+++ b/Replanetizer/Tools/Tool.cs
@@ -22,6 +22,10 @@ namespace Replanetizer.Tools
             VertexTranslator
         }
 
+        public float transformMultipier { get; set; } = 50f;
+        public TransformationSpace transformationSpace { get; set; } = TransformationSpace.GLOBAL;
+        public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.MEDIAN;
+
         protected int vbo;
         protected float[] vb;
 
@@ -41,7 +45,16 @@ namespace Replanetizer.Tools
             GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, sizeof(float) * 3, 0);
         }
 
-        public abstract ToolType GetToolType();
+        public abstract ToolType toolType { get; }
         public abstract void Render(Vector3 position, LevelFrame frame);
+
+        protected virtual Vector3 ProcessVec(Vector3 direction, Vector3 magnitude)
+        {
+            return direction * magnitude * transformMultipier;
+        }
+
+        public virtual void Reset()
+        {
+        }
     }
 }

--- a/Replanetizer/Tools/ToolType.cs
+++ b/Replanetizer/Tools/ToolType.cs
@@ -9,10 +9,10 @@ namespace Replanetizer.Tools
 {
     public enum ToolType
     {
-        None,
-        Translate,
-        Rotate,
-        Scale,
-        VertexTranslator
+        None = 0,
+        Translation,
+        Rotation,
+        Scaling,
+        VertexTranslation
     }
 }

--- a/Replanetizer/Tools/ToolType.cs
+++ b/Replanetizer/Tools/ToolType.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+namespace Replanetizer.Tools
+{
+    public enum ToolType
+    {
+        None,
+        Translate,
+        Rotate,
+        Scale,
+        VertexTranslator
+    }
+}

--- a/Replanetizer/Tools/Toolbox.cs
+++ b/Replanetizer/Tools/Toolbox.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using System;
+
+namespace Replanetizer.Tools
+{
+    public class ToolChangedEventArgs : EventArgs
+    {
+        public ToolType toolType { get; }
+
+        public ToolChangedEventArgs(ToolType toolType)
+        {
+            this.toolType = toolType;
+        }
+    }
+
+    public class Toolbox
+    {
+        public Tool? tool => _tool;
+        public ToolType type => _type;
+        public TransformationSpace transformationSpace { get; set; } = TransformationSpace.Global;
+        public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.Median;
+
+        public event EventHandler<ToolChangedEventArgs>? ToolChanged;
+
+        private Tool? _tool;
+        private ToolType _type = ToolType.None;
+        private readonly TranslationTool TRANSLATION_TOOL;
+        private readonly RotationTool ROTATION_TOOL;
+        private readonly ScalingTool SCALING_TOOL;
+        private readonly VertexTranslationTool VERTEX_TRANSLATION_TOOL;
+
+        public Toolbox()
+        {
+            TRANSLATION_TOOL = new TranslationTool(this);
+            ROTATION_TOOL = new RotationTool(this);
+            SCALING_TOOL = new ScalingTool(this);
+            VERTEX_TRANSLATION_TOOL = new VertexTranslationTool(this);
+        }
+
+        public void ChangeTool(ToolType toolType)
+        {
+            if (toolType == type)
+                return;
+            _type = toolType;
+
+            if (toolType == ToolType.None)
+                _tool = null;
+            else if (toolType == ToolType.Translate)
+                _tool = TRANSLATION_TOOL;
+            else if (toolType == ToolType.Rotate)
+                _tool = ROTATION_TOOL;
+            else if (toolType == ToolType.Scale)
+                _tool = SCALING_TOOL;
+            else if (toolType == ToolType.VertexTranslator)
+                _tool = VERTEX_TRANSLATION_TOOL;
+
+            _tool?.Reset();
+            OnToolChanged(new ToolChangedEventArgs(toolType));
+        }
+
+        private void OnToolChanged(ToolChangedEventArgs e)
+        {
+            ToolChanged?.Invoke(this, e);
+        }
+    }
+}

--- a/Replanetizer/Tools/Toolbox.cs
+++ b/Replanetizer/Tools/Toolbox.cs
@@ -51,13 +51,13 @@ namespace Replanetizer.Tools
 
             if (toolType == ToolType.None)
                 _tool = null;
-            else if (toolType == ToolType.Translate)
+            else if (toolType == ToolType.Translation)
                 _tool = TRANSLATION_TOOL;
-            else if (toolType == ToolType.Rotate)
+            else if (toolType == ToolType.Rotation)
                 _tool = ROTATION_TOOL;
-            else if (toolType == ToolType.Scale)
+            else if (toolType == ToolType.Scaling)
                 _tool = SCALING_TOOL;
-            else if (toolType == ToolType.VertexTranslator)
+            else if (toolType == ToolType.VertexTranslation)
                 _tool = VERTEX_TRANSLATION_TOOL;
 
             _tool?.Reset();

--- a/Replanetizer/Tools/Toolbox.cs
+++ b/Replanetizer/Tools/Toolbox.cs
@@ -23,7 +23,7 @@ namespace Replanetizer.Tools
     {
         public Tool? tool => _tool;
         public ToolType type => _type;
-        public TransformationSpace transformationSpace { get; set; } = TransformationSpace.Global;
+        public TransformSpace transformSpace { get; set; } = TransformSpace.Global;
         public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.Median;
 
         public event EventHandler<ToolChangedEventArgs>? ToolChanged;

--- a/Replanetizer/Tools/TransformSpace.cs
+++ b/Replanetizer/Tools/TransformSpace.cs
@@ -7,7 +7,7 @@
 
 namespace Replanetizer.Tools
 {
-    public enum TransformationSpace
+    public enum TransformSpace
     {
         Global = 0,
         Local

--- a/Replanetizer/Tools/TransformSpace.cs
+++ b/Replanetizer/Tools/TransformSpace.cs
@@ -5,11 +5,17 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using Replanetizer.Utils;
+
 namespace Replanetizer.Tools
 {
-    public enum TransformSpace
+    public class TransformSpace : EnhancedEnum<TransformSpace>
     {
-        Global = 0,
-        Local
+        public static readonly TransformSpace Global = new(0, "Global");
+        public static readonly TransformSpace Local = new(1, "Local");
+
+        public TransformSpace(int key, string humanName) : base(key, humanName)
+        {
+        }
     }
 }

--- a/Replanetizer/Tools/TransformationSpace.cs
+++ b/Replanetizer/Tools/TransformationSpace.cs
@@ -9,7 +9,7 @@ namespace Replanetizer.Tools
 {
     public enum TransformationSpace
     {
-        GLOBAL,
-        LOCAL
+        Global = 0,
+        Local
     }
 }

--- a/Replanetizer/Tools/TransformationSpace.cs
+++ b/Replanetizer/Tools/TransformationSpace.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+namespace Replanetizer.Tools
+{
+    public enum TransformationSpace
+    {
+        GLOBAL,
+        LOCAL
+    }
+}

--- a/Replanetizer/Tools/TranslationTool.cs
+++ b/Replanetizer/Tools/TranslationTool.cs
@@ -105,7 +105,21 @@ namespace Replanetizer.Tools
 
         public override void Transform(LevelObject obj, Vector3 vec, Vector3 pivot)
         {
-            obj.Translate(vec);
+            var mat = obj.modelMatrix;
+
+            if (toolbox.transformationSpace == TransformationSpace.Global)
+            {
+                var trans = Matrix4.CreateTranslation(vec);
+                mat = mat * trans;
+            }
+            else if (toolbox.transformationSpace == TransformationSpace.Local)
+            {
+                // Compensate for scale diminishing the strength of the translation
+                var trans = Matrix4.CreateTranslation(vec/obj.scale.LengthFast);
+                mat = trans * mat;
+            }
+
+            obj.SetFromMatrix(mat);
         }
     }
 }

--- a/Replanetizer/Tools/TranslationTool.cs
+++ b/Replanetizer/Tools/TranslationTool.cs
@@ -103,7 +103,7 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.Triangles, 33, 3);
         }
 
-        public override void Transform(LevelObject obj, Vector3 vec)
+        public override void Transform(LevelObject obj, Vector3 vec, Vector3 pivot)
         {
             obj.Translate(vec);
         }

--- a/Replanetizer/Tools/TranslationTool.cs
+++ b/Replanetizer/Tools/TranslationTool.cs
@@ -74,12 +74,11 @@ namespace Replanetizer.Tools
             };
         }
 
-        public override void Render(Vector3 position, LevelFrame frame)
+        public override void Render(Matrix4 mat, LevelFrame frame)
         {
             GetVbo();
 
-            var modelMatrix = GetModelMatrix(position, frame);
-            GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref modelMatrix);
+            GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref mat);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(1, 0, 0, 1));

--- a/Replanetizer/Tools/TranslationTool.cs
+++ b/Replanetizer/Tools/TranslationTool.cs
@@ -5,19 +5,22 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using LibReplanetizer.LevelObjects;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using Replanetizer.Frames;
 
 namespace Replanetizer.Tools
 {
-    class TranslationTool : Tool
+    class TranslationTool : BasicTransformTool
     {
+        public override ToolType toolType => ToolType.Translate;
+
         public TranslationTool()
         {
-            float length = 2.0f;
+            const float length = 2.0f;
 
-            vb = new float[]{
+            vb = new[]{
                 length / 2,     - length / 3,   0,
                 length / 2,     length / 3,     0,
                 length,         0,              0,
@@ -100,9 +103,9 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.Triangles, 33, 3);
         }
 
-        public override ToolType GetToolType()
+        public override void Transform(LevelObject obj, Vector3 vec)
         {
-            return ToolType.Translate;
+            obj.Translate(vec);
         }
     }
 }

--- a/Replanetizer/Tools/TranslationTool.cs
+++ b/Replanetizer/Tools/TranslationTool.cs
@@ -14,7 +14,7 @@ namespace Replanetizer.Tools
 {
     class TranslationTool : BasicTransformTool
     {
-        public override ToolType toolType => ToolType.Translate;
+        public override ToolType toolType => ToolType.Translation;
 
         public TranslationTool(Toolbox toolbox) : base(toolbox)
         {

--- a/Replanetizer/Tools/TranslationTool.cs
+++ b/Replanetizer/Tools/TranslationTool.cs
@@ -16,7 +16,7 @@ namespace Replanetizer.Tools
     {
         public override ToolType toolType => ToolType.Translate;
 
-        public TranslationTool()
+        public TranslationTool(Toolbox toolbox) : base(toolbox)
         {
             const float length = 2.0f;
 

--- a/Replanetizer/Tools/TranslationTool.cs
+++ b/Replanetizer/Tools/TranslationTool.cs
@@ -78,7 +78,7 @@ namespace Replanetizer.Tools
         {
             GetVbo();
 
-            Matrix4 modelMatrix = Matrix4.CreateTranslation(position);
+            var modelMatrix = GetModelMatrix(position, frame);
             GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref modelMatrix);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);

--- a/Replanetizer/Tools/TranslationTool.cs
+++ b/Replanetizer/Tools/TranslationTool.cs
@@ -107,12 +107,12 @@ namespace Replanetizer.Tools
         {
             var mat = obj.modelMatrix;
 
-            if (toolbox.transformationSpace == TransformationSpace.Global)
+            if (toolbox.transformSpace == TransformSpace.Global)
             {
                 var trans = Matrix4.CreateTranslation(vec);
                 mat = mat * trans;
             }
-            else if (toolbox.transformationSpace == TransformationSpace.Local)
+            else if (toolbox.transformSpace == TransformSpace.Local)
             {
                 // Compensate for scale diminishing the strength of the translation
                 var trans = Matrix4.CreateTranslation(vec/obj.scale.LengthFast);

--- a/Replanetizer/Tools/VertexTranslationTool.cs
+++ b/Replanetizer/Tools/VertexTranslationTool.cs
@@ -17,7 +17,7 @@ namespace Replanetizer.Tools
     {
         public override ToolType toolType => ToolType.VertexTranslator;
 
-        public VertexTranslationTool()
+        public VertexTranslationTool(Toolbox toolbox) : base(toolbox)
         {
             const float length = 0.7f;
 

--- a/Replanetizer/Tools/VertexTranslationTool.cs
+++ b/Replanetizer/Tools/VertexTranslationTool.cs
@@ -5,19 +5,23 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using LibReplanetizer.LevelObjects;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using Replanetizer.Frames;
+using Replanetizer.Utils;
 
 namespace Replanetizer.Tools
 {
-    class VertexTranslationTool : Tool
+    class VertexTranslationTool : SpecialTransformTool
     {
+        public override ToolType toolType => ToolType.VertexTranslator;
+
         public VertexTranslationTool()
         {
             float length = 0.7f;
 
-            vb = new float[]{
+            vb = new[]{
                 -length,    0,          0,
                 length,     0,          0,
                 0,          -length,    0,
@@ -47,9 +51,20 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
         }
 
-        public override ToolType GetToolType()
+        public void Transform(LevelObject obj, Vector3 vec, int vertexIndex)
         {
-            return ToolType.VertexTranslator;
+            if (obj is not Spline spline)
+                return;
+
+            spline.TranslateVertex(vertexIndex, vec);
+        }
+
+        public void Transform(
+            Selection selection, Vector3 direction, Vector3 magnitude, int vertexIndex)
+        {
+            Vector3 vec = ProcessVec(direction, magnitude);
+            if (selection.TryGetOne(out var obj))
+                Transform(obj, vec, vertexIndex);
         }
     }
 }

--- a/Replanetizer/Tools/VertexTranslationTool.cs
+++ b/Replanetizer/Tools/VertexTranslationTool.cs
@@ -15,7 +15,7 @@ namespace Replanetizer.Tools
 {
     class VertexTranslationTool : SpecialTransformTool
     {
-        public override ToolType toolType => ToolType.VertexTranslator;
+        public override ToolType toolType => ToolType.VertexTranslation;
 
         public int currentVertex { get; set; }
 

--- a/Replanetizer/Tools/VertexTranslationTool.cs
+++ b/Replanetizer/Tools/VertexTranslationTool.cs
@@ -35,7 +35,7 @@ namespace Replanetizer.Tools
         {
             GetVbo();
 
-            Matrix4 modelMatrix = Matrix4.CreateTranslation(position);
+            var modelMatrix = GetModelMatrix(position, frame);
             GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref modelMatrix);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);

--- a/Replanetizer/Tools/VertexTranslationTool.cs
+++ b/Replanetizer/Tools/VertexTranslationTool.cs
@@ -33,12 +33,11 @@ namespace Replanetizer.Tools
             };
         }
 
-        public override void Render(Vector3 position, LevelFrame frame)
+        public override void Render(Matrix4 mat, LevelFrame frame)
         {
             GetVbo();
 
-            var modelMatrix = GetModelMatrix(position, frame);
-            GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref modelMatrix);
+            GL.UniformMatrix4(frame.shaderIDTable.uniformModelToWorldMatrix, false, ref mat);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(1, 0, 0, 1));

--- a/Replanetizer/Tools/VertexTranslationTool.cs
+++ b/Replanetizer/Tools/VertexTranslationTool.cs
@@ -17,6 +17,8 @@ namespace Replanetizer.Tools
     {
         public override ToolType toolType => ToolType.VertexTranslator;
 
+        public int currentVertex { get; set; }
+
         public VertexTranslationTool(Toolbox toolbox) : base(toolbox)
         {
             const float length = 0.7f;
@@ -51,6 +53,16 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
         }
 
+        public void Render(Spline spline, LevelFrame frame)
+        {
+            Render(spline.GetVertex(currentVertex), frame);
+        }
+
+        public override void Reset()
+        {
+            currentVertex = 0;
+        }
+
         public void Transform(LevelObject obj, Vector3 vec, int vertexIndex)
         {
             if (obj is not Spline spline)
@@ -65,6 +77,19 @@ namespace Replanetizer.Tools
             Vector3 vec = ProcessVec(direction, magnitude);
             if (selection.TryGetOne(out var obj))
                 Transform(obj, vec, vertexIndex);
+        }
+
+        public void Transform(LevelObject obj, Vector3 vec)
+        {
+            Transform(obj, vec, currentVertex);
+        }
+
+        public void Transform(
+            Selection selection, Vector3 direction, Vector3 magnitude)
+        {
+            Vector3 vec = ProcessVec(direction, magnitude);
+            if (selection.TryGetOne(out var obj))
+                Transform(obj, vec);
         }
     }
 }

--- a/Replanetizer/Tools/VertexTranslationTool.cs
+++ b/Replanetizer/Tools/VertexTranslationTool.cs
@@ -19,7 +19,7 @@ namespace Replanetizer.Tools
 
         public VertexTranslationTool()
         {
-            float length = 0.7f;
+            const float length = 0.7f;
 
             vb = new[]{
                 -length,    0,          0,

--- a/Replanetizer/Utils/EnhancedEnum.cs
+++ b/Replanetizer/Utils/EnhancedEnum.cs
@@ -36,6 +36,15 @@ namespace Replanetizer.Utils
             return ENUM_VALUES[newIdx];
         }
 
+        public static T operator --(EnhancedEnum<T> a)
+        {
+            int newIdx = ENUM_VALUES.IndexOf((T) a) - 1;
+            // Negative modulus is weird, that's why I'm not using it here
+            if (newIdx == -1)
+                newIdx = ENUM_VALUES.Count - 1;
+            return ENUM_VALUES[newIdx];
+        }
+
         public static ReadOnlyCollection<T> GetValues()
         {
             return ENUM_VALUES.AsReadOnly();

--- a/Replanetizer/Utils/EnhancedEnum.cs
+++ b/Replanetizer/Utils/EnhancedEnum.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Replanetizer.Utils
+{
+    public abstract class EnhancedEnum<T> where T : EnhancedEnum<T>
+    {
+        protected static readonly List<T> ENUM_VALUES = new();
+        protected static readonly HashSet<int> KEYS_SET = new();
+
+        public readonly int KEY;
+        public readonly string HUMAN_NAME;
+
+        public EnhancedEnum(int key, string humanName)
+        {
+            if (KEYS_SET.Contains(key))
+                throw new ArgumentException($"Enum already contains a key {key}");
+            KEYS_SET.Add(key);
+
+            KEY = key;
+            HUMAN_NAME = humanName;
+            ENUM_VALUES.Add((T) this);
+        }
+
+        public static T operator ++(EnhancedEnum<T> a)
+        {
+            int newIdx = (ENUM_VALUES.IndexOf((T) a) + 1) % ENUM_VALUES.Count;
+            return ENUM_VALUES[newIdx];
+        }
+
+        public static ReadOnlyCollection<T> GetValues()
+        {
+            return ENUM_VALUES.AsReadOnly();
+        }
+
+        public static T? GetByKey(int key)
+        {
+            foreach (T t in ENUM_VALUES)
+                if (t.KEY == key)
+                    return t;
+            return null;
+        }
+
+        public override string ToString()
+        {
+            return HUMAN_NAME;
+        }
+    }
+}

--- a/Replanetizer/Utils/Keymap.cs
+++ b/Replanetizer/Utils/Keymap.cs
@@ -30,8 +30,8 @@ namespace Replanetizer.Utils
         ToolVertexTranslator,
 
         // Misc
-        Delete,
-        MultiSelectModifier,
+        DeleteObject,
+        MultiSelectModifier
     }
 
     public readonly struct KeyCombo
@@ -93,7 +93,7 @@ namespace Replanetizer.Utils
                 { Keybinds.ToolScaling, new[] { new KeyCombo(Keys.D3) } },
                 { Keybinds.ToolVertexTranslator, new[] { new KeyCombo(Keys.D4) } },
                 // Misc
-                { Keybinds.Delete, new[] { new KeyCombo(Keys.Delete) } },
+                { Keybinds.DeleteObject, new[] { new KeyCombo(Keys.Delete) } },
                 {
                     Keybinds.MultiSelectModifier,
                     new[] { new KeyCombo(Keys.LeftShift), new KeyCombo(Keys.RightShift) }

--- a/Replanetizer/Utils/Keymap.cs
+++ b/Replanetizer/Utils/Keymap.cs
@@ -70,7 +70,7 @@ namespace Replanetizer.Utils
 
             char keyChar = (char) key;
             if (keyChar >= 0x21 && keyChar <= 0x7e)
-                return keyChar.ToString();
+                return keyChar.ToString().ToUpper();
 
             return key.ToString();
         }

--- a/Replanetizer/Utils/Keymap.cs
+++ b/Replanetizer/Utils/Keymap.cs
@@ -13,6 +13,9 @@ using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace Replanetizer.Utils
 {
+    /// <summary>
+    /// Keybind actions for this application
+    /// </summary>
     public enum Keybinds
     {
         // Camera movement
@@ -36,23 +39,40 @@ namespace Replanetizer.Utils
         MultiSelectModifier
     }
 
+    /// <summary>
+    /// Represents a combination of modifier keys and a base key (e.g. "W",
+    /// "Ctrl+Z", "Ctrl+Shift+P")
+    /// </summary>
     public readonly struct KeyCombo
     {
         public Keys[] modifiers { get; }
         public Keys key { get; }
 
+        /// <summary>
+        /// A KeyCombo with only one key
+        /// </summary>
         public KeyCombo(Keys key)
         {
             this.key = key;
             modifiers = Array.Empty<Keys>();
         }
 
+        /// <summary>
+        /// A KeyCombo with one base key and one or more modifier keys (Ctrl,
+        /// Shift, Alt)
+        /// </summary>
+        /// <param name="modifiersAndKey">
+        /// a list of multiple modifier keys and one base key
+        /// </param>
         public KeyCombo(params Keys[] modifiersAndKey)
         {
             key = modifiersAndKey[^1];
             modifiers = modifiersAndKey[..^1];
         }
 
+        /// <summary>
+        /// Format a key into a human-readable form
+        /// </summary>
         private static string FormatKey(Keys key)
         {
             if (key is Keys.LeftControl)
@@ -75,6 +95,9 @@ namespace Replanetizer.Utils
             return key.ToString();
         }
 
+        /// <summary>
+        /// Format this KeyCombo into a human-readable string (e.g. "Ctrl+P")
+        /// </summary>
         public override string ToString()
         {
             var sb = new StringBuilder();
@@ -86,6 +109,9 @@ namespace Replanetizer.Utils
             return sb.Append(FormatKey(key)).ToString();
         }
 
+        /// <summary>
+        /// Get whether this KeyCombo is currently held down
+        /// </summary>
         public bool IsDown(Window wnd)
         {
             foreach (Keys modifier in modifiers)
@@ -94,6 +120,9 @@ namespace Replanetizer.Utils
             return wnd.IsKeyDown(key);
         }
 
+        /// <summary>
+        /// Get whether this KeyCombo just started being pressed
+        /// </summary>
         public bool IsPressed(Window wnd)
         {
             foreach (Keys modifier in modifiers)
@@ -102,6 +131,9 @@ namespace Replanetizer.Utils
             return wnd.IsKeyPressed(key);
         }
 
+        /// <summary>
+        /// Get whether this KeyCombo just finished being pressed
+        /// </summary>
         public bool IsReleased(Window wnd)
         {
             foreach (Keys modifier in modifiers)
@@ -111,11 +143,19 @@ namespace Replanetizer.Utils
         }
     }
 
+    /// <summary>
+    /// A class which handles the mapping of keypresses to keybinds. This allows
+    /// you to define actions in a key-agnostic way, and makes it easier to
+    /// change the keys associated with a given action.
+    /// </summary>
     public class Keymap
     {
         public Window wnd { get; set; }
         public IDictionary<Keybinds, KeyCombo[]> keymap { get; set; }
 
+        /// <summary>
+        /// The default keymap for this application
+        /// </summary>
         public static readonly ImmutableDictionary<Keybinds, KeyCombo[]> DEFAULT_KEYMAP =
             new Dictionary<Keybinds, KeyCombo[]>
             {
@@ -147,6 +187,9 @@ namespace Replanetizer.Utils
             this.keymap = keymap;
         }
 
+        /// <summary>
+        /// Get whether <param name="keybind"/> is currently held down
+        /// </summary>
         public bool IsDown(Keybinds keybind)
         {
             foreach (KeyCombo keyCombo in keymap[keybind])
@@ -158,6 +201,9 @@ namespace Replanetizer.Utils
             return false;
         }
 
+        /// <summary>
+        /// Get whether <paramref name="keybind"/> just started being pressed
+        /// </summary>
         public bool IsPressed(Keybinds keybind)
         {
             foreach (KeyCombo keyCombo in keymap[keybind])
@@ -169,6 +215,9 @@ namespace Replanetizer.Utils
             return false;
         }
 
+        /// <summary>
+        /// Get whether <paramref name="keybind"/> just finished being pressed
+        /// </summary>
         public bool IsReleased(Keybinds keybind)
         {
             foreach (KeyCombo keyCombo in keymap[keybind])
@@ -180,6 +229,10 @@ namespace Replanetizer.Utils
             return false;
         }
 
+        /// <summary>
+        /// Get the human-readable name of <paramref name="keybind"/> under the
+        /// current keymap (e.g. "Ctrl+Y / Ctrl+Shift+Z")
+        /// </summary>
         public string NameOf(Keybinds keybind)
         {
             if (!keymap.TryGetValue(keybind, out var keyCombos))

--- a/Replanetizer/Utils/Keymap.cs
+++ b/Replanetizer/Utils/Keymap.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Text;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace Replanetizer.Utils
@@ -50,6 +51,39 @@ namespace Replanetizer.Utils
         {
             key = modifiersAndKey[^1];
             modifiers = modifiersAndKey[..^1];
+        }
+
+        private static string FormatKey(Keys key)
+        {
+            if (key is Keys.LeftControl)
+                return "Ctrl";
+            if (key is Keys.RightControl)
+                return "RCtrl";
+            if (key is Keys.LeftShift)
+                return "Shift";
+            if (key is Keys.RightShift)
+                return "RShift";
+            if (key is Keys.LeftAlt)
+                return "Alt";
+            if (key is Keys.RightAlt)
+                return "RAlt";
+
+            char keyChar = (char) key;
+            if (keyChar >= 0x21 && keyChar <= 0x7e)
+                return keyChar.ToString();
+
+            return key.ToString();
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            foreach (var mod in modifiers)
+            {
+                sb.Append(FormatKey(mod));
+                sb.Append('+');
+            }
+            return sb.Append(FormatKey(key)).ToString();
         }
 
         public bool IsDown(Window wnd)
@@ -144,6 +178,13 @@ namespace Replanetizer.Utils
             }
 
             return false;
+        }
+
+        public string NameOf(Keybinds keybind)
+        {
+            if (!keymap.TryGetValue(keybind, out var keyCombos))
+                return "ERR_NO_KEY";
+            return new StringBuilder().AppendJoin(" ", keyCombos).ToString();
         }
     }
 }

--- a/Replanetizer/Utils/Keymap.cs
+++ b/Replanetizer/Utils/Keymap.cs
@@ -106,7 +106,7 @@ namespace Replanetizer.Utils
             this.keymap = keymap;
         }
 
-        public bool IsKeybindDown(Keybinds keybind)
+        public bool IsDown(Keybinds keybind)
         {
             foreach (KeyCombo keyCombo in keymap[keybind])
             {
@@ -117,7 +117,7 @@ namespace Replanetizer.Utils
             return false;
         }
 
-        public bool IsKeybindPressed(Keybinds keybind)
+        public bool IsPressed(Keybinds keybind)
         {
             foreach (KeyCombo keyCombo in keymap[keybind])
             {
@@ -128,7 +128,7 @@ namespace Replanetizer.Utils
             return false;
         }
 
-        public bool IsKeybindReleased(Keybinds keybind)
+        public bool IsReleased(Keybinds keybind)
         {
             foreach (KeyCombo keyCombo in keymap[keybind])
             {

--- a/Replanetizer/Utils/Keymap.cs
+++ b/Replanetizer/Utils/Keymap.cs
@@ -184,7 +184,7 @@ namespace Replanetizer.Utils
         {
             if (!keymap.TryGetValue(keybind, out var keyCombos))
                 return "ERR_NO_KEY";
-            return new StringBuilder().AppendJoin(" ", keyCombos).ToString();
+            return new StringBuilder().AppendJoin(" / ", keyCombos).ToString();
         }
     }
 }

--- a/Replanetizer/Utils/Keymap.cs
+++ b/Replanetizer/Utils/Keymap.cs
@@ -49,9 +49,7 @@ namespace Replanetizer.Utils
         public KeyCombo(params Keys[] modifiersAndKey)
         {
             key = modifiersAndKey[^1];
-            modifiers = new Keys[modifiersAndKey.Length - 1];
-            Array.ConstrainedCopy(modifiersAndKey, 0, modifiers, 0, modifiersAndKey.Length - 1);
-            modifiers = modifiersAndKey;
+            modifiers = modifiersAndKey[..^1];
         }
 
         public bool IsDown(Window wnd)

--- a/Replanetizer/Utils/Keymap.cs
+++ b/Replanetizer/Utils/Keymap.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using OpenTK.Windowing.GraphicsLibraryFramework;
+
+namespace Replanetizer.Utils
+{
+    public enum Keybinds
+    {
+        // Camera movement
+        MoveForward,
+        MoveBackward,
+        MoveLeft,
+        MoveRight,
+        MoveUp,
+        MoveDown,
+        MoveFastModifier,
+
+        // Tools
+        ToolNone,
+        ToolTranslate,
+        ToolRotation,
+        ToolScaling,
+        ToolVertexTranslator,
+
+        // Misc
+        Delete,
+        MultiSelectModifier,
+    }
+
+    public readonly struct KeyCombo
+    {
+        public Keys[] modifiers { get; }
+        public Keys key { get; }
+
+        public KeyCombo(Keys key, params Keys[] modifiers)
+        {
+            this.key = key;
+            this.modifiers = modifiers;
+        }
+
+        public bool IsDown(Window wnd)
+        {
+            foreach (Keys modifier in modifiers)
+                if (!wnd.IsKeyDown(modifier))
+                    return false;
+            return wnd.IsKeyDown(key);
+        }
+
+        public bool IsPressed(Window wnd)
+        {
+            foreach (Keys modifier in modifiers)
+                if (!wnd.IsKeyDown(modifier) && !wnd.IsKeyPressed(modifier))
+                    return false;
+            return wnd.IsKeyPressed(key);
+        }
+
+        public bool IsReleased(Window wnd)
+        {
+            foreach (Keys modifier in modifiers)
+                if (!wnd.IsKeyDown(modifier) && !wnd.IsKeyReleased(modifier))
+                    return false;
+            return wnd.IsKeyReleased(key);
+        }
+    }
+
+    public class Keymap
+    {
+        public Window wnd { get; set; }
+        public IDictionary<Keybinds, KeyCombo[]> keymap { get; set; }
+
+        public static readonly ImmutableDictionary<Keybinds, KeyCombo[]> DEFAULT_KEYMAP =
+            new Dictionary<Keybinds, KeyCombo[]>
+            {
+                // Camera movement
+                { Keybinds.MoveForward, new[] { new KeyCombo(Keys.W) } },
+                { Keybinds.MoveBackward, new[] { new KeyCombo(Keys.S) } },
+                { Keybinds.MoveLeft, new[] { new KeyCombo(Keys.A) } },
+                { Keybinds.MoveRight, new[] { new KeyCombo(Keys.D) } },
+                { Keybinds.MoveUp, new[] { new KeyCombo(Keys.E) } },
+                { Keybinds.MoveDown, new[] { new KeyCombo(Keys.Q) } },
+                { Keybinds.MoveFastModifier, new[] { new KeyCombo(Keys.LeftShift) } },
+                // Tools
+                { Keybinds.ToolNone, new[] { new KeyCombo(Keys.D5) } },
+                { Keybinds.ToolTranslate, new[] { new KeyCombo(Keys.D1) } },
+                { Keybinds.ToolRotation, new[] { new KeyCombo(Keys.D2) } },
+                { Keybinds.ToolScaling, new[] { new KeyCombo(Keys.D3) } },
+                { Keybinds.ToolVertexTranslator, new[] { new KeyCombo(Keys.D4) } },
+                // Misc
+                { Keybinds.Delete, new[] { new KeyCombo(Keys.Delete) } },
+                {
+                    Keybinds.MultiSelectModifier,
+                    new[] { new KeyCombo(Keys.LeftShift), new KeyCombo(Keys.RightShift) }
+                }
+            }.ToImmutableDictionary();
+
+        public Keymap(Window wnd, IDictionary<Keybinds, KeyCombo[]> keymap)
+        {
+            this.wnd = wnd;
+            this.keymap = keymap;
+        }
+
+        public bool IsKeybindDown(Keybinds keybind)
+        {
+            foreach (KeyCombo keyCombo in keymap[keybind])
+            {
+                if (keyCombo.IsDown(wnd))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public bool IsKeybindPressed(Keybinds keybind)
+        {
+            foreach (KeyCombo keyCombo in keymap[keybind])
+            {
+                if (keyCombo.IsPressed(wnd))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public bool IsKeybindReleased(Keybinds keybind)
+        {
+            foreach (KeyCombo keyCombo in keymap[keybind])
+            {
+                if (keyCombo.IsReleased(wnd))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Replanetizer/Utils/Keymap.cs
+++ b/Replanetizer/Utils/Keymap.cs
@@ -5,6 +5,7 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using OpenTK.Windowing.GraphicsLibraryFramework;
@@ -39,10 +40,18 @@ namespace Replanetizer.Utils
         public Keys[] modifiers { get; }
         public Keys key { get; }
 
-        public KeyCombo(Keys key, params Keys[] modifiers)
+        public KeyCombo(Keys key)
         {
             this.key = key;
-            this.modifiers = modifiers;
+            modifiers = Array.Empty<Keys>();
+        }
+
+        public KeyCombo(params Keys[] modifiersAndKey)
+        {
+            key = modifiersAndKey[^1];
+            modifiers = new Keys[modifiersAndKey.Length - 1];
+            Array.ConstrainedCopy(modifiersAndKey, 0, modifiers, 0, modifiersAndKey.Length - 1);
+            modifiers = modifiersAndKey;
         }
 
         public bool IsDown(Window wnd)

--- a/Replanetizer/Utils/RenderableBuffer.cs
+++ b/Replanetizer/Utils/RenderableBuffer.cs
@@ -195,7 +195,7 @@ namespace Replanetizer.Utils
         /// Sets an internal variable to true if the corresponding modelObject is a member
         /// of selectedObjects in which case an outline will be rendered.
         /// </summary>
-        public void Select(IList<LevelObject> selectedObjects)
+        public void Select(ICollection<LevelObject> selectedObjects)
         {
             selected = selectedObjects.Contains(modelObject);
         }

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -62,7 +62,6 @@ namespace Replanetizer.Utils
 
         public void Clear()
         {
-            var removedItems = new List<LevelObject>(OBJECTS);
             OBJECTS.Clear();
 
             splinesCount = 0;
@@ -70,7 +69,7 @@ namespace Replanetizer.Utils
             SetDirty();
 
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(
-                NotifyCollectionChangedAction.Reset, removedItems
+                NotifyCollectionChangedAction.Reset
             ));
         }
 

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -39,6 +39,17 @@ namespace Replanetizer.Utils
             SetDirty(true);
             base.Clear();
         }
+
+        public bool Set(LevelObject obj)
+        {
+            if (Count == 1 && ReferenceEquals(this[0], obj))
+                return false;
+
+            Clear();
+            Add(obj);
+            return true;
+        }
+
         public new bool Add(LevelObject obj)
         {
             if (Contains(obj))
@@ -52,12 +63,6 @@ namespace Replanetizer.Utils
             SetDirty(true);
             base.Add(obj);
             return true;
-        }
-
-        public void Set(LevelObject obj)
-        {
-            Clear();
-            Add(obj);
         }
 
         public new bool Remove(LevelObject obj)

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -96,6 +96,29 @@ namespace Replanetizer.Utils
             );
         }
 
+        public void Add(IEnumerable<LevelObject> objects)
+        {
+            var newItems = new List<LevelObject>();
+
+            foreach (var obj in objects)
+            {
+                newItems.Add(obj);
+                OBJECTS.Add(obj);
+
+                if (obj is Spline)
+                    splinesCount++;
+                else
+                    nonSplinesCount++;
+            }
+
+            SetDirty();
+            OnCollectionChanged(
+                new NotifyCollectionChangedEventArgs(
+                    NotifyCollectionChangedAction.Add, newItems
+                )
+            );
+        }
+
         public bool Remove(LevelObject obj)
         {
             if (!OBJECTS.Remove(obj))
@@ -113,6 +136,30 @@ namespace Replanetizer.Utils
                 )
             );
             return true;
+        }
+
+
+        public void Remove(IEnumerable<LevelObject> objects)
+        {
+            var removedItems = new List<LevelObject>();
+
+            foreach (var obj in objects)
+            {
+                removedItems.Remove(obj);
+                OBJECTS.Remove(obj);
+
+                if (obj is Spline)
+                    splinesCount--;
+                else
+                    nonSplinesCount--;
+            }
+
+            SetDirty();
+            OnCollectionChanged(
+                new NotifyCollectionChangedEventArgs(
+                    NotifyCollectionChangedAction.Remove, removedItems
+                )
+            );
         }
 
         public void Toggle(LevelObject obj)

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -32,6 +32,8 @@ namespace Replanetizer.Utils
         private int splinesCount;
         private int nonSplinesCount;
 
+        public LevelObject? newestObject { get; private set; }
+
         public int Count => OBJECTS.Count;
         public bool IsReadOnly => false;
 
@@ -82,6 +84,7 @@ namespace Replanetizer.Utils
         public void Add(LevelObject obj)
         {
             OBJECTS.Add(obj);
+            newestObject = obj;
 
             if (obj is Spline)
                 splinesCount++;
@@ -104,6 +107,7 @@ namespace Replanetizer.Utils
             {
                 newItems.Add(obj);
                 OBJECTS.Add(obj);
+                newestObject = obj;
 
                 if (obj is Spline)
                     splinesCount++;
@@ -123,6 +127,8 @@ namespace Replanetizer.Utils
         {
             if (!OBJECTS.Remove(obj))
                 return false;
+            if (ReferenceEquals(obj, newestObject))
+                newestObject = null;
 
             if (obj is Spline)
                 splinesCount--;
@@ -147,6 +153,8 @@ namespace Replanetizer.Utils
             {
                 removedItems.Remove(obj);
                 OBJECTS.Remove(obj);
+                if (ReferenceEquals(obj, newestObject))
+                    newestObject = null;
 
                 if (obj is Spline)
                     splinesCount--;

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using LibReplanetizer.LevelObjects;
 using OpenTK.Mathematics;
 
@@ -87,6 +88,16 @@ namespace Replanetizer.Utils
         public bool ToggleOne(LevelObject obj)
         {
             return Set(obj) || Remove(obj);
+        }
+
+        public bool TryGetOne([NotNullWhen(true)] out LevelObject? obj)
+        {
+            obj = null;
+            if (Count != 1)
+                return false;
+
+            obj = this[0];
+            return true;
         }
 
         private Vector3 CalculatePivotPoint()

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -28,17 +28,12 @@ namespace Replanetizer.Utils
         private int splinesCount;
         private int nonSplinesCount;
 
-        private void SetDirty(bool dirty)
+        /// <summary>
+        /// Flag lazy properties for recalculation (e.g. when object positions change)
+        /// </summary>
+        public void SetDirty(bool dirty = true)
         {
             pivotDirty = dirty;
-        }
-
-        /// <summary>
-        /// Force recalculate lazy properties (e.g. when object positions change)
-        /// </summary>
-        public void Update()
-        {
-            SetDirty(true);
         }
 
         public new void Clear()

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -7,10 +7,17 @@ using OpenTK.Mathematics;
 
 namespace Replanetizer.Utils
 {
+    /// <summary>
+    /// A container for LevelObjects that the user can select. Allows for adding
+    /// and removing individual objects from the selection without resetting it.
+    /// </summary>
     public class Selection : INotifyCollectionChanged, ICollection<LevelObject>
     {
         private readonly HashSet<LevelObject> OBJECTS = new();
 
+        /// <summary>
+        /// The median point of all selected objects (averaged positions)
+        /// </summary>
         public Vector3 median
         {
             get
@@ -28,10 +35,19 @@ namespace Replanetizer.Utils
         private bool medianDirty;
         private Vector3 _median;
 
+        /// <summary>
+        /// Whether the selection contains only splines
+        /// </summary>
         public bool isOnlySplines => splinesCount > 1 && nonSplinesCount == 0;
         private int splinesCount;
         private int nonSplinesCount;
 
+        /// <summary>
+        /// The most recently selected object. Note that this will be null if
+        /// the most recently selected object was deselected, even if there are
+        /// other objects still selected. This is a consequence of using a
+        /// HashSet implementation for quick membership testing.
+        /// </summary>
         public LevelObject? newestObject { get; private set; }
 
         public int Count => OBJECTS.Count;
@@ -47,6 +63,10 @@ namespace Replanetizer.Utils
             OBJECTS.CopyTo(array, arrayIndex);
         }
 
+        /// <summary>
+        /// Occurs when one or more objects are added to or removed from the
+        /// selection, or when the selection is cleared.
+        /// </summary>
         public event NotifyCollectionChangedEventHandler? CollectionChanged;
 
         protected void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
@@ -62,6 +82,9 @@ namespace Replanetizer.Utils
             medianDirty = dirty;
         }
 
+        /// <summary>
+        /// Remove all objects from the selection
+        /// </summary>
         public void Clear()
         {
             OBJECTS.Clear();
@@ -75,12 +98,18 @@ namespace Replanetizer.Utils
             ));
         }
 
+        /// <summary>
+        /// Clear the selection and add only the given object
+        /// </summary>
         public void Set(LevelObject obj)
         {
             Clear();
             Add(obj);
         }
 
+        /// <summary>
+        /// Add an object to the selection
+        /// </summary>
         public void Add(LevelObject obj)
         {
             OBJECTS.Add(obj);
@@ -99,6 +128,9 @@ namespace Replanetizer.Utils
             );
         }
 
+        /// <summary>
+        /// Add several objects to the collection at once
+        /// </summary>
         public void Add(IEnumerable<LevelObject> objects)
         {
             var newItems = new List<LevelObject>();
@@ -123,6 +155,10 @@ namespace Replanetizer.Utils
             );
         }
 
+        /// <summary>
+        /// Remove an object from the selection
+        /// </summary>
+        /// <returns>whether the object was removed from the selection</returns>
         public bool Remove(LevelObject obj)
         {
             if (!OBJECTS.Remove(obj))
@@ -144,7 +180,9 @@ namespace Replanetizer.Utils
             return true;
         }
 
-
+        /// <summary>
+        /// Remove several objects from the selection at once
+        /// </summary>
         public void Remove(IEnumerable<LevelObject> objects)
         {
             var removedItems = new List<LevelObject>();
@@ -170,7 +208,9 @@ namespace Replanetizer.Utils
             );
         }
 
-        // Toggle selection of an object without affecting the other selections
+        /// <summary>
+        /// Toggle selection of an object without affecting the other selections
+        /// </summary>
         public void Toggle(LevelObject obj)
         {
             if (OBJECTS.Contains(obj))
@@ -179,7 +219,9 @@ namespace Replanetizer.Utils
                 Add(obj);
         }
 
-        // Toggle selection of just one object, clearing any other selections.
+        /// <summary>
+        /// Toggle selection of just one object, clearing any other selections
+        /// </summary>
         public void ToggleOne(LevelObject obj)
         {
             if (OBJECTS.Count == 1 && OBJECTS.Contains(obj))
@@ -188,6 +230,12 @@ namespace Replanetizer.Utils
                 Set(obj);
         }
 
+        /// <summary>
+        /// Get the single selected object if it is the only one in the selection
+        /// </summary>
+        /// <param name="obj">the single selected object or null if there are zero
+        /// or multiple objects selected</param>
+        /// <returns>true if the single selected object was set, else false</returns>
         public bool TryGetOne([NotNullWhen(true)] out LevelObject? obj)
         {
             obj = null;
@@ -200,6 +248,9 @@ namespace Replanetizer.Utils
             return true;
         }
 
+        /// <summary>
+        /// Calculate the median point of all selected object
+        /// </summary>
         private Vector3 CalculateMedian()
         {
             var median = new Vector3();

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -10,17 +10,17 @@ namespace Replanetizer.Utils
         {
             get
             {
-                if (_pivotDirty)
+                if (pivotDirty)
                 {
                     _pivot = CalculatePivotPoint();
-                    _pivotDirty = false;
+                    pivotDirty = false;
                 }
 
                 return _pivot;
             }
         }
 
-        private bool _pivotDirty;
+        private bool pivotDirty;
         private Vector3 _pivot;
 
         public bool isOnlySplines => splinesCount > 1 && nonSplinesCount == 0;
@@ -29,7 +29,7 @@ namespace Replanetizer.Utils
 
         private void SetDirty(bool dirty)
         {
-            _pivotDirty = dirty;
+            pivotDirty = dirty;
         }
 
         public new void Clear()

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -11,22 +11,22 @@ namespace Replanetizer.Utils
     {
         private readonly HashSet<LevelObject> OBJECTS = new();
 
-        public Vector3 pivot
+        public Vector3 median
         {
             get
             {
-                if (pivotDirty)
+                if (medianDirty)
                 {
-                    _pivot = CalculatePivotPoint();
-                    pivotDirty = false;
+                    _median = CalculateMedian();
+                    medianDirty = false;
                 }
 
-                return _pivot;
+                return _median;
             }
         }
 
-        private bool pivotDirty;
-        private Vector3 _pivot;
+        private bool medianDirty;
+        private Vector3 _median;
 
         public bool isOnlySplines => splinesCount > 1 && nonSplinesCount == 0;
         private int splinesCount;
@@ -57,7 +57,7 @@ namespace Replanetizer.Utils
         /// </summary>
         public void SetDirty(bool dirty = true)
         {
-            pivotDirty = dirty;
+            medianDirty = dirty;
         }
 
         public void Clear()
@@ -190,15 +190,15 @@ namespace Replanetizer.Utils
             return true;
         }
 
-        private Vector3 CalculatePivotPoint()
+        private Vector3 CalculateMedian()
         {
-            var pivot = new Vector3();
+            var median = new Vector3();
             foreach (var obj in OBJECTS)
             {
-                pivot += obj.position;
+                median += obj.position;
             }
-            pivot /= OBJECTS.Count;
-            return pivot;
+            median /= OBJECTS.Count;
+            return median;
         }
     }
 }

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -84,6 +84,11 @@ namespace Replanetizer.Utils
             return Add(obj) || Remove(obj);
         }
 
+        public bool ToggleOne(LevelObject obj)
+        {
+            return Set(obj) || Remove(obj);
+        }
+
         private Vector3 CalculatePivotPoint()
         {
             var pivot = new Vector3();

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -162,6 +162,7 @@ namespace Replanetizer.Utils
             );
         }
 
+        // Toggle selection of an object without affecting the other selections
         public void Toggle(LevelObject obj)
         {
             if (OBJECTS.Contains(obj))
@@ -170,9 +171,10 @@ namespace Replanetizer.Utils
                 Add(obj);
         }
 
+        // Toggle selection of just one object, clearing any other selections.
         public void ToggleOne(LevelObject obj)
         {
-            if (OBJECTS.Contains(obj))
+            if (OBJECTS.Count == 1 && OBJECTS.Contains(obj))
                 Clear();
             else
                 Set(obj);

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -33,6 +33,14 @@ namespace Replanetizer.Utils
             pivotDirty = dirty;
         }
 
+        /// <summary>
+        /// Force recalculate lazy properties (e.g. when object positions change)
+        /// </summary>
+        public void Update()
+        {
+            SetDirty(true);
+        }
+
         public new void Clear()
         {
             splinesCount = 0;

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -32,6 +32,13 @@ namespace Replanetizer.Utils
             _pivotDirty = dirty;
         }
 
+        public new void Clear()
+        {
+            splinesCount = 0;
+            nonSplinesCount = 0;
+            SetDirty(true);
+            base.Clear();
+        }
         public new bool Add(LevelObject obj)
         {
             if (Contains(obj))

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -194,7 +194,9 @@ namespace Replanetizer.Utils
             if (OBJECTS.Count != 1)
                 return false;
 
-            obj = OBJECTS.GetEnumerator().Current;
+            using var enumerator = OBJECTS.GetEnumerator();
+            enumerator.MoveNext();
+            obj = enumerator.Current;
             return true;
         }
 

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.ObjectModel;
+using LibReplanetizer.LevelObjects;
+using OpenTK.Mathematics;
+
+namespace Replanetizer.Utils
+{
+    public class Selection : ObservableCollection<LevelObject>
+    {
+        public Vector3 pivot
+        {
+            get
+            {
+                if (_pivotDirty)
+                {
+                    _pivot = CalculatePivotPoint();
+                    _pivotDirty = false;
+                }
+
+                return _pivot;
+            }
+        }
+
+        private bool _pivotDirty;
+        private Vector3 _pivot;
+
+        public bool isOnlySplines => splinesCount > 1 && nonSplinesCount == 0;
+        private int splinesCount;
+        private int nonSplinesCount;
+
+        private void SetDirty(bool dirty)
+        {
+            _pivotDirty = dirty;
+        }
+
+        public new bool Add(LevelObject obj)
+        {
+            if (Contains(obj))
+                return false;
+
+            if (obj is Spline)
+                splinesCount++;
+            else
+                nonSplinesCount++;
+
+            SetDirty(true);
+            base.Add(obj);
+            return true;
+        }
+
+        public void Set(LevelObject obj)
+        {
+            Clear();
+            Add(obj);
+        }
+
+        public new bool Remove(LevelObject obj)
+        {
+            if (!base.Remove(obj))
+                return false;
+
+            if (obj is Spline)
+                splinesCount--;
+            else
+                nonSplinesCount--;
+
+            SetDirty(true);
+            return true;
+        }
+
+        public bool Toggle(LevelObject obj)
+        {
+            return Add(obj) || Remove(obj);
+        }
+
+        private Vector3 CalculatePivotPoint()
+        {
+            var pivot = new Vector3();
+            foreach (var obj in this)
+            {
+                pivot += obj.position;
+            }
+            pivot /= Count;
+            return pivot;
+        }
+    }
+}


### PR DESCRIPTION
# Multi-select

I have added a bunch of features related to multi-selection!

## How to select

- Left click to toggle selection of a single object
- Shift+left click to toggle selection of multiple objects

## New transformation settings (modeled after Blender)

There are two new buttons in the menu bar which cycle through the following options:

- Transform space - transform along:
  - Global (world) axes
  - Local (object) axes
- Pivot positioning - pivot multiple selected objects about:
  - The median point of the objects
  - Each object's origin

## Keybindings / keymap ([Replanetizer/Utils/Keymap.cs](https://github.com/Phanabani/Replanetizer/blob/b5d2d83b0e4491cce21a38b416181463d93c1dd1/Replanetizer/Utils/Keymap.cs))

In the process of creating this feature, I've also created some classes to make it easier to program in a key-agnostic way and to move keys out of Tick functions and into a single area.

There is an immutable dictionary `Keymap.DEFAULT_KEYMAP` which holds the current keymappings. In the future, this could be expanded to allow for user-define keymappings.

Here are some examples of how you can use keybinds:
```cs
if (KEYMAP.IsPressed(Keybinds.DeleteObject))
    DeleteObject(selectedObjects);

float moveSpeed = KEYMAP.IsDown(Keybinds.MoveFastModifier) ? 40 : 10;
```

Closes #50.