### PR TITLE
Fixes serialization of language

### DIFF
--- a/LibReplanetizer/DataFunctions.cs
+++ b/LibReplanetizer/DataFunctions.cs
@@ -135,21 +135,23 @@ namespace LibReplanetizer
             return new byte[0];
         }
 
-        public static String ReadString(FileStream fs, int offset)
+        public static byte[] ReadString(FileStream fs, int offset)
         {
-            String output = "";
+            var output = new List<byte>();
+
             fs.Seek(offset, SeekOrigin.Begin);
-            int pos = offset;
 
             byte[] buffer = new byte[4];
             do
             {
                 fs.Read(buffer, 0, 4);
-                output += System.Text.Encoding.ASCII.GetString(buffer);
+                output.AddRange(buffer);
             }
             while (buffer[3] != '\0');
 
-            return output.Substring(0, output.IndexOf('\0'));
+            output.RemoveAll(item => item == 0);
+
+            return output.ToArray();
         }
 
         public static void WriteUint(byte[] byteArr, int offset, uint input)

--- a/LibReplanetizer/Level Objects/Gameplay/LanguageData.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/LanguageData.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using System.Collections.Generic;
+using static LibReplanetizer.DataFunctions;
+
+namespace LibReplanetizer.LevelObjects
+{
+    public class LanguageData
+    {
+        public const int ELEMENTSIZE = 0x10;
+        public int id;
+        public int secondId; // sound id?
+        public byte[] text;
+
+        public LanguageData(byte[] block, int index)
+        {
+            int headOffset = 8 + index * ELEMENTSIZE;
+
+            int offset = ReadInt(block, headOffset + 0x00);
+            id = ReadInt(block, headOffset + 0x04);
+            secondId = ReadInt(block, headOffset + 0x08);
+
+            List<byte> output = new();
+
+            output.AddRange(block[offset..(offset + 4)]);
+            while (block[offset + 3] != 0)
+            {
+                offset += 4;
+                output.AddRange(block[offset..(offset + 4)]);
+            }
+
+            output.RemoveAll(item => item == 0);
+            text = output.ToArray();
+        }
+
+    }
+}

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -64,14 +64,14 @@ namespace LibReplanetizer
         public LevelVariables levelVariables;
         public OcclusionData occlusionData;
 
-        public Dictionary<int, String> english;
-        public Dictionary<int, String> ukenglish;
-        public Dictionary<int, String> french;
-        public Dictionary<int, String> german;
-        public Dictionary<int, String> spanish;
-        public Dictionary<int, String> italian;
-        public Dictionary<int, String> japanese;
-        public Dictionary<int, String> korean;
+        public Dictionary<int, byte[]> english;
+        public Dictionary<int, byte[]> ukenglish;
+        public Dictionary<int, byte[]> french;
+        public Dictionary<int, byte[]> german;
+        public Dictionary<int, byte[]> spanish;
+        public Dictionary<int, byte[]> italian;
+        public Dictionary<int, byte[]> japanese;
+        public Dictionary<int, byte[]> korean;
 
         public byte[] unk3;
         public byte[] unk4;

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -64,14 +64,14 @@ namespace LibReplanetizer
         public LevelVariables levelVariables;
         public OcclusionData occlusionData;
 
-        public Dictionary<int, byte[]> english;
-        public Dictionary<int, byte[]> ukenglish;
-        public Dictionary<int, byte[]> french;
-        public Dictionary<int, byte[]> german;
-        public Dictionary<int, byte[]> spanish;
-        public Dictionary<int, byte[]> italian;
-        public Dictionary<int, byte[]> japanese;
-        public Dictionary<int, byte[]> korean;
+        public List<LanguageData> english;
+        public List<LanguageData> ukenglish;
+        public List<LanguageData> french;
+        public List<LanguageData> german;
+        public List<LanguageData> spanish;
+        public List<LanguageData> italian;
+        public List<LanguageData> japanese;
+        public List<LanguageData> korean;
 
         public byte[] unk3;
         public byte[] unk4;

--- a/LibReplanetizer/Parsers/GameplayParser.cs
+++ b/LibReplanetizer/Parsers/GameplayParser.cs
@@ -53,15 +53,15 @@ namespace LibReplanetizer.Parsers
             return new LevelVariables(game, fileStream, gameplayHeader.levelVarPointer, gameplayHeader.englishPointer - gameplayHeader.levelVarPointer);
         }
 
