### PR TITLE
Rigged model exports

### DIFF
--- a/LibReplanetizer/DataFunctions.cs
+++ b/LibReplanetizer/DataFunctions.cs
@@ -87,6 +87,26 @@ namespace LibReplanetizer
                 );
         }
 
+        public static Matrix3x4 ReadMatrix3x4(byte[] buf, int offset)
+        {
+            return new Matrix3x4(
+                ReadFloat(buf, offset + 0x00),
+                ReadFloat(buf, offset + 0x04),
+                ReadFloat(buf, offset + 0x08),
+                ReadFloat(buf, offset + 0x0C),
+
+                ReadFloat(buf, offset + 0x10),
+                ReadFloat(buf, offset + 0x14),
+                ReadFloat(buf, offset + 0x18),
+                ReadFloat(buf, offset + 0x1C),
+
+                ReadFloat(buf, offset + 0x20),
+                ReadFloat(buf, offset + 0x24),
+                ReadFloat(buf, offset + 0x28),
+                ReadFloat(buf, offset + 0x2C)
+                );
+        }
+
         public static byte[] ReadBlock(FileStream fs, long offset, int length)
         {
             if (length > 0)

--- a/LibReplanetizer/DataFunctions.cs
+++ b/LibReplanetizer/DataFunctions.cs
@@ -216,6 +216,24 @@ namespace LibReplanetizer
             WriteFloat(byteArray, offset + 0x3C, input.M44);
         }
 
+        public static void WriteMatrix3x4(byte[] byteArray, int offset, Matrix3x4 input)
+        {
+            WriteFloat(byteArray, offset + 0x00, input.M11);
+            WriteFloat(byteArray, offset + 0x04, input.M12);
+            WriteFloat(byteArray, offset + 0x08, input.M13);
+            WriteFloat(byteArray, offset + 0x0C, input.M14);
+
+            WriteFloat(byteArray, offset + 0x10, input.M21);
+            WriteFloat(byteArray, offset + 0x14, input.M22);
+            WriteFloat(byteArray, offset + 0x18, input.M23);
+            WriteFloat(byteArray, offset + 0x1C, input.M24);
+
+            WriteFloat(byteArray, offset + 0x20, input.M31);
+            WriteFloat(byteArray, offset + 0x24, input.M32);
+            WriteFloat(byteArray, offset + 0x28, input.M33);
+            WriteFloat(byteArray, offset + 0x2C, input.M34);
+        }
+
         public static byte[] GetBytes(byte[] array, int ind, int length)
         {
             byte[] data = new byte[length];

--- a/LibReplanetizer/Level Objects/Engine/Shrub.cs
+++ b/LibReplanetizer/Level Objects/Engine/Shrub.cs
@@ -119,7 +119,7 @@ namespace LibReplanetizer.LevelObjects
 
         public override LevelObject Clone()
         {
-            return new Tie(modelMatrix);
+            return (Shrub) this.MemberwiseClone();
         }
     }
 }

--- a/LibReplanetizer/Level Objects/Engine/Tie.cs
+++ b/LibReplanetizer/Level Objects/Engine/Tie.cs
@@ -35,11 +35,6 @@ namespace LibReplanetizer.LevelObjects
 
         public byte[] colorBytes;
 
-        public Tie(Matrix4 matrix4)
-        {
-            modelMatrix = matrix4;
-        }
-
         public Tie(byte[] levelBlock, int num, List<Model> tieModels, FileStream fs)
         {
             int offset = num * ELEMENTSIZE;
@@ -129,7 +124,7 @@ namespace LibReplanetizer.LevelObjects
 
         public override LevelObject Clone()
         {
-            return new Tie(modelMatrix);
+            return (Tie) this.MemberwiseClone();
         }
     }
 }

--- a/LibReplanetizer/Level Objects/Gameplay/LevelVariables.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/LevelVariables.cs
@@ -91,7 +91,7 @@ namespace LibReplanetizer.LevelObjects
         public int off80 { get; set; }
 
         [Category("Unknown"), DisplayName("UnknownBytes")]
-        public byte[] unknownBytes { get; set; }
+        public byte[] unknownBytes { get; set; } = new byte[0];
 
         public LevelVariables(GameType game, FileStream fileStream, int levelVarPointer, int length)
         {

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -23,8 +23,7 @@ namespace LibReplanetizer
 
         public bool valid;
 
-        public string path;
-        public EngineHeader engineHeader;
+        public string? path;
 
         public GameType game;
 
@@ -36,7 +35,6 @@ namespace LibReplanetizer
         public List<Model> armorModels;
         public Model collisionEngine;
         public List<Model> collisionChunks;
-        public List<Model> chunks;
         public List<Texture> textures;
         public List<List<Texture>> armorTextures;
         public List<Texture> gadgetTextures;
@@ -124,9 +122,6 @@ namespace LibReplanetizer
             LOGGER.Trace("Level destroyed");
         }
 
