### PR TITLE
Skybox Export and Vertex Color Export in Collada

### DIFF
--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -141,6 +141,11 @@ namespace Replanetizer.Frames
                     }
                     ImGui.TreePop();
                 }
+                if (ImGui.TreeNode("Miscellaneous"))
+                {
+                    RenderModelEntry(level.skybox, level.textures, "Skybox");
+                    ImGui.TreePop();
+                }
                 ImGui.EndChild();
             }
         }
@@ -368,7 +373,7 @@ namespace Replanetizer.Frames
             GL.ClearColor(Color.SkyBlue);
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
-            if (selectedModel != null)
+            if (selectedModel != null && !(selectedModel is SkyboxModel))
             {
                 // Has to be done in this order to work correctly
                 Matrix4 mvp = trans * scale * rot;


### PR DESCRIPTION
The skybox now appears in the model viewer (though it is not rendered).

The skybox can be exported for both `.obj` and `.dae` formats. The `.dae` format also includes the vertex colors. 

Since I had to implement vertex colors for collada, I also added vertex color export for terrain, 