-        public Dictionary<int, String> GetLang(int offset)
+        public Dictionary<int, byte[]> GetLang(int offset)
         {
-            if (offset == 0) { return new Dictionary<int, string>(); }
+            if (offset == 0) { return new Dictionary<int, byte[]>(); }
 
             byte[] langHeader = ReadBlock(fileStream, offset, 0x08);
             int numItems = ReadInt(langHeader, 0x00);
             int langLength = ReadInt(langHeader, 0x04);
 
-            Dictionary<int, String> languageData = new Dictionary<int, String>();
+            var languageData = new Dictionary<int, byte[]>();
 
             for (int i = 0; i < numItems; i++)
             {
@@ -71,49 +71,49 @@ namespace LibReplanetizer.Parsers
                 int textPointer = ReadInt(block, 0x00);
                 int textId = ReadInt(block, 0x04);
 
-                String textData = ReadString(fileStream, offset + textPointer);
+                byte[] textData = ReadString(fileStream, offset + textPointer);
                 languageData.Add(textId, textData);
             }
 
             return languageData;
         }
 
-        public Dictionary<int, String> GetEnglish()
+        public Dictionary<int, byte[]> GetEnglish()
         {
             return GetLang(gameplayHeader.englishPointer);
         }
 
-        public Dictionary<int, String> GetUkEnglish()
+        public Dictionary<int, byte[]> GetUkEnglish()
         {
             return GetLang(gameplayHeader.ukenglishPointer);
         }
 
-        public Dictionary<int, String> GetFrench()
+        public Dictionary<int, byte[]> GetFrench()
         {
             return GetLang(gameplayHeader.frenchPointer);
         }
 
-        public Dictionary<int, String> GetGerman()
+        public Dictionary<int, byte[]> GetGerman()
         {
             return GetLang(gameplayHeader.germanPointer);
         }
 
-        public Dictionary<int, String> GetSpanish()
+        public Dictionary<int, byte[]> GetSpanish()
         {
             return GetLang(gameplayHeader.spanishPointer);
         }
 
-        public Dictionary<int, String> GetItalian()
+        public Dictionary<int, byte[]> GetItalian()
         {
             return GetLang(gameplayHeader.italianPointer);
         }
 
-        public Dictionary<int, String> GetJapanese()
+        public Dictionary<int, byte[]> GetJapanese()
         {
             return GetLang(gameplayHeader.japanesePointer);
         }
 
-        public Dictionary<int, String> GetKorean()
+        public Dictionary<int, byte[]> GetKorean()
         {
             return GetLang(gameplayHeader.koreanPointer);
         }

--- a/LibReplanetizer/Parsers/GameplayParser.cs
+++ b/LibReplanetizer/Parsers/GameplayParser.cs
@@ -53,67 +53,63 @@ namespace LibReplanetizer.Parsers
             return new LevelVariables(game, fileStream, gameplayHeader.levelVarPointer, gameplayHeader.englishPointer - gameplayHeader.levelVarPointer);
         }
 
-        public Dictionary<int, byte[]> GetLang(int offset)
+        public List<LanguageData> GetLang(int offset)
         {
-            if (offset == 0) { return new Dictionary<int, byte[]>(); }
+            if (offset == 0) { return new List<LanguageData>(); }
 
             byte[] langHeader = ReadBlock(fileStream, offset, 0x08);
             int numItems = ReadInt(langHeader, 0x00);
             int langLength = ReadInt(langHeader, 0x04);
 
-            var languageData = new Dictionary<int, byte[]>();
+
+            byte[] langBlock = ReadBlock(fileStream, offset, langLength);
+
+            var languageData = new List<LanguageData>();
 
             for (int i = 0; i < numItems; i++)
             {
-                int pointerOffset = offset + 8 + (i * 16);
-                byte[] block = ReadBlock(fileStream, pointerOffset, 0x08);
-
-                int textPointer = ReadInt(block, 0x00);
-                int textId = ReadInt(block, 0x04);
-
-                byte[] textData = ReadString(fileStream, offset + textPointer);
-                languageData.Add(textId, textData);
+                languageData.Add(new LanguageData(langBlock, i));
             }
 
             return languageData;
         }
 
-        public Dictionary<int, byte[]> GetEnglish()
+        public List<LanguageData> GetEnglish()
         {
             return GetLang(gameplayHeader.englishPointer);
         }
 
-        public Dictionary<int, byte[]> GetUkEnglish()
+        public List<LanguageData> GetUkEnglish()
         {
             return GetLang(gameplayHeader.ukenglishPointer);
         }
 
-        public Dictionary<int, byte[]> GetFrench()
+        public List<LanguageData> GetFrench()
         {
             return GetLang(gameplayHeader.frenchPointer);
         }
 
-        public Dictionary<int, byte[]> GetGerman()
+        public List<LanguageData> GetGerman()
         {
             return GetLang(gameplayHeader.germanPointer);
         }
 
-        public Dictionary<int, byte[]> GetSpanish()
+        public List<LanguageData> GetSpanish()
         {
             return GetLang(gameplayHeader.spanishPointer);
         }
 
-        public Dictionary<int, byte[]> GetItalian()
+        public List<LanguageData> GetItalian()
         {
             return GetLang(gameplayHeader.italianPointer);
         }
 