-        //New file constructor
-        public Level() { }
-
         //Engine file constructor
         public Level(string enginePath)
         {
@@ -182,14 +177,14 @@ namespace LibReplanetizer
 
                 LOGGER.Debug("Parsing terrain elements...");
                 terrainEngine = engineParser.GetTerrainModel();
-                LOGGER.Debug("Added {0} terrain elements", terrainEngine?.fragments.Count);
+                LOGGER.Debug("Added {0} terrain elements", terrainEngine.fragments.Count);
 
                 LOGGER.Debug("Parsing player animations...");
                 playerAnimations = engineParser.GetPlayerAnimations((MobyModel) mobyModels[0]);
-                LOGGER.Debug("Added {0} player animations", playerAnimations?.Count);
+                LOGGER.Debug("Added {0} player animations", playerAnimations.Count);
 
                 uiElements = engineParser.GetUiElements();
-                LOGGER.Debug("Added {0} ui elements", uiElements?.Count);
+                LOGGER.Debug("Added {0} ui elements", uiElements.Count);
 
                 lightConfig = engineParser.GetLightConfig();
                 textureConfigMenus = engineParser.GetTextureConfigMenu();
@@ -212,11 +207,11 @@ namespace LibReplanetizer
 
                 LOGGER.Debug("Parsing mobs...");
                 mobs = gameplayParser.GetMobies(mobyModels);
-                LOGGER.Debug("Added {0} mobs", mobs?.Count);
+                LOGGER.Debug("Added {0} mobs", mobs.Count);
 
                 LOGGER.Debug("Parsing splines...");
                 splines = gameplayParser.GetSplines();
-                LOGGER.Debug("Added {0} splines", splines?.Count);
+                LOGGER.Debug("Added {0} splines", splines.Count);
 
                 LOGGER.Debug("Parsing languages...");
                 english = gameplayParser.GetEnglish();
@@ -373,7 +368,7 @@ namespace LibReplanetizer
 
         public void Save(string outputFile)
         {
-            string directory;
+            string? directory;
             if (File.Exists(outputFile) && File.GetAttributes(outputFile).HasFlag(FileAttributes.Directory))
             {
                 directory = outputFile;
@@ -382,6 +377,9 @@ namespace LibReplanetizer
             {
                 directory = Path.GetDirectoryName(outputFile);
             }
+
+            if (directory == null) return;
+
             EngineSerializer engineSerializer = new EngineSerializer();
             engineSerializer.Save(this, directory);
             GameplaySerializer gameplaySerializer = new GameplaySerializer();

--- a/LibReplanetizer/Models/Animation/BoneData.cs
+++ b/LibReplanetizer/Models/Animation/BoneData.cs
@@ -37,7 +37,8 @@ namespace LibReplanetizer.Models.Animations
             WriteFloat(outBytes, 0x00, translationX);
             WriteFloat(outBytes, 0x04, translationY);
             WriteFloat(outBytes, 0x08, translationZ);
-            //WriteFloat(outBytes, 0x0C, unk4);
+            WriteShort(outBytes, 0x0C, unk0x0C);
+            WriteShort(outBytes, 0x0E, (short) (parent * 0x40));
 
             return outBytes;
         }

--- a/LibReplanetizer/Models/Animation/BoneData.cs
+++ b/LibReplanetizer/Models/Animation/BoneData.cs
@@ -11,10 +11,12 @@ namespace LibReplanetizer.Models.Animations
 {
     public class BoneData
     {
-        public float unk1;
-        public float unk2;
-        public float unk3;
-        public float unk4;
+        public float unk1, unk2, unk3;
+        public short unk0x0C;
+        public short parent;
+
+        //The first 12 bytes are 3 floats which are exactly the translation from the BoneMatrix
+        //Last 4 bytes are equal to the last 4 bytes in the corresponding BoneMatrix
 
         public BoneData(byte[] boneDataBlock, int num)
         {
@@ -22,9 +24,10 @@ namespace LibReplanetizer.Models.Animations
             unk1 = ReadFloat(boneDataBlock, offset + 0x00);
             unk2 = ReadFloat(boneDataBlock, offset + 0x04);
             unk3 = ReadFloat(boneDataBlock, offset + 0x08);
-            unk4 = ReadFloat(boneDataBlock, offset + 0x0C);
 
-            //unk4 = 0;
+            //0 for root and some constant else (0b0111000000000000 = 0x7000 = 28672)
+            unk0x0C = ReadShort(boneDataBlock, offset + 0x0C);
+            parent = (short) (ReadShort(boneDataBlock, offset + 0x0E) / 0x40);
         }
 
         public byte[] Serialize()
@@ -34,7 +37,7 @@ namespace LibReplanetizer.Models.Animations
             WriteFloat(outBytes, 0x00, unk1);
             WriteFloat(outBytes, 0x04, unk2);
             WriteFloat(outBytes, 0x08, unk3);
-            WriteFloat(outBytes, 0x0C, unk4);
+            //WriteFloat(outBytes, 0x0C, unk4);
 
             return outBytes;
         }

--- a/LibReplanetizer/Models/Animation/BoneData.cs
+++ b/LibReplanetizer/Models/Animation/BoneData.cs
@@ -11,7 +11,7 @@ namespace LibReplanetizer.Models.Animations
 {
     public class BoneData
     {
-        public float unk1, unk2, unk3;
+        public float translationX, translationY, translationZ;
         public short unk0x0C;
         public short parent;
 
@@ -21,9 +21,9 @@ namespace LibReplanetizer.Models.Animations
         public BoneData(byte[] boneDataBlock, int num)
         {
             int offset = num * 0x10;
-            unk1 = ReadFloat(boneDataBlock, offset + 0x00);
-            unk2 = ReadFloat(boneDataBlock, offset + 0x04);
-            unk3 = ReadFloat(boneDataBlock, offset + 0x08);
+            translationX = ReadFloat(boneDataBlock, offset + 0x00);
+            translationY = ReadFloat(boneDataBlock, offset + 0x04);
+            translationZ = ReadFloat(boneDataBlock, offset + 0x08);
 
             //0 for root and some constant else (0b0111000000000000 = 0x7000 = 28672)
             unk0x0C = ReadShort(boneDataBlock, offset + 0x0C);
@@ -34,9 +34,9 @@ namespace LibReplanetizer.Models.Animations
         {
             byte[] outBytes = new byte[0x10];
 
-            WriteFloat(outBytes, 0x00, unk1);
-            WriteFloat(outBytes, 0x04, unk2);
-            WriteFloat(outBytes, 0x08, unk3);
+            WriteFloat(outBytes, 0x00, translationX);
+            WriteFloat(outBytes, 0x04, translationY);
+            WriteFloat(outBytes, 0x08, translationZ);
             //WriteFloat(outBytes, 0x0C, unk4);
 
             return outBytes;

--- a/LibReplanetizer/Models/Animation/BoneMatrix.cs
+++ b/LibReplanetizer/Models/Animation/BoneMatrix.cs
@@ -12,47 +12,41 @@ namespace LibReplanetizer.Models.Animations
 {
     public class BoneMatrix
     {
-        public Matrix4 mat1;
-        public short bb;
-        public Vector4 col3;
+        public Matrix4 transformation;
+        public float unk1, unk2, unk3;
+        public short parent;
+        public short id;
+        public short unk0x3C;
+
+        //The last 4 bytes and the translation are also present in the BoneData.
 
         public BoneMatrix(byte[] boneBlock, int num)
         {
             int offset = num * 0x40;
-            mat1 = ReadMatrix4(boneBlock, offset);
+            id = (short) (offset / 0x40);
 
-            col3 = mat1.Column3;
+            transformation = ReadMatrix4(boneBlock, offset);
 
-            mat1.M14 = 0;
-            mat1.M24 = 0;
-            mat1.M34 = 0;
-            mat1.M44 = 1;
+            transformation.M41 = 0;
+            transformation.M42 = 0;
+            transformation.M43 = 0;
+            transformation.M44 = 1;
 
-            /*
-            mat1.M11 = 1;
-            mat1.M12 = 0;
-            mat1.M13 = 0;
+            unk1 = ReadFloat(boneBlock, offset + 0x30);
+            unk2 = ReadFloat(boneBlock, offset + 0x34);
+            unk3 = ReadFloat(boneBlock, offset + 0x38);
 
-            mat1.M21 = 0;
-            mat1.M22 = 1;
-            mat1.M23 = 0;
-
-            mat1.M31 = 0;
-            mat1.M32 = 0;
-            mat1.M33 = 1;
-            */
-
-            bb = ReadShort(boneBlock, offset + 0x3E);
-            //mat1.Transpose();
-            //mat1.Invert();
+            //0 for root and some constant else (0b0111000000000000 = 0x7000 = 28672)
+            unk0x3C = ReadShort(boneBlock, offset + 0x3C);
+            parent = (short) (ReadShort(boneBlock, offset + 0x3E) / 0x40);
         }
 
         public byte[] Serialize()
         {
             byte[] outBytes = new byte[0x40];
-            Matrix4 mat = mat1;
+            /*Matrix4 mat = transformation;
             mat.Column3 = col3;
-            WriteMatrix4(outBytes, 0, mat);
+            WriteMatrix4(outBytes, 0, mat);*/
 
             return outBytes;
         }

--- a/LibReplanetizer/Models/Animation/BoneMatrix.cs
+++ b/LibReplanetizer/Models/Animation/BoneMatrix.cs
@@ -39,9 +39,12 @@ namespace LibReplanetizer.Models.Animations
         public byte[] Serialize()
         {
             byte[] outBytes = new byte[0x40];
-            /*Matrix4 mat = transformation;
-            mat.Column3 = col3;
-            WriteMatrix4(outBytes, 0, mat);*/
+            WriteMatrix3x4(outBytes, 0x00, transformation);
+            WriteFloat(outBytes, 0x30, cumulativeOffsetX);
+            WriteFloat(outBytes, 0x34, cumulativeOffsetY);
+            WriteFloat(outBytes, 0x38, cumulativeOffsetZ);
+            WriteShort(outBytes, 0x3C, unk0x3C);
+            WriteShort(outBytes, 0x3E, (short) (parent * 0x40));
 
             return outBytes;
         }

--- a/LibReplanetizer/Models/Animation/BoneMatrix.cs
+++ b/LibReplanetizer/Models/Animation/BoneMatrix.cs
@@ -12,8 +12,8 @@ namespace LibReplanetizer.Models.Animations
 {
     public class BoneMatrix
     {
-        public Matrix4 transformation;
-        public float unk1, unk2, unk3;
+        public Matrix3x4 transformation;
+        public float cumulativeOffsetX, cumulativeOffsetY, cumulativeOffsetZ;
         public short parent;
         public short id;
         public short unk0x3C;
@@ -25,16 +25,11 @@ namespace LibReplanetizer.Models.Animations
             int offset = num * 0x40;
             id = (short) (offset / 0x40);
 
-            transformation = ReadMatrix4(boneBlock, offset);
+            transformation = ReadMatrix3x4(boneBlock, offset);
 
-            transformation.M41 = 0;
-            transformation.M42 = 0;
-            transformation.M43 = 0;
-            transformation.M44 = 1;
-
-            unk1 = ReadFloat(boneBlock, offset + 0x30);
-            unk2 = ReadFloat(boneBlock, offset + 0x34);
-            unk3 = ReadFloat(boneBlock, offset + 0x38);
+            cumulativeOffsetX = ReadFloat(boneBlock, offset + 0x30);
+            cumulativeOffsetY = ReadFloat(boneBlock, offset + 0x34);
+            cumulativeOffsetZ = ReadFloat(boneBlock, offset + 0x38);
 
             //0 for root and some constant else (0b0111000000000000 = 0x7000 = 28672)
             unk0x3C = ReadShort(boneBlock, offset + 0x3C);

--- a/LibReplanetizer/Models/Animation/Skeleton.cs
+++ b/LibReplanetizer/Models/Animation/Skeleton.cs
@@ -1,0 +1,45 @@
+// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using System.Collections.Generic;
+
+namespace LibReplanetizer.Models.Animations
+{
+    public class Skeleton
+    {
+        public BoneMatrix bone;
+        public List<Skeleton> children;
+
+        /// <summary>
+        /// Creates a new skeleton with a root node. Use this function once and use InsertBone to construct the skeleton.
+        /// </summary>
+        public Skeleton(BoneMatrix root)
+        {
+            bone = root;
+            children = new List<Skeleton>();
+        }
+
+        public bool InsertBone(BoneMatrix bone)
+        {
+            if (this.bone.id == bone.parent)
+            {
+                children.Add(new Skeleton(bone));
+                return true;
+            }
+
+            bool found = false;
+
+            foreach (Skeleton skel in children)
+            {
+                found = skel.InsertBone(bone);
+                if (found) break;
+            }
+
+            return found;
+        }
+    }
+}

--- a/LibReplanetizer/Models/MobyModel.cs
+++ b/LibReplanetizer/Models/MobyModel.cs
@@ -55,6 +55,8 @@ namespace LibReplanetizer.Models
         public List<TextureConfig> otherTextureConfigs { get; set; } = new List<TextureConfig>();
         public List<ushort> otherIndexBuffer { get; set; } = new List<ushort>();
 
+        public Skeleton skeleton;
+
 
 
         public bool isModel = true;
@@ -243,6 +245,16 @@ namespace LibReplanetizer.Models
                         otherfaceCount += tex.size;
                     }
                     otherIndexBuffer.AddRange(GetIndices(fs, indexPointer + faceCount * sizeof(ushort), otherfaceCount));
+                }
+            }
+
+            if (boneMatrices.Count > 0)
+            {
+                skeleton = new Skeleton(boneMatrices[0]);
+
+                for (int i = 1; i < boneCount; i++)
+                {
+                    skeleton.InsertBone(boneMatrices[i]);
                 }
             }
         }

--- a/LibReplanetizer/Models/MobyModel.cs
+++ b/LibReplanetizer/Models/MobyModel.cs
@@ -54,11 +54,7 @@ namespace LibReplanetizer.Models
         public List<byte> otherBuffer { get; set; } = new List<byte>();
         public List<TextureConfig> otherTextureConfigs { get; set; } = new List<TextureConfig>();
         public List<ushort> otherIndexBuffer { get; set; } = new List<ushort>();
-
-        public Skeleton skeleton;
-
-
-
+        public Skeleton? skeleton = null;
         public bool isModel = true;
 
 

--- a/LibReplanetizer/Models/Model.cs
+++ b/LibReplanetizer/Models/Model.cs
@@ -23,8 +23,13 @@ namespace LibReplanetizer.Models
         public float size;
         public float[] vertexBuffer = { };
         public ushort[] indexBuffer = { };
+
+        // Every vertex can be assigned to at most 4 bones
+        // weights contains 4 uint8 each being of weight (value / 255.0)
+        // ids contains 4 uint8 each defining which bones we refer to
         public uint[] weights;
         public uint[] ids;
+
         public byte[] rgbas;
 
 

--- a/LibReplanetizer/Models/Texture.cs
+++ b/LibReplanetizer/Models/Texture.cs
@@ -37,6 +37,8 @@ namespace LibReplanetizer
 
         public int off20;
 
+        public int id;
+
 
         public Texture(int id, short width, short height, byte[] data)
         {
@@ -71,6 +73,8 @@ namespace LibReplanetizer
             off1C = ReadInt(textureBlock, (offset * TEXTUREELEMSIZE) + 0x1C);
 
             off20 = ReadInt(textureBlock, (offset * TEXTUREELEMSIZE) + 0x20);
+
+            id = offset;
         }
 
         public byte[] Serialize(int vramOffset)

--- a/LibReplanetizer/Serializers/EngineSerializer.cs
+++ b/LibReplanetizer/Serializers/EngineSerializer.cs
@@ -18,7 +18,7 @@ namespace LibReplanetizer.Serializers
 {
     public class EngineSerializer
     {
-        private string enginePath;
+        private string? enginePath;
 
         public void Save(Level level, string directory)
         {
@@ -389,7 +389,8 @@ namespace LibReplanetizer.Serializers
 
         private byte[] WriteTextures(List<Texture> textures)
         {
-            if (enginePath == null) return null;
+            if (enginePath == null)
+                throw new System.Exception("Cannot write textures without a path!");
 
             var vramBytes = new List<byte>();
             var outBytes = new byte[textures.Count * 0x24];

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -570,14 +570,19 @@ namespace LibReplanetizer
                 {
                     MobyModel moby = (MobyModel) model;
 
-                    WriteSkeletonDae(colladaStream, moby.skeleton, model.size, "\t\t\t");
+                    if (moby.skeleton != null)
+                        WriteSkeletonDae(colladaStream, moby.skeleton, model.size, "\t\t\t");
                 }
                 colladaStream.WriteLine("\t\t\t<node id=\"Object\" name=\"Object\" type=\"NODE\">");
                 colladaStream.WriteLine("\t\t\t\t<matrix sid=\"transform\">1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1</matrix>");
-                colladaStream.WriteLine("\t\t\t\t<instance_controller url=\"#Armature\" name=\"Armature\">");
                 if (model is MobyModel)
                 {
+                    colladaStream.WriteLine("\t\t\t\t<instance_controller url=\"#Armature\" name=\"Armature\">");
                     colladaStream.WriteLine("\t\t\t\t\t<skeleton>#Skel0</skeleton>");
+                }
+                else
+                {
+                    colladaStream.WriteLine("\t\t\t\t<instance_geometry url=\"#Model\" name=\"Model\">");
                 }
                 colladaStream.WriteLine("\t\t\t\t\t<bind_material>");
                 colladaStream.WriteLine("\t\t\t\t\t\t<technique_common>");
@@ -589,7 +594,14 @@ namespace LibReplanetizer
                 }
                 colladaStream.WriteLine("\t\t\t\t\t\t</technique_common>");
                 colladaStream.WriteLine("\t\t\t\t\t</bind_material>");
-                colladaStream.WriteLine("\t\t\t\t</instance_controller>");
+                if (model is MobyModel)
+                {
+                    colladaStream.WriteLine("\t\t\t\t</instance_controller>");
+                }
+                else
+                {
+                    colladaStream.WriteLine("\t\t\t\t</instance_geometry>");
+                }
                 colladaStream.WriteLine("\t\t\t</node>");
                 colladaStream.WriteLine("\t\t</visual_scene>");
                 colladaStream.WriteLine("\t</library_visual_scenes>");

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -156,8 +156,6 @@ namespace LibReplanetizer
 
             string? filePath = Path.GetDirectoryName(fileName);
 
-            if (!(model is MobyModel mobyModel)) return;
-
             using (StreamWriter colladaStream = new StreamWriter(fileName))
             {
                 int vertexCount = model.vertexBuffer.Length / 8;
@@ -317,12 +315,239 @@ namespace LibReplanetizer
                 colladaStream.WriteLine("\t\t</geometry>");
                 colladaStream.WriteLine("\t</library_geometries>");
 
+                if (model is MobyModel)
+                {
+                    MobyModel moby = (MobyModel) model;
+
+                    //animation
+                    colladaStream.WriteLine("\t<library_animations>");
+                    colladaStream.WriteLine("\t</library_animations>");
+
+                    //controllers
+                    colladaStream.WriteLine("\t<library_controllers>");
+                    colladaStream.WriteLine("\t\t<controller id=\"Armature\" name=\"Armature\">");
+                    colladaStream.WriteLine("\t\t\t<skin source=\"#Model\">");
+                    colladaStream.WriteLine("\t\t\t\t<source id=\"Joints\">");
+                    colladaStream.Write("\t\t\t\t\t<Name_array id=\"JointsArray\" count=\"" + moby.boneDatas.Count + "\">");
+                    for (int i = 0; i < moby.boneDatas.Count; i++)
+                    {
+                        colladaStream.Write("J" + i.ToString() + " ");
+                    }
+                    colladaStream.WriteLine("\t\t\t\t\t</Name_array>");
+                    colladaStream.WriteLine("\t\t\t\t\t<technique_common>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<accessor source=\"#JointsArray\" count=\"" + moby.boneDatas.Count + "\" stride=\"1\">");
+                    colladaStream.WriteLine("\t\t\t\t\t\t\t<param name=\"JOINT\" type=\"Name\"/>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t</accessor>");
+                    colladaStream.WriteLine("\t\t\t\t\t</technique_common>");
+                    colladaStream.WriteLine("\t\t\t\t</source>");
+                    colladaStream.WriteLine("\t\t\t\t<source id=\"Weights\">");
+                    colladaStream.Write("\t\t\t\t\t<float_array id=\"WeightsArray\" count=\"" + vertexCount * 4 + "\">");
+                    for (int i = 0; i < vertexCount; i++)
+                    {
+                        byte[] vWeights = BitConverter.GetBytes(model.weights[i]);
+                        float a = vWeights[0x00] / 255.0f;
+                        float b = vWeights[0x01] / 255.0f;
+                        float c = vWeights[0x02] / 255.0f;
+                        float d = vWeights[0x03] / 255.0f;
+
+                        colladaStream.Write(a.ToString("G", en_US) + " " + b.ToString("G", en_US) + " " + c.ToString("G", en_US) + " " + d.ToString("G", en_US) + " ");
+                    }
+                    colladaStream.WriteLine("</float_array>");
+                    colladaStream.WriteLine("\t\t\t\t\t<technique_common>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<accessor source=\"#WeightsArray\" count=\"" + 4 * vertexCount + "\" stride=\"1\">");
+                    colladaStream.WriteLine("\t\t\t\t\t\t\t<param name=\"WEIGHT\" type=\"float\"/>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t</accessor>");
+                    colladaStream.WriteLine("\t\t\t\t\t</technique_common>");
+                    colladaStream.WriteLine("\t\t\t\t</source>");
+                    colladaStream.WriteLine("\t\t\t\t<source id=\"InvBindMats\">");
+                    colladaStream.Write("\t\t\t\t\t<float_array id=\"InvBindMatsArray\" count=\"" + 16 * moby.boneMatrices.Count + "\">");
+                    for (int i = 0; i < moby.boneMatrices.Count; i++)
+                    {
+                        var mat = moby.boneMatrices[i];
+                        /*colladaStream.Write((mat.mat1.M11).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M12).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M13).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M14).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M21).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M22).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M23).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M24).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M31).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M32).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M33).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M34).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M41).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M42).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M43).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M44).ToString("G", en_US) + " ");*/
+                        colladaStream.Write("1.0 ");
+                        colladaStream.Write("0.0 ");
+                        colladaStream.Write("0.0 ");
+                        colladaStream.Write((moby.boneDatas[i].unk1 / 1024f).ToString("G", en_US) + " ");
+                        colladaStream.Write("0.0 ");
+                        colladaStream.Write("1.0 ");
+                        colladaStream.Write("0.0 ");
+                        colladaStream.Write((moby.boneDatas[i].unk2 / 1024f).ToString("G", en_US) + " ");
+                        colladaStream.Write("0.0 ");
+                        colladaStream.Write("0.0 ");
+                        colladaStream.Write("1.0 ");
+                        colladaStream.Write((moby.boneDatas[i].unk3 / 1024f).ToString("G", en_US) + " ");
+                        colladaStream.Write("0.0 ");
+                        colladaStream.Write("0.0 ");
+                        colladaStream.Write("0.0 ");
+                        colladaStream.Write("1.0 ");
+
+                        /*colladaStream.Write(mat.mat1.M11.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M21.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M31.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M41.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M12.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M22.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M32.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M42.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M13.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M23.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M33.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M43.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M14.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M24.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M34.ToString("G", en_US) + " ");
+                        colladaStream.Write(mat.mat1.M44.ToString("G", en_US) + " ");*/
+                    }
+                    colladaStream.WriteLine("\t\t\t\t\t</float_array>");
+                    colladaStream.WriteLine("\t\t\t\t\t<technique_common>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<accessor source=\"#InvBindMatsArray\" count=\"" + moby.boneMatrices.Count + "\" stride=\"16\">");
+                    colladaStream.WriteLine("\t\t\t\t\t\t\t<param name=\"TRANSFORM\" type=\"float4x4\"/>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t</accessor>");
+                    colladaStream.WriteLine("\t\t\t\t\t</technique_common>");
+                    colladaStream.WriteLine("\t\t\t\t</source>");
+                    colladaStream.WriteLine("\t\t\t\t<joints>");
+                    colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"JOINT\" source=\"#Joints\"/>");
+                    colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"INV_BIND_MATRIX\" source=\"#InvBindMats\"/>");
+                    colladaStream.WriteLine("\t\t\t\t</joints>");
+                    colladaStream.WriteLine("\t\t\t\t<vertex_weights count=\"" + vertexCount + "\">");
+                    colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"JOINT\" source=\"#Joints\" offset=\"0\"/>");
+                    colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"WEIGHT\" source=\"#Weights\" offset=\"1\"/>");
+                    colladaStream.Write("\t\t\t\t\t<vcount>");
+                    for (int i = 0; i < vertexCount; i++)
+                    {
+                        colladaStream.Write("4 ");
+                    }
+                    colladaStream.WriteLine("</vcount>");
+                    colladaStream.Write("\t\t\t\t\t<v>");
+                    for (int i = 0; i < vertexCount; i++)
+                    {
+                        Byte[] indices = BitConverter.GetBytes(model.ids[i]);
+
+                        colladaStream.Write(indices[0x00] + " " + (i * 0x04 + 0x00) + " ");
+                        colladaStream.Write(indices[0x01] + " " + (i * 0x04 + 0x01) + " ");
+                        colladaStream.Write(indices[0x02] + " " + (i * 0x04 + 0x02) + " ");
+                        colladaStream.Write(indices[0x03] + " " + (i * 0x04 + 0x03) + " ");
+                    }
+                    colladaStream.WriteLine("</v>");
+                    colladaStream.WriteLine("\t\t\t\t</vertex_weights>");
+                    colladaStream.WriteLine("\t\t\t</skin>");
+                    colladaStream.WriteLine("\t\t</controller>");
+                    colladaStream.WriteLine("\t</library_controllers>");
+
+                    colladaStream.WriteLine("\t<library_animations>");
+                    for (int i = 0; i < moby.animations.Count; i++)
+                    {
+                        Animation anim = (moby.id == 0) ? level.playerAnimations[i] : moby.animations[i];
+                        colladaStream.WriteLine("\t\t<animation id=\"Anim" + i.ToString() + "\" name=\"Anim" + i.ToString() + "\">");
+                        colladaStream.WriteLine("\t\t\t<source id=\"Anim" + i.ToString() + "Input\">");
+                        colladaStream.Write("\t\t\t\t<float_array id=\"Anim" + i.ToString() + "InputArray\" count=\"" + anim.frames.Count + "\">");
+                        for (int j = 0; j < anim.frames.Count; j++)
+                        {
+                            colladaStream.Write((j / (60f * anim.speed)).ToString("G", en_US) + " ");
+                        }
+                        colladaStream.WriteLine("</float_array>");
+                        colladaStream.WriteLine("\t\t\t\t<technique_common>");
+                        colladaStream.WriteLine("\t\t\t\t\t<accessor source=\"#Anim" + i.ToString() + "InputArray\" count=\"" + anim.frames.Count + "\" stride=\"1\">");
+                        colladaStream.WriteLine("\t\t\t\t\t\t<param name=\"TIME\" type=\"float\"/>");
+                        colladaStream.WriteLine("\t\t\t\t\t</accessor>");
+                        colladaStream.WriteLine("\t\t\t\t</technique_common>");
+                        colladaStream.WriteLine("\t\t\t</source>");
+                        colladaStream.WriteLine("\t\t\t<source id=\"Anim" + i.ToString() + "Output\">");
+                        colladaStream.Write("\t\t\t\t<float_array id=\"Anim" + i.ToString() + "OutputArray\" count=\"" + 16 * anim.frames.Count + "\">");
+                        for (int j = 0; j < anim.frames.Count; j++)
+                        {
+                            colladaStream.Write("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 ");
+                        }
+                        colladaStream.WriteLine("</float_array>");
+                        colladaStream.WriteLine("\t\t\t\t<technique_common>");
+                        colladaStream.WriteLine("\t\t\t\t\t<accessor source=\"#Anim" + i.ToString() + "OutputArray\" count=\"" + anim.frames.Count + "\" stride=\"16\">");
+                        colladaStream.WriteLine("\t\t\t\t\t\t<param name=\"TRANSFORM\" type=\"float4x4\"/>");
+                        colladaStream.WriteLine("\t\t\t\t\t</accessor>");
+                        colladaStream.WriteLine("\t\t\t\t</technique_common>");
+                        colladaStream.WriteLine("\t\t\t</source>");
+                        colladaStream.WriteLine("\t\t\t<source id=\"Anim" + i.ToString() + "Interp\">");
+                        colladaStream.Write("\t\t\t\t<Name_array id=\"Anim" + i.ToString() + "InterpArray\" count=\"" + anim.frames.Count + "\">");
+                        for (int j = 0; j < anim.frames.Count; j++)
+                        {
+                            colladaStream.Write("LINEAR ");
+                        }
+                        colladaStream.WriteLine("</Name_array>");
+                        colladaStream.WriteLine("\t\t\t\t<technique_common>");
+                        colladaStream.WriteLine("\t\t\t\t\t<accessor source=\"#Anim" + i.ToString() + "InterpArray\" count=\"" + anim.frames.Count + "\" stride=\"1\">");
+                        colladaStream.WriteLine("\t\t\t\t\t\t<param name=\"INTERPOLATION\" type=\"Name\"/>");
+                        colladaStream.WriteLine("\t\t\t\t\t</accessor>");
+                        colladaStream.WriteLine("\t\t\t\t</technique_common>");
+                        colladaStream.WriteLine("\t\t\t</source>");
+                        colladaStream.WriteLine("\t\t\t<sampler id=\"Anim" + i.ToString() + "Sampler\">");
+                        colladaStream.WriteLine("\t\t\t\t<input semantic=\"INPUT\" source=\"#Anim" + i.ToString() + "Input\"/>");
+                        colladaStream.WriteLine("\t\t\t\t<input semantic=\"OUTPUT\" source=\"#Anim" + i.ToString() + "Output\"/>");
+                        colladaStream.WriteLine("\t\t\t\t<input semantic=\"INTERPOLATION\" source=\"#Anim" + i.ToString() + "Interp\"/>");
+                        colladaStream.WriteLine("\t\t\t</sampler>");
+                        colladaStream.WriteLine("\t\t\t<channel source=\"Anim" + i.ToString() + "Sampler\" target=\"Skel/transform\"/>");
+                        colladaStream.WriteLine("\t\t</animation>");
+                    }
+                    colladaStream.WriteLine("\t</library_animations>");
+                }
+
                 //scene
                 colladaStream.WriteLine("\t<library_visual_scenes>");
                 colladaStream.WriteLine("\t\t<visual_scene id=\"Scene\" name=\"Scene\">");
+                if (model is MobyModel)
+                {
+                    MobyModel moby = (MobyModel) model;
+
+                    colladaStream.WriteLine("\t\t\t<node id=\"Skel\" name=\"Skel\">");
+                    for (int i = 0; i < moby.boneDatas.Count; i++)
+                    {
+                        var mat = moby.boneMatrices[i];
+
+                        colladaStream.WriteLine("\t\t\t<node id=\"VSJ" + i.ToString() + "\" sid=\"J" + i.ToString() + "\" name=\"J" + i.ToString() + "\" type=\"JOINT\">");
+                        colladaStream.Write("\t\t\t\t<matrix>");
+                        colladaStream.Write((mat.mat1.M11).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M12).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M13).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M14).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M21).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M22).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M23).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M24).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M31).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M32).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M33).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M34).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M41).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M42).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M43).ToString("G", en_US) + " ");
+                        colladaStream.Write((mat.mat1.M44).ToString("G", en_US) + " ");
+                        colladaStream.WriteLine("</matrix>");
+                        colladaStream.WriteLine("\t\t\t</node>");
+                        //}
+                    }
+                    colladaStream.WriteLine("\t\t\t</node>");
+                }
                 colladaStream.WriteLine("\t\t\t<node id=\"Object\" name=\"Object\" type=\"NODE\">");
                 colladaStream.WriteLine("\t\t\t\t<matrix sid=\"transform\">1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1</matrix>");
-                colladaStream.WriteLine("\t\t\t\t<instance_geometry url=\"#Model\" name=\"Model\">");
+                colladaStream.WriteLine("\t\t\t\t<instance_controller url=\"#Armature\" name=\"Armature\">");
+                if (model is MobyModel)
+                {
+                    colladaStream.WriteLine("\t\t\t\t\t<skeleton>#Skel</skeleton>");
+                }
                 colladaStream.WriteLine("\t\t\t\t\t<bind_material>");
                 colladaStream.WriteLine("\t\t\t\t\t\t<technique_common>");
                 foreach (TextureConfig config in model.textureConfig)
@@ -333,7 +558,7 @@ namespace LibReplanetizer
                 }
                 colladaStream.WriteLine("\t\t\t\t\t\t</technique_common>");
                 colladaStream.WriteLine("\t\t\t\t\t</bind_material>");
-                colladaStream.WriteLine("\t\t\t\t</instance_geometry>");
+                colladaStream.WriteLine("\t\t\t\t</instance_controller>");
                 colladaStream.WriteLine("\t\t\t</node>");
                 colladaStream.WriteLine("\t\t</visual_scene>");
                 colladaStream.WriteLine("\t</library_visual_scenes>");

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -152,7 +152,7 @@ namespace LibReplanetizer
         {
             LOGGER.Trace(fileName);
 
-            string filePath = Path.GetDirectoryName(fileName);
+            string? filePath = Path.GetDirectoryName(fileName);
 
             if (!(model is MobyModel mobyModel)) return;
 
@@ -277,7 +277,7 @@ namespace LibReplanetizer
 
         public static void WriteObj(string fileName, Model model)
         {
-            string pathName = Path.GetDirectoryName(fileName);
+            string? pathName = Path.GetDirectoryName(fileName);
             string fileNameNoExtension = Path.GetFileNameWithoutExtension(fileName);
 
             using (StreamWriter mtlfs = new StreamWriter(pathName + "\\" + fileNameNoExtension + ".mtl"))
@@ -324,7 +324,7 @@ namespace LibReplanetizer
 
         private static void WriteObjSeparate(string fileName, Level level, WriterLevelSettings settings)
         {
-            string pathName = Path.GetDirectoryName(fileName);
+            string? pathName = Path.GetDirectoryName(fileName);
             string fileNameNoExtension = Path.GetFileNameWithoutExtension(fileName);
 
             List<TerrainFragment> terrain = CollectTerrainFragments(level, settings);
@@ -384,7 +384,7 @@ namespace LibReplanetizer
 
         private static void WriteObjCombined(string fileName, Level level, WriterLevelSettings settings)
         {
-            string pathName = Path.GetDirectoryName(fileName);
+            string? pathName = Path.GetDirectoryName(fileName);
             string fileNameNoExtension = Path.GetFileNameWithoutExtension(fileName);
 
             List<TerrainFragment> terrain = CollectTerrainFragments(level, settings);
@@ -441,7 +441,7 @@ namespace LibReplanetizer
 
         private static void WriteObjTypewise(string fileName, Level level, WriterLevelSettings settings)
         {
-            string pathName = Path.GetDirectoryName(fileName);
+            string? pathName = Path.GetDirectoryName(fileName);
             string fileNameNoExtension = Path.GetFileNameWithoutExtension(fileName);
 
             List<TerrainFragment> terrain = CollectTerrainFragments(level, settings);
@@ -581,7 +581,7 @@ namespace LibReplanetizer
 
         private static void WriteObjMaterialwise(string fileName, Level level, WriterLevelSettings settings)
         {
-            string pathName = Path.GetDirectoryName(fileName);
+            string? pathName = Path.GetDirectoryName(fileName);
             string fileNameNoExtension = Path.GetFileNameWithoutExtension(fileName);
 
             List<TerrainFragment> terrain = CollectTerrainFragments(level, settings);

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -177,10 +177,57 @@ namespace LibReplanetizer
                 colladaStream.WriteLine("\t</asset>");
 
                 //image
+                colladaStream.WriteLine("\t<library_images>");
+                foreach (TextureConfig config in model.textureConfig)
+                {
+                    colladaStream.WriteLine("\t\t<image id=\"texture_" + config.id + "\">");
+                    colladaStream.Write("\t\t\t<init_from>");
+                    colladaStream.Write(config.id + ".png");
+                    colladaStream.WriteLine("</init_from>");
+                    colladaStream.WriteLine("\t\t</image>");
+                }
+                colladaStream.WriteLine("\t</library_images>");
 
                 //effects
+                colladaStream.WriteLine("\t<library_effects>");
+                foreach (TextureConfig config in model.textureConfig)
+                {
+                    colladaStream.WriteLine("\t\t<effect id=\"effect_" + config.id + "\">");
+                    colladaStream.WriteLine("\t\t\t<profile_COMMON>");
+                    colladaStream.WriteLine("\t\t\t\t<newparam sid=\"surface_" + config.id + "\">");
+                    colladaStream.WriteLine("\t\t\t\t\t<surface type=\"2D\">");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<init_from>texture_" + config.id + "</init_from>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<format>A8R8G8B8</format>");
+                    colladaStream.WriteLine("\t\t\t\t\t</surface>");
+                    colladaStream.WriteLine("\t\t\t\t</newparam>");
+                    colladaStream.WriteLine("\t\t\t\t<newparam sid=\"sampler_" + config.id + "\">");
+                    colladaStream.WriteLine("\t\t\t\t\t<sampler2D>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<source>surface_" + config.id + "</source>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<minfilter>LINEAR_MIPMAP_LINEAR</minfilter>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<magfilter>LINEAR</magfilter>");
+                    colladaStream.WriteLine("\t\t\t\t\t</sampler2D>");
+                    colladaStream.WriteLine("\t\t\t\t</newparam>");
+                    colladaStream.WriteLine("\t\t\t\t<technique sid=\"common\">");
+                    colladaStream.WriteLine("\t\t\t\t\t<lambert>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<diffuse>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t\t<texture texture=\"sampler_" + config.id + "\" texcoord=\"texcoord_" + config.id + "\"/>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t</diffuse>");
+                    colladaStream.WriteLine("\t\t\t\t\t</lambert>");
+                    colladaStream.WriteLine("\t\t\t\t</technique>");
+                    colladaStream.WriteLine("\t\t\t</profile_COMMON>");
+                    colladaStream.WriteLine("\t\t</effect>");
+                }
+                colladaStream.WriteLine("\t</library_effects>");
 
                 //materials
+                colladaStream.WriteLine("\t<library_materials>");
+                foreach (TextureConfig config in model.textureConfig)
+                {
+                    colladaStream.WriteLine("\t\t<material id=\"material_" + config.id + "\">");
+                    colladaStream.WriteLine("\t\t\t<instance_effect url=\"#effect_" + config.id + "\"/>");
+                    colladaStream.WriteLine("\t\t</material>");
+                }
+                colladaStream.WriteLine("\t</library_materials>");
 
                 //geometry
                 colladaStream.WriteLine("\t<library_geometries>");
@@ -245,24 +292,27 @@ namespace LibReplanetizer
                 colladaStream.WriteLine("\t\t\t\t<vertices id=\"Model_vertices\">");
                 colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"POSITION\" source=\"#Model_positions\"/>");
                 colladaStream.WriteLine("\t\t\t\t</vertices>");
-                colladaStream.WriteLine("\t\t\t\t<triangles count=\"" + model.indexBuffer.Length / 3 + "\" material=\"material_symbol_0\">");
-                colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"VERTEX\" source=\"#Model_vertices\" offset=\"0\"/>");
-                colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"NORMAL\" source=\"#Model_normals\" offset=\"0\"/>");
-                colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"TEXCOORD\" source=\"#Model_uvs\" offset=\"0\" set=\"0\"/>");
-                colladaStream.Write("\t\t\t\t\t<p> ");
-                for (int i = 0; i < model.indexBuffer.Length / 3; i++)
+                foreach (TextureConfig config in model.textureConfig)
                 {
-                    int f1 = model.indexBuffer[i * 3 + 0];
-                    int f2 = model.indexBuffer[i * 3 + 1];
-                    int f3 = model.indexBuffer[i * 3 + 2];
+                    colladaStream.WriteLine("\t\t\t\t<triangles count=\"" + config.size / 3 + "\" material=\"material_symbol_" + config.id + "\">");
+                    colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"VERTEX\" source=\"#Model_vertices\" offset=\"0\"/>");
+                    colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"NORMAL\" source=\"#Model_normals\" offset=\"0\"/>");
+                    colladaStream.WriteLine("\t\t\t\t\t<input semantic=\"TEXCOORD\" source=\"#Model_uvs\" offset=\"0\" set=\"0\"/>");
+                    colladaStream.Write("\t\t\t\t\t<p> ");
+                    for (int i = config.start / 3; i < config.start / 3 + config.size / 3; i++)
+                    {
+                        int f1 = model.indexBuffer[i * 3 + 0];
+                        int f2 = model.indexBuffer[i * 3 + 1];
+                        int f3 = model.indexBuffer[i * 3 + 2];
 
-                    if (ShouldReverseWinding(vertices, normals, f1, f2, f3))
-                        (f2, f3) = (f3, f2);
+                        if (ShouldReverseWinding(vertices, normals, f1, f2, f3))
+                            (f2, f3) = (f3, f2);
 
-                    colladaStream.Write(f1 + " " + f2 + " " + f3 + " ");
+                        colladaStream.Write(f1 + " " + f2 + " " + f3 + " ");
+                    }
+                    colladaStream.WriteLine("</p>");
+                    colladaStream.WriteLine("\t\t\t\t</triangles>");
                 }