-        public Dictionary<int, byte[]> GetJapanese()
+        public List<LanguageData> GetJapanese()
         {
             return GetLang(gameplayHeader.japanesePointer);
         }
 
-        public Dictionary<int, byte[]> GetKorean()
+        public List<LanguageData> GetKorean()
         {
             return GetLang(gameplayHeader.koreanPointer);
         }

--- a/LibReplanetizer/Serializers/GameplaySerializer.cs
+++ b/LibReplanetizer/Serializers/GameplaySerializer.cs
@@ -253,11 +253,11 @@ namespace LibReplanetizer.Serializers
             fs.Write(head, 0, head.Length);
         }
 
-        public static byte[] GetLangBytes(Dictionary<int, String> languageData)
+        public static byte[] GetLangBytes(Dictionary<int, byte[]> languageData)
         {
             int headerSize = (languageData.Count() * 16) + 8;
             int dataSize = 0;
-            foreach (KeyValuePair<int, String> entry in languageData)
+            foreach (KeyValuePair<int, byte[]> entry in languageData)
             {
                 int entrySize = entry.Value.Length + 1;
                 if (entrySize % 4 != 0)
@@ -276,7 +276,7 @@ namespace LibReplanetizer.Serializers
             int textPos = headerSize;
             int headerPos = 8;
 
-            foreach (KeyValuePair<int, String> entry in languageData)
+            foreach (KeyValuePair<int, byte[]> entry in languageData)
             {
                 int entrySize = entry.Value.Length + 1;
                 if (entrySize % 4 != 0)
@@ -284,7 +284,7 @@ namespace LibReplanetizer.Serializers
                     entrySize += 4 - (entrySize % 4);
                 }
 
-                System.Text.Encoding.ASCII.GetBytes(entry.Value, 0, entry.Value.Length, bytes, textPos);
+                entry.Value.CopyTo(bytes, textPos);
 
                 WriteUint(bytes, headerPos, (uint) textPos);
                 WriteUint(bytes, headerPos + 4, (uint) entry.Key);

--- a/LibReplanetizer/Serializers/GameplaySerializer.cs
+++ b/LibReplanetizer/Serializers/GameplaySerializer.cs
@@ -253,13 +253,13 @@ namespace LibReplanetizer.Serializers
             fs.Write(head, 0, head.Length);
         }
 
-        public static byte[] GetLangBytes(Dictionary<int, byte[]> languageData)
+        public static byte[] GetLangBytes(List<LanguageData> languageData)
         {
-            int headerSize = (languageData.Count() * 16) + 8;
+            int headerSize = (languageData.Count * 16) + 8;
             int dataSize = 0;
-            foreach (KeyValuePair<int, byte[]> entry in languageData)
+            foreach (LanguageData entry in languageData)
             {
-                int entrySize = entry.Value.Length + 1;
+                int entrySize = entry.text.Length + 1;
                 if (entrySize % 4 != 0)
                 {
                     entrySize += (4 - entrySize % 4);
@@ -270,25 +270,25 @@ namespace LibReplanetizer.Serializers
             int totalSize = headerSize + dataSize;
             byte[] bytes = new byte[totalSize];
 
-            WriteUint(bytes, 0, (uint) languageData.Count());
+            WriteUint(bytes, 0, (uint) languageData.Count);
             WriteUint(bytes, 4, (uint) totalSize);
 
             int textPos = headerSize;
             int headerPos = 8;
 
-            foreach (KeyValuePair<int, byte[]> entry in languageData)
+            foreach (LanguageData entry in languageData)
             {
-                int entrySize = entry.Value.Length + 1;
+                int entrySize = entry.text.Length + 1;
                 if (entrySize % 4 != 0)
                 {
                     entrySize += 4 - (entrySize % 4);
                 }
 
-                entry.Value.CopyTo(bytes, textPos);
+                entry.text.CopyTo(bytes, textPos);
 
                 WriteUint(bytes, headerPos, (uint) textPos);
-                WriteUint(bytes, headerPos + 4, (uint) entry.Key);
-                WriteUint(bytes, headerPos + 8, 0xFFFFFFFF);
+                WriteUint(bytes, headerPos + 4, (uint) entry.id);
+                WriteInt(bytes, headerPos + 8, entry.secondId);
                 WriteUint(bytes, headerPos + 12, 0);
                 headerPos += 16;
                 textPos += entrySize;


### PR DESCRIPTION
Previously we parsed language data as ASCII characters which meant that any character outside the ASCII range got parsed as a ?. Because of this dataloss the gameplay_ntsc file could not be reconstructed. This PR fixes that, and also parses the secondary id data in the "header" portion of the language data. I believe this is used to indicate soundclips that are supposed to be played during helpdesk messages.

Notably this will break the previous string viewer UI, but that doesn't seem to be reimplemented in the imgui version, so I guess it's fine.