-                colladaStream.WriteLine("</p>");
-                colladaStream.WriteLine("\t\t\t\t</triangles>");
                 colladaStream.WriteLine("\t\t\t</mesh>");
                 colladaStream.WriteLine("\t\t</geometry>");
                 colladaStream.WriteLine("\t</library_geometries>");
@@ -273,6 +323,16 @@ namespace LibReplanetizer
                 colladaStream.WriteLine("\t\t\t<node id=\"Object\" name=\"Object\" type=\"NODE\">");
                 colladaStream.WriteLine("\t\t\t\t<matrix sid=\"transform\">1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1</matrix>");
                 colladaStream.WriteLine("\t\t\t\t<instance_geometry url=\"#Model\" name=\"Model\">");
+                colladaStream.WriteLine("\t\t\t\t\t<bind_material>");
+                colladaStream.WriteLine("\t\t\t\t\t\t<technique_common>");
+                foreach (TextureConfig config in model.textureConfig)
+                {
+                    colladaStream.WriteLine("\t\t\t\t\t\t\t<instance_material symbol=\"material_symbol_" + config.id + "\" target=\"#material_" + config.id + "\">");
+                    colladaStream.WriteLine("\t\t\t\t\t\t\t\t<bind_vertex_input semantic=\"texcoord_" + config.id + "\" input_semantic=\"TEXCOORD\" input_set=\"0\"/>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t\t</instance_material>");
+                }
+                colladaStream.WriteLine("\t\t\t\t\t\t</technique_common>");
+                colladaStream.WriteLine("\t\t\t\t\t</bind_material>");
                 colladaStream.WriteLine("\t\t\t\t</instance_geometry>");
                 colladaStream.WriteLine("\t\t\t</node>");
                 colladaStream.WriteLine("\t\t</visual_scene>");

--- a/LibReplanetizer/Serializers/ModelWriter.cs
+++ b/LibReplanetizer/Serializers/ModelWriter.cs
@@ -605,6 +605,9 @@ namespace LibReplanetizer
                 colladaStream.WriteLine("\t\t\t</node>");
                 colladaStream.WriteLine("\t\t</visual_scene>");
                 colladaStream.WriteLine("\t</library_visual_scenes>");
+                colladaStream.WriteLine("\t<scene>");
+                colladaStream.WriteLine("\t\t<instance_visual_scene url=\"#Scene\"/>");
+                colladaStream.WriteLine("\t</scene>");
 
                 colladaStream.WriteLine("</COLLADA>");
             }

--- a/Replanetizer/Frames/DemoWindowFrame.cs
+++ b/Replanetizer/Frames/DemoWindowFrame.cs
@@ -15,6 +15,7 @@ namespace Replanetizer.Frames
 
         public DemoWindowFrame(Window wnd) : base(wnd)
         {
+            frameName = "DefaultFrameName";
         }
 
         public override void Render(float deltaTime)

--- a/Replanetizer/Frames/LevelExportFrame.cs
+++ b/Replanetizer/Frames/LevelExportFrame.cs
@@ -15,7 +15,7 @@ namespace Replanetizer.Frames
     public class LevelExportFrame : LevelSubFrame
     {
         protected override string frameName { get; set; } = "Level Export";
-        private Level level => levelFrame.level;
+        private Level? level => levelFrame.level;
 
         private ModelWriter.WriterLevelSettings settings;
         private string[] enumNameMap;
@@ -25,9 +25,12 @@ namespace Replanetizer.Frames
             settings = new ModelWriter.WriterLevelSettings();
             enumNameMap = Enum.GetNames(typeof(ModelWriter.WriterLevelMode));
 
-            for (int i = 0; i < level.terrainChunks.Count; i++)
+            if (level != null)
             {
-                settings.chunksSelected[i] = true;
+                for (int i = 0; i < level.terrainChunks.Count; i++)
+                {
+                    settings.chunksSelected[i] = true;
+                }
             }
         }
 
@@ -68,16 +71,23 @@ namespace Replanetizer.Frames
                 ImGui.TreePop();
             }
 
-            if (ImGui.Button("Perform export"))
+
+            if (level == null)
             {
-                var res = CrossFileDialog.SaveFile("Level.obj", "*.obj");
-                if (res.Length > 0)
+                ImGui.Text("Export unavailable, no level found!");
+            }
+            else
+            {
+                if (ImGui.Button("Perform export"))
                 {
-                    ModelWriter.WriteObj(res, level, settings);
-                    isOpen = false;
+                    var res = CrossFileDialog.SaveFile("Level.obj", "*.obj");
+                    if (res.Length > 0)
+                    {
+                        ModelWriter.WriteObj(res, level, settings);
+                        isOpen = false;
+                    }
                 }
             }
-
         }
     }
 }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -217,7 +217,15 @@ namespace Replanetizer.Frames
                     }
                     if (ImGui.MenuItem("Model viewer"))
                     {
-                        subFrames.Add(new ModelFrame(this.wnd, this, this.shaderIDTable));
+                        if (selectedObjects.newestObject != null && selectedObjects.newestObject is ModelObject)
+                        {
+                            ModelObject obj = (ModelObject) selectedObjects.newestObject;
+                            subFrames.Add(new ModelFrame(this.wnd, this, this.shaderIDTable, obj.model));
+                        }
+                        else
+                        {
+                            subFrames.Add(new ModelFrame(this.wnd, this, this.shaderIDTable));
+                        }
                     }
                     if (ImGui.MenuItem("Texture viewer"))
                     {

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -141,7 +141,7 @@ namespace Replanetizer.Frames
 
                     if (ImGui.BeginMenu("Export"))
                     {
-                        if (ImGui.MenuItem("Collision"))
+                        if (ImGui.MenuItem("Collision (Internal R&C format only)"))
                         {
                             var res = CrossFileDialog.SaveFile();
                             if (res.Length > 0)

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -238,7 +238,7 @@ namespace Replanetizer.Frames
                     if (ImGui.MenuItem("Level variables"))
                     {
                         subFrames.Add(
-                            new PropertyFrame(this.wnd, this, "Level variables")
+                            new PropertyFrame(this.wnd, this, "Level variables", true)
                             {
                                 selectedObject = level.levelVariables
                             }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -57,6 +57,8 @@ namespace Replanetizer.Frames
         private Matrix4 view { get; set; }
 
         public readonly Selection selectedObjects;
+        private string[] selectionPositioningOptions = { PivotPositioning.Mean.HUMAN_NAME, PivotPositioning.IndividualOrigins.HUMAN_NAME };
+        private string[] selectionSpaceOptions = { TransformSpace.Global.HUMAN_NAME, TransformSpace.Local.HUMAN_NAME };
 
         private int antialiasing = 1;
         private string[] antialiasingOptions = { "Off", "2x MSAA", "4x MSAA", "8x MSAA", "16x MSAA", "32x MSAA", "64x MSAA", "128x MSAA", "256x MSAA", "512x MSAA" };
@@ -297,21 +299,31 @@ namespace Replanetizer.Frames
 
                 ImGui.Separator();
 
-                if (ImGui.Button(toolbox.transformSpace.HUMAN_NAME))
+                if (selectedObjects != null && selectedObjects.Count != 0)
                 {
-                    toolbox.transformSpace++;
-                    InvalidateView();
-                }
-                if (ImGui.IsItemHovered())
-                    ImGui.SetTooltip("Transform space");
+                    if (ImGui.BeginMenu("Selection"))
+                    {
+                        int transformSpace = toolbox.transformSpace.KEY;
+                        int pivotPositioning = toolbox.pivotPositioning.KEY;
 
-                if (ImGui.Button(toolbox.pivotPositioning.HUMAN_NAME))
-                {
-                    toolbox.pivotPositioning++;
-                    InvalidateView();
+                        ImGui.PushItemWidth(160.0f);
+                        if (ImGui.Combo("Transform Space", ref transformSpace, selectionSpaceOptions, selectionSpaceOptions.Count()))
+                        {
+                            toolbox.transformSpace = TransformSpace.GetByKey(transformSpace) ?? TransformSpace.Global;
+                            InvalidateView();
+                        }
+
+                        if (ImGui.Combo("Pivot Positioning", ref pivotPositioning, selectionPositioningOptions, selectionPositioningOptions.Count()))
+                        {
+                            toolbox.pivotPositioning = PivotPositioning.GetByKey(pivotPositioning) ?? PivotPositioning.Mean;
+                            InvalidateView();
+                        }
+                        ImGui.PopItemWidth();
+
+                        ImGui.EndMenu();
+                    }
+
                 }
-                if (ImGui.IsItemHovered())
-                    ImGui.SetTooltip("Pivot positioning");
 
                 ImGui.EndMenuBar();
             }
@@ -1006,12 +1018,17 @@ namespace Replanetizer.Frames
 
         private bool HandleSelect(LevelObject? obj)
         {
-            if (obj == null)
-                return false;
             if (wnd.MouseState.WasButtonDown(MouseButton.Left))
                 return false;
 
             bool isMultiSelect = KEYMAP.IsDown(Keybinds.MultiSelectModifier);
+
+            if (obj == null)
+            {
+                if (!isMultiSelect)
+                    selectedObjects.Clear();
+                return false;
+            }
 
             if (isMultiSelect)
                 selectedObjects.Toggle(obj);
@@ -1108,7 +1125,7 @@ namespace Replanetizer.Frames
             UpdateAaLevel();
         }
 
-        public LevelObject GetObjectAtScreenPosition(Vector2 pos)
+        public LevelObject? GetObjectAtScreenPosition(Vector2 pos)
         {
             if (xLock || yLock || zLock) return null;
 

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -474,7 +474,7 @@ namespace Replanetizer.Frames
             var model = selectedModel;
             if (model == null) return;
 
-            var fileName = CrossFileDialog.SaveFile(filter: ".obj;.iqe");
+            var fileName = CrossFileDialog.SaveFile(filter: ".obj;.iqe;.dae");
             if (fileName.Length == 0) return;
 
             var extension = Path.GetExtension(fileName);
@@ -485,6 +485,9 @@ namespace Replanetizer.Frames
                     break;
                 case ".iqe":
                     ModelWriter.WriteIqe(fileName, level, model);
+                    break;
+                case ".dae":
+                    ModelWriter.WriteDae(fileName, level, model);
                     break;
             }
         }

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -80,7 +80,7 @@ namespace Replanetizer.Frames
         private int width, height;
         private PropertyFrame propertyFrame;
 
-        public ModelFrame(Window wnd, LevelFrame levelFrame, ShaderIDTable shaderIDTable, Model model = null) : base(wnd, levelFrame)
+        public ModelFrame(Window wnd, LevelFrame levelFrame, ShaderIDTable shaderIDTable, Model? model = null) : base(wnd, levelFrame)
         {
             modelTextureList = new List<Texture>();
             propertyFrame = new PropertyFrame(wnd, listenToCallbacks: true, hideCallbackButton: true);
@@ -304,12 +304,12 @@ namespace Replanetizer.Frames
             }
         }
 
-        private void SelectModel(Model model)
+        private void SelectModel(Model? model)
         {
             SelectModel(model, level.textures);
         }
 
-        private void SelectModel(Model model, List<Texture> textures)
+        private void SelectModel(Model? model, List<Texture> textures)
         {
             if (model == null) return;
 

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -168,7 +168,7 @@ namespace Replanetizer.Frames
             else if (type == typeof(string))
             {
                 byte[] v = Encoding.ASCII.GetBytes(val as string ?? string.Empty);
-                if (ImGui.InputText(propertyName, v, (uint)v.Length))
+                if (ImGui.InputText(propertyName, v, (uint) v.Length))
                 {
                     propertyInfo.SetValue(selectedObject, Encoding.ASCII.GetString(v));
                     UpdateLevelFrame();
@@ -188,7 +188,7 @@ namespace Replanetizer.Frames
                 int v = unchecked((int) (uint) val);
                 if (ImGui.InputInt(propertyName, ref v))
                 {
-                    propertyInfo.SetValue(selectedObject, unchecked((uint)v));
+                    propertyInfo.SetValue(selectedObject, unchecked((uint) v));
                     UpdateLevelFrame();
                 }
             }
@@ -197,7 +197,7 @@ namespace Replanetizer.Frames
                 int v = Convert.ToInt32(val);
                 if (ImGui.InputInt(propertyName, ref v))
                 {
-                    propertyInfo.SetValue(selectedObject, (short)(v & 0xffff));
+                    propertyInfo.SetValue(selectedObject, (short) (v & 0xffff));
                     UpdateLevelFrame();
                 }
             }
@@ -206,7 +206,7 @@ namespace Replanetizer.Frames
                 int v = (ushort) val;
                 if (ImGui.InputInt(propertyName, ref v))
                 {
-                    propertyInfo.SetValue(selectedObject, unchecked((ushort)(v & 0xffff)));
+                    propertyInfo.SetValue(selectedObject, unchecked((ushort) (v & 0xffff)));
                     UpdateLevelFrame();
                 }
             }

--- a/Replanetizer/Frames/TextureFrame.cs
+++ b/Replanetizer/Frames/TextureFrame.cs
@@ -33,6 +33,8 @@ namespace Replanetizer.Frames
             var width = ImGui.GetWindowContentRegionWidth() - additionalOffset;
             var itemsPerRow = (int) Math.Floor(width / itemSizeX);
 
+            if (itemsPerRow == 0) return;
+
             int i = 0;
             while (i < textures.Count)
             {

--- a/Replanetizer/Frames/TextureFrame.cs
+++ b/Replanetizer/Frames/TextureFrame.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using ImGuiNET;
 using LibReplanetizer;
 using Replanetizer.Utils;
@@ -18,15 +19,16 @@ namespace Replanetizer.Frames
     {
         protected sealed override string frameName { get; set; } = "Textures";
         private Level level => levelFrame.level;
-        private static System.Numerics.Vector2 LIST_SIZE = new(64, 64);
+        private static Vector2 IMAGE_SIZE = new(64, 64);
+        private static Vector2 ITEM_SIZE = new(64, 84);
         private float itemSizeX;
 
         public TextureFrame(Window wnd, LevelFrame levelFrame) : base(wnd, levelFrame)
         {
-            itemSizeX = LIST_SIZE.X + ImGui.GetStyle().ItemSpacing.X;
+            itemSizeX = IMAGE_SIZE.X + ImGui.GetStyle().ItemSpacing.X;
         }
 
-        public static void RenderTextureList(List<Texture> textures, float itemSizeX, Dictionary<Texture, int> textureIds, int additionalOffset = 0)
+        public static void RenderTextureList(List<Texture> textures, float itemSizeX, Dictionary<Texture, int> textureIds, string prefix = "", int additionalOffset = 0)
         {
             var width = ImGui.GetWindowContentRegionWidth() - additionalOffset;
             var itemsPerRow = (int) Math.Floor(width / itemSizeX);
@@ -35,7 +37,15 @@ namespace Replanetizer.Frames
             while (i < textures.Count)
             {
                 Texture t = textures[i];
-                ImGui.Image((IntPtr) textureIds[t], LIST_SIZE);
+
+                ImGui.BeginChild("imageChild_" + prefix + i, ITEM_SIZE, false);
+                ImGui.Image((IntPtr) textureIds[t], IMAGE_SIZE);
+                string idText = prefix + i;
+                float idWidth = ImGui.CalcTextSize(idText).X;
+                ImGui.SetCursorPosX(ITEM_SIZE.X - idWidth);
+                ImGui.Text(idText);
+                ImGui.EndChild();
+
                 if (ImGui.BeginPopupContextItem($"context-menu for {i}"))
                 {
                     if (ImGui.Button("Export"))
@@ -51,8 +61,11 @@ namespace Replanetizer.Frames
                 else if (ImGui.IsItemHovered())
                 {
                     ImGui.BeginTooltip();
-                    ImGui.Text($"{t.width}x{t.height}");
                     ImGui.Image((IntPtr) textureIds[t], new System.Numerics.Vector2(t.width, t.height));
+                    string resolutionText = $"{t.width}x{t.height}";
+                    float resolutionWidth = ImGui.CalcTextSize(resolutionText).X;
+                    ImGui.SetCursorPosX(t.width - resolutionWidth);
+                    ImGui.Text(resolutionText);
                     ImGui.EndTooltip();
                 }
 

--- a/Replanetizer/Frames/TextureFrame.cs
+++ b/Replanetizer/Frames/TextureFrame.cs
@@ -38,9 +38,9 @@ namespace Replanetizer.Frames
             {
                 Texture t = textures[i];
 
-                ImGui.BeginChild("imageChild_" + prefix + i, ITEM_SIZE, false);
+                ImGui.BeginChild("imageChild_" + prefix + t.id, ITEM_SIZE, false);
                 ImGui.Image((IntPtr) textureIds[t], IMAGE_SIZE);
-                string idText = prefix + i;
+                string idText = prefix + t.id;
                 float idWidth = ImGui.CalcTextSize(idText).X;
                 ImGui.SetCursorPosX(ITEM_SIZE.X - idWidth);
                 ImGui.Text(idText);

--- a/Replanetizer/Frames/TextureFrame.cs
+++ b/Replanetizer/Frames/TextureFrame.cs
@@ -38,7 +38,7 @@ namespace Replanetizer.Frames
             {
                 Texture t = textures[i];
 
-                ImGui.BeginChild("imageChild_" + prefix + t.id, ITEM_SIZE, false);
+                ImGui.BeginChild("imageChild_" + prefix + i, ITEM_SIZE, false);
                 ImGui.Image((IntPtr) textureIds[t], IMAGE_SIZE);
                 string idText = prefix + t.id;
                 float idWidth = ImGui.CalcTextSize(idText).X;

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -88,7 +88,7 @@
   </ItemGroup>
 
   <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation">
-    <Exec Command="git describe --long --always --dirty --exclude=* --abbrev=8" ConsoleToMSBuild="True" IgnoreExitCode="False">
+    <Exec Command="git describe --long --always --dirty --exclude=* --abbrev=8" ConsoleToMSBuild="True" IgnoreExitCode="True">
       <Output PropertyName="SourceRevisionId" TaskParameter="ConsoleOutput" />
     </Exec>
   </Target>

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -36,8 +36,9 @@
   <ItemGroup>
     <PackageReference Include="ImGui.NET" Version="1.78.0" />
     <PackageReference Include="NLog" Version="4.7.10" />
-    <PackageReference Include="OpenTK" Version="4.6.4" />
-    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.6.4" />
+    <PackageReference Include="OpenTK" Version="4.6.7" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.6.7" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.6.7" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.1" />
   </ItemGroup>
 

--- a/Replanetizer/Tools/BasicTransformTool.cs
+++ b/Replanetizer/Tools/BasicTransformTool.cs
@@ -35,6 +35,8 @@ namespace Replanetizer.Tools
             Vector3 pivot = selection.mean;
             foreach (var obj in selection)
             {
+                if (obj is TerrainFragment) continue;
+
                 if (toolbox.pivotPositioning == PivotPositioning.IndividualOrigins)
                     pivot = obj.position;
                 Transform(obj, vec, pivot);

--- a/Replanetizer/Tools/BasicTransformTool.cs
+++ b/Replanetizer/Tools/BasicTransformTool.cs
@@ -32,7 +32,7 @@ namespace Replanetizer.Tools
         public void Transform(Selection selection, Vector3 direction, Vector3 magnitude)
         {
             Vector3 vec = ProcessVec(direction, magnitude);
-            Vector3 pivot = selection.median;
+            Vector3 pivot = selection.mean;
             foreach (var obj in selection)
             {
                 if (toolbox.pivotPositioning == PivotPositioning.IndividualOrigins)

--- a/Replanetizer/Tools/PivotPositioning.cs
+++ b/Replanetizer/Tools/PivotPositioning.cs
@@ -11,7 +11,7 @@ namespace Replanetizer.Tools
 {
     public class PivotPositioning : EnhancedEnum<PivotPositioning>
     {
-        public static readonly PivotPositioning Median = new(0, "Median");
+        public static readonly PivotPositioning Mean = new(0, "Mean");
         public static readonly PivotPositioning IndividualOrigins = new(1, "Individual origins");
 
         public PivotPositioning(int key, string humanName) : base(key, humanName)

--- a/Replanetizer/Tools/Tool.cs
+++ b/Replanetizer/Tools/Tool.cs
@@ -83,14 +83,14 @@ namespace Replanetizer.Tools
         {
             if (toolbox.transformSpace == TransformSpace.Global)
             {
-                Render(selection.median, frame);
+                Render(selection.mean, frame);
             }
             else if (toolbox.transformSpace == TransformSpace.Local)
             {
                 if (selection.newestObject != null)
-                    Render(selection.median, selection.newestObject.rotation, frame);
+                    Render(selection.mean, selection.newestObject.rotation, frame);
                 else
-                    Render(selection.median, frame);
+                    Render(selection.mean, frame);
             }
         }
 

--- a/Replanetizer/Tools/Toolbox.cs
+++ b/Replanetizer/Tools/Toolbox.cs
@@ -24,7 +24,7 @@ namespace Replanetizer.Tools
         public Tool? tool => _tool;
         public ToolType type => _type;
         public TransformSpace transformSpace { get; set; } = TransformSpace.Global;
-        public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.Median;
+        public PivotPositioning pivotPositioning { get; set; } = PivotPositioning.Mean;
 
         public event EventHandler<ToolChangedEventArgs>? ToolChanged;
 

--- a/Replanetizer/Utils/FramebufferRenderer.cs
+++ b/Replanetizer/Utils/FramebufferRenderer.cs
@@ -6,7 +6,7 @@
 // Please see the LICENSE.md file for more details.
 
 using System;
-using OpenTK.Graphics.OpenGL4;
+using OpenTK.Graphics.OpenGL;
 
 namespace Replanetizer.Utils
 {

--- a/Replanetizer/Utils/GLTexture.cs
+++ b/Replanetizer/Utils/GLTexture.cs
@@ -8,8 +8,8 @@
 using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using OpenTK.Graphics.OpenGL4;
-using PixelFormat = OpenTK.Graphics.OpenGL4.PixelFormat;
+using OpenTK.Graphics.OpenGL;
+using PixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 
 namespace Replanetizer.Utils
 {

--- a/Replanetizer/Utils/ImGuiController.cs
+++ b/Replanetizer/Utils/ImGuiController.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using ImGuiNET;
-using OpenTK.Graphics.OpenGL4;
+using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Desktop;
 using OpenTK.Windowing.GraphicsLibraryFramework;

--- a/Replanetizer/Utils/RenderableBuffer.cs
+++ b/Replanetizer/Utils/RenderableBuffer.cs
@@ -38,7 +38,7 @@ namespace Replanetizer.Utils
         private Level level;
         private Dictionary<Texture, int> textureIds;
 
-        public static ShaderIDTable SHADER_ID_TABLE { get; set; }
+        public static ShaderIDTable? SHADER_ID_TABLE { get; set; }
 
         public RenderableBuffer(ModelObject modelObject, RenderedObjectType type, int id, Level level, Dictionary<Texture, int> textureIds)
         {
@@ -272,6 +272,7 @@ namespace Replanetizer.Utils
         /// </summary>
         public void Render()
         {
+            if (SHADER_ID_TABLE == null) return;
             if (culled) return;
             if (!BindIbo() || !BindVbo()) return;
 

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -16,24 +16,24 @@ namespace Replanetizer.Utils
         private readonly HashSet<LevelObject> OBJECTS = new();
 
         /// <summary>
-        /// The median point of all selected objects (averaged positions)
+        /// The mean point of all selected objects (averaged positions)
         /// </summary>
-        public Vector3 median
+        public Vector3 mean
         {
             get
             {
-                if (medianDirty)
+                if (meanDirty)
                 {
-                    _median = CalculateMedian();
-                    medianDirty = false;
+                    _mean = CalculateMean();
+                    meanDirty = false;
                 }
 
-                return _median;
+                return _mean;
             }
         }
 
-        private bool medianDirty;
-        private Vector3 _median;
+        private bool meanDirty;
+        private Vector3 _mean;
 
         /// <summary>
         /// Whether the selection contains only splines
@@ -79,7 +79,7 @@ namespace Replanetizer.Utils
         /// </summary>
         public void SetDirty(bool dirty = true)
         {
-            medianDirty = dirty;
+            meanDirty = dirty;
         }
 
         /// <summary>
@@ -249,17 +249,17 @@ namespace Replanetizer.Utils
         }
 
         /// <summary>
-        /// Calculate the median point of all selected object
+        /// Calculate the mean point of all selected object
         /// </summary>
-        private Vector3 CalculateMedian()
+        private Vector3 CalculateMean()
         {
-            var median = new Vector3();
+            var mean = new Vector3();
             foreach (var obj in OBJECTS)
             {
-                median += obj.position;
+                mean += obj.position;
             }
-            median /= OBJECTS.Count;
-            return median;
+            mean /= OBJECTS.Count;
+            return mean;
         }
     }
 }

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -254,11 +254,17 @@ namespace Replanetizer.Utils
         private Vector3 CalculateMean()
         {
             var mean = new Vector3();
+            int count = 0;
+
             foreach (var obj in OBJECTS)
             {
+                if (obj is TerrainFragment) continue;
+
                 mean += obj.position;
+                count++;
             }
-            mean /= OBJECTS.Count;
+
+            mean /= count;
             return mean;
         }
     }

--- a/Replanetizer/Utils/Selection.cs
+++ b/Replanetizer/Utils/Selection.cs
@@ -88,6 +88,7 @@ namespace Replanetizer.Utils
         public void Clear()
         {
             OBJECTS.Clear();
+            newestObject = null;
 
             splinesCount = 0;
             nonSplinesCount = 0;

--- a/Replanetizer/Utils/Shader.cs
+++ b/Replanetizer/Utils/Shader.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using OpenTK.Graphics.OpenGL4;
+using OpenTK.Graphics.OpenGL;
 
 namespace Replanetizer.Utils
 {

--- a/Replanetizer/Utils/Util.cs
+++ b/Replanetizer/Utils/Util.cs
@@ -8,7 +8,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using OpenTK.Graphics.OpenGL4;
+using OpenTK.Graphics.OpenGL;
 
 namespace Replanetizer.Utils
 {

--- a/Replanetizer/Window.cs
+++ b/Replanetizer/Window.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using ImGuiNET;
 using LibReplanetizer;
-using OpenTK.Graphics.OpenGL4;
+using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;


### PR DESCRIPTION
Changes:
- Added collada (`*.dae`) exporter which can export rigged models.
- Added ID to each texture in textureFrame.
- SelectedObject in levelFrame is now highlighted on opening the modelFrame.
- Changed selection options menu.
- Fixed median/mean misnomer.
- Fixed terrainFragments being part of transformations.
- Fixed level variable frame not working.
- Added a hint to collision export that it is using the internal RaC format to avoid that people think they could use it somewhere else.

Closes #67