### PR TITLE
.Net 6, dithered transparency, RaC 3 transparency bugfixes and new level variables.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,14 +4,14 @@ on: [push]
 
 jobs:
   build_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       release_name: ${{ steps.get-version.outputs.release_name }}
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - run: dotnet --list-runtimes && dotnet --list-sdks
         name: Output dotnet versions for debugging
@@ -39,13 +39,13 @@ jobs:
           path: /tmp/zips/replanetizer-${{steps.get-version.outputs.release_name}}-linux-x64.zip
 
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [build_linux]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - run: dotnet --list-runtimes && dotnet --list-sdks
         name: Output dotnet versions for debugging
@@ -56,7 +56,7 @@ jobs:
       - run: mkdir -p /tmp/zips
         name: Create output directory
 
-      - run: dotnet publish -c Release -o /tmp/out-win/replanetizer --self-contained --runtime win-x64 --framework net5.0-windows Replanetizer
+      - run: dotnet publish -c Release -o /tmp/out-win/replanetizer --self-contained --runtime win-x64 Replanetizer
         name: Build Replanetizer for Windows
 
       - run: Compress-Archive -Path /tmp/out-win/replanetizer -DestinationPath /tmp/zips/replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip
@@ -69,13 +69,13 @@ jobs:
             path: /tmp/zips/replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip
 
   build_macos:
-    runs-on: macos-10.15
+    runs-on: macos-12
     needs: [build_linux]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - run: dotnet --list-runtimes && dotnet --list-sdks
         name: Output dotnet versions for debugging
@@ -86,7 +86,7 @@ jobs:
       - run: mkdir -p /tmp/zips
         name: Create output directory
 
-      - run: dotnet publish -c Release -o /tmp/out-osx/replanetizer --self-contained --runtime osx-x64 --framework net5.0 Replanetizer
+      - run: dotnet publish -c Release -o /tmp/out-osx/replanetizer --self-contained --runtime osx-x64 Replanetizer
         name: Build Replanetizer for Mac
 
       - run: cd /tmp/out-osx/ && zip -r /tmp/zips/replanetizer-${{needs.build_linux.outputs.release_name}}-osx-x64.zip replanetizer

--- a/LibReplanetizer/Level Objects/QuaternionTypeConverter.cs
+++ b/LibReplanetizer/Level Objects/QuaternionTypeConverter.cs
@@ -16,12 +16,14 @@ namespace LibReplanetizer.Level_Objects
 {
     class QuaternionTypeConverter : TypeConverter
     {
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {
+            if (destinationType == null) return false;
+
             return destinationType == typeof(string);
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {
             if (destinationType == typeof(string) && value is Quaternion q)
             {
@@ -31,7 +33,9 @@ namespace LibReplanetizer.Level_Objects
                     z: (float) Math.Atan2(2.0 * (q.W * q.Z + q.X * q.Y), 1.0 - 2.0 * (q.Y * q.Y + q.Z * q.Z)));
                 return "(" + v.X + ". " + v.Y + ". " + v.Z + ")";
             }
-            return base.ConvertTo(context, culture, value, destinationType);
+            object? o = base.ConvertTo(context, culture, value, destinationType);
+
+            return (o == null) ? new object() : o;
         }
     }
 }

--- a/LibReplanetizer/LibReplanetizer.csproj
+++ b/LibReplanetizer/LibReplanetizer.csproj
@@ -12,10 +12,4 @@
     <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="NLog.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/LibReplanetizer/LibReplanetizer.csproj
+++ b/LibReplanetizer/LibReplanetizer.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/LibReplanetizer/Models/MobyModel.cs
+++ b/LibReplanetizer/Models/MobyModel.cs
@@ -5,6 +5,7 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using System.ComponentModel;
 using LibReplanetizer.Models.Animations;
 using System.Collections.Generic;
 using System.IO;
@@ -23,16 +24,22 @@ namespace LibReplanetizer.Models
 
         public int null1 { get; set; }
 
+        [Category("Attributes"), DisplayName("Bone Count")]
         public byte boneCount { get; set; }
+        [Category("Attributes"), DisplayName("Low Poly Bone Count")]
         public byte lpBoneCount { get; set; }            // Low poly bone count
         public byte count3 { get; set; }
         public byte count4 { get; set; }
+        [Category("Attributes"), DisplayName("Low Poly Render Distance")]
         public byte lpRenderDist { get; set; }            // Low poly render distance
         public byte count8 { get; set; }
 
         public int null2 { get; set; }
         public int null3 { get; set; }
 
+        /*
+         * These are not zero, yet setting them to 0 has no effect on Oozla (maybe test other levels?)
+         */
         public float unk1 { get; set; }
         public float unk2 { get; set; }
         public float unk3 { get; set; }
@@ -43,11 +50,17 @@ namespace LibReplanetizer.Models
 
         public ushort vertexCount2 { get; set; }
 
+        [Category("Attributes"), DisplayName("Animations")]
         public List<Animation> animations { get; set; } = new List<Animation>();
+        [Category("Attributes"), DisplayName("Sounds")]
         public List<ModelSound> modelSounds { get; set; } = new List<ModelSound>();
+        [Category("Attributes"), DisplayName("Attachments")]
         public List<Attachment> attachments { get; set; } = new List<Attachment>();
+        [Category("Attributes"), DisplayName("Index Attachments")]
         public List<byte> indexAttachments { get; set; } = new List<byte>();
+        [Category("Attributes"), DisplayName("Bone Matrices")]
         public List<BoneMatrix> boneMatrices { get; set; } = new List<BoneMatrix>();
+        [Category("Attributes"), DisplayName("Bone Datas")]
         public List<BoneData> boneDatas { get; set; } = new List<BoneData>();
 
 
@@ -55,7 +68,8 @@ namespace LibReplanetizer.Models
         public List<TextureConfig> otherTextureConfigs { get; set; } = new List<TextureConfig>();
         public List<ushort> otherIndexBuffer { get; set; } = new List<ushort>();
         public Skeleton? skeleton = null;
-        public bool isModel = true;
+        [Category("Attributes"), DisplayName("Is Model")]
+        public bool isModel { get; set; } = true;
 
 
         // Unparsed sections

--- a/LibReplanetizer/Models/Model.cs
+++ b/LibReplanetizer/Models/Model.cs
@@ -37,7 +37,7 @@ namespace LibReplanetizer.Models
         [Category("Attributes"), DisplayName("Vertex Colors")]
         public byte[] rgbas { get; set; } = new byte[0];
 
-        [Category("Attributes"), DisplayName("Texture Configuration")]
+        [Category("Attributes"), DisplayName("Texture Configurations")]
         public List<TextureConfig> textureConfig { get; set; } = new List<TextureConfig>();
 
         public ushort[] GetIndices()

--- a/LibReplanetizer/Models/Model.cs
+++ b/LibReplanetizer/Models/Model.cs
@@ -5,6 +5,7 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using System.ComponentModel;
 using LibReplanetizer.LevelObjects;
 using System.Collections.Generic;
 using System.IO;
@@ -20,19 +21,23 @@ namespace LibReplanetizer.Models
     public abstract class Model : IRenderable
     {
         public short id { get; set; }
-        public float size = 1.0f;
+        [Category("Attributes"), DisplayName("Size")]
+        public float size { get; set; } = 1.0f;
         public float[] vertexBuffer = { };
         public ushort[] indexBuffer = { };
 
         // Every vertex can be assigned to at most 4 bones
         // weights contains 4 uint8 each being of weight (value / 255.0)
         // ids contains 4 uint8 each defining which bones we refer to
-        public uint[] weights = new uint[0];
-        public uint[] ids = new uint[0];
+        [Category("Attributes"), DisplayName("Bone Weights")]
+        public uint[] weights { get; set; } = new uint[0];
+        [Category("Attributes"), DisplayName("Vertex to Bone Map")]
+        public uint[] ids { get; set; } = new uint[0];
 
-        public byte[] rgbas = new byte[0];
+        [Category("Attributes"), DisplayName("Vertex Colors")]
+        public byte[] rgbas { get; set; } = new byte[0];
 
-
+        [Category("Attributes"), DisplayName("Texture Configuration")]
         public List<TextureConfig> textureConfig { get; set; } = new List<TextureConfig>();
 
         public ushort[] GetIndices()

--- a/LibReplanetizer/Models/ShrubModel.cs
+++ b/LibReplanetizer/Models/ShrubModel.cs
@@ -5,6 +5,7 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using System.ComponentModel;
 using System.IO;
 using static LibReplanetizer.DataFunctions;
 
@@ -16,9 +17,13 @@ namespace LibReplanetizer.Models
         const int SHRUBVERTELEMSIZE = 0x18;
         const int SHRUBUVELEMSIZE = 0x08;
 
+        [Category("Culling Parameters"), DisplayName("Position X")]
         public float cullingX { get; set; }
+        [Category("Culling Parameters"), DisplayName("Position Y")]
         public float cullingY { get; set; }
+        [Category("Culling Parameters"), DisplayName("Position Z")]
         public float cullingZ { get; set; }
+        [Category("Culling Parameters"), DisplayName("Radius")]
         public float cullingRadius { get; set; }
 
         public uint off20 { get; set; }

--- a/LibReplanetizer/Models/Texture.cs
+++ b/LibReplanetizer/Models/Texture.cs
@@ -98,13 +98,22 @@ namespace LibReplanetizer
             return outBytes;
         }
 
-        public Bitmap? GetTextureImage()
+        public Bitmap? GetTextureImage(bool includeTransparency)
         {
             if (img != null) return img;
 
             byte[]? imgData = DecompressDxt5(data, width, height);
+
             if (imgData != null)
             {
+                if (!includeTransparency)
+                {
+                    for (int i = 0; i < width * height; i++)
+                    {
+                        imgData[i * 4 + 3] = 255;
+                    }
+                }
+
                 img = new Bitmap(width, height, PixelFormat.Format32bppArgb);
                 BitmapData bmData = img.LockBits(new Rectangle(0, 0, img.Width, img.Height), ImageLockMode.ReadWrite, img.PixelFormat);
                 IntPtr pNative = bmData.Scan0;

--- a/LibReplanetizer/Models/TextureConfig.cs
+++ b/LibReplanetizer/Models/TextureConfig.cs
@@ -5,13 +5,19 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using System.ComponentModel;
+
 namespace LibReplanetizer
 {
     public class TextureConfig
     {
+        [Category("Attributes"), DisplayName("Texture ID")]
         public int id { get; set; }
+        [Category("Attributes"), DisplayName("Vertex Start Index")]
         public int start { get; set; }
+        [Category("Attributes"), DisplayName("Number of Vertices")]
         public int size { get; set; }
+        [Category("Attributes"), DisplayName("Mode")]
         public int mode { get; set; }
     }
 }

--- a/LibReplanetizer/Models/TextureConfig.cs
+++ b/LibReplanetizer/Models/TextureConfig.cs
@@ -19,5 +19,27 @@ namespace LibReplanetizer
         public int size { get; set; }
         [Category("Attributes"), DisplayName("Mode")]
         public int mode { get; set; }
+
+        /*
+         * The textureConfig modes in the following are probably bitmask but more testing is required
+         * to confirm that, until then simply add all modes that are observed.
+         * Ideally write the binary + the game in which this was observed as it could be that the
+         * bitmasks differ between the games.
+         */
+
+        public bool IgnoresTransparency()
+        {
+            switch (mode)
+            {
+                case 136311: /* 100001010001110111 (RaC 3) */
+                case 136279: /* 100001010001010111 (RaC 3) */
+                case 136277: /* 100001010001010101 (RaC 3) */
+                case 136533: /* 100001010101010101 (RaC 3) */
+                case 136447: /* 100001010011111111 (RaC 3) */
+                    return true;
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/LibReplanetizer/Models/TieModel.cs
+++ b/LibReplanetizer/Models/TieModel.cs
@@ -5,6 +5,7 @@
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
+using System.ComponentModel;
 using System.IO;
 using static LibReplanetizer.DataFunctions;
 
@@ -16,9 +17,13 @@ namespace LibReplanetizer.Models
         const int TIEVERTELEMSIZE = 0x18;
         const int TIEUVELEMSIZE = 0x08;
 
+        [Category("Culling Parameters"), DisplayName("Position X")]
         public float cullingX { get; set; }
+        [Category("Culling Parameters"), DisplayName("Position Y")]
         public float cullingY { get; set; }
+        [Category("Culling Parameters"), DisplayName("Position Z")]
         public float cullingZ { get; set; }
+        [Category("Culling Parameters"), DisplayName("Radius")]
         public float cullingRadius { get; set; }
 
         public uint off20 { get; set; }

--- a/LibReplanetizer/Utilities.cs
+++ b/LibReplanetizer/Utilities.cs
@@ -150,12 +150,12 @@ namespace LibReplanetizer
 
     public class Vector3Converter : TypeConverter
     {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(string);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        public override object ConvertFrom(ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object value)
         {
             try
             {
@@ -168,12 +168,19 @@ namespace LibReplanetizer
             }
             catch
             {
-                return context.PropertyDescriptor.GetValue(context.Instance);
+                if (context == null)
+                {
+                    return new object();
+                }
+                object? o = context.PropertyDescriptor.GetValue(context.Instance);
+                return (o == null) ? new object() : o;
             }
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        public override object ConvertTo(ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, Type destinationType)
         {
+            if (value == null) return "0.0 0.0 0.0";
+
             Vector3 p = (Vector3) value;
             return String.Format(
                 "{0} {1} {2}",
@@ -185,12 +192,12 @@ namespace LibReplanetizer
     }
     public class Vector3RadiansConverter : TypeConverter
     {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(string);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        public override object ConvertFrom(ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object value)
         {
             try
             {
@@ -203,12 +210,19 @@ namespace LibReplanetizer
             }
             catch
             {
-                return context.PropertyDescriptor.GetValue(context.Instance);
+                if (context == null)
+                {
+                    return new object();
+                }
+                object? o = context.PropertyDescriptor.GetValue(context.Instance);
+                return (o == null) ? new object() : o;
             }
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        public override object ConvertTo(ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, Type destinationType)
         {
+            if (value == null) return "0.0 0.0 0.0";
+
             Vector3 p = (Vector3) value;
             return String.Format(
                 "{0} {1} {2}",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Replanetizer is still in an early state of development. Its feature set entails:
    - Manipulation of variables
  - Export
    - Textures (`.png`)
-   - Rigged models (`.dae`, `.obj`)
+   - Rigged models including animations (`.dae`, `.obj`)
    - Level as a model (`.obj`)
    - Collision (`.obj`)
 
@@ -59,7 +59,7 @@ You can move around the world with keyboard and mouse:
 
 Dependencies:
 
- - .NET 5 tooling (dotnet host, runtime, sdk and targeting pack)
+ - .NET 6 tooling (dotnet host, runtime, sdk and targeting pack)
  - For Linux (and maybe other Unixes):
    - Zenity (or KDialog if you prefer KDE dialogs)
    - Basic OpenGL dependencies (most of these will be installed if you run any form of GUI).
@@ -75,7 +75,7 @@ Alternatively, open Replanetizer.sln in your favourite IDE, and use its tooling 
 
 The project is written in C#, and uses OpenTK4 for rendering. C# bindings for Dear ImGui are used for the UI.
 
-We currently target .NET 5 (net5.0-windows for the Windows builds, net5.0 on anything else).
+We currently target .NET 6 (net6.0-windows for the Windows builds, net6.0 on anything else).
 
 OpenGL 3.3 is used for the rendering.
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -521,7 +521,7 @@ namespace Replanetizer.Frames
             GL.Enable(EnableCap.DepthTest);
             GL.LineWidth(5.0f);
 
-            string? applicationFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string? applicationFolder = System.AppContext.BaseDirectory;
             string shaderFolder = Path.Join(applicationFolder, "Shaders");
 
             shaderIDTable = new ShaderIDTable();

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -1391,13 +1391,6 @@ namespace Replanetizer.Frames
                 GL.DisableVertexAttribArray(3);
             }
 
-            if (enableShrub)
-            {
-                GL.Uniform1(shaderIDTable.uniformLevelObjectType, (int) RenderedObjectType.Shrub);
-                foreach (RenderableBuffer buffer in shrubsBuffers)
-                    RenderBuffer(buffer);
-            }
-
             if (enableTie)
             {
                 GL.EnableVertexAttribArray(3);
@@ -1405,6 +1398,13 @@ namespace Replanetizer.Frames
                 foreach (RenderableBuffer buffer in tiesBuffers)
                     RenderBuffer(buffer);
                 GL.DisableVertexAttribArray(3);
+            }
+
+            if (enableShrub)
+            {
+                GL.Uniform1(shaderIDTable.uniformLevelObjectType, (int) RenderedObjectType.Shrub);
+                foreach (RenderableBuffer buffer in shrubsBuffers)
+                    RenderBuffer(buffer);
             }
 
             if (enableMoby)

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -599,6 +599,8 @@ namespace Replanetizer.Frames
             GL.BindTexture(TextureTarget.Texture2D, texId);
             GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
             GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (float) TextureMinFilter.LinearMipmapLinear);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (float) TextureMinFilter.LinearMipmapLinear);
             int offset = 0;
 
             if (t.mipMapCount > 1)

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -557,6 +557,8 @@ namespace Replanetizer.Frames
             shaderIDTable.uniformAmbientColor = GL.GetUniformLocation(shaderIDTable.shaderMain, "staticColor");
             shaderIDTable.uniformLightIndex = GL.GetUniformLocation(shaderIDTable.shaderMain, "lightIndex");
 
+            shaderIDTable.uniformUseTransparency = GL.GetUniformLocation(shaderIDTable.shaderMain, "useTransparency");
+
             shaderIDTable.uniformSkyTexAvailable = GL.GetUniformLocation(shaderIDTable.shaderSky, "texAvailable");
 
             shaderIDTable.uniformDissolvePattern = GL.GetUniformLocation(shaderIDTable.shaderMain, "dissolvePattern");

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -599,7 +599,10 @@ namespace Replanetizer.Frames
                 if (textureId < 0 || textureId >= selectedTextureSet.Count) continue;
 
                 var texture = selectedTextureSet[textureId];
-                TextureIO.ExportTexture(texture, Path.Combine(folder, $"{textureId}.png"));
+
+                bool includeTransparency = (config.IgnoresTransparency()) ? false : true;
+
+                TextureIO.ExportTexture(texture, Path.Combine(folder, $"{textureId}.png"), includeTransparency);
             }
         }
     }

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -98,7 +98,6 @@ namespace Replanetizer.Frames
 
         public override void RenderAsWindow(float deltaTime)
         {
-            ImGui.SetNextWindowSize(new System.Numerics.Vector2(1280, 720));
             if (ImGui.Begin(frameName, ref isOpen))
             {
                 Render(deltaTime);

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -16,6 +16,7 @@ using System.Text;
 using System.Drawing;
 using ImGuiNET;
 using LibReplanetizer.LevelObjects;
+using LibReplanetizer;
 using Replanetizer.Utils;
 
 namespace Replanetizer.Frames
@@ -363,8 +364,39 @@ namespace Replanetizer.Frames
             else if (type is { IsGenericType: true } && type.GetGenericTypeDefinition() == typeof(List<>))
             {
                 ICollection list = (ICollection) val;
-                var genericType = type.GetGenericArguments()[0].Name;
-                ImGui.LabelText(propertyName, "List<" + genericType + ">[" + list.Count + "]");
+                Type genericType = type.GetGenericArguments()[0];
+                if (genericType == typeof(TextureConfig))
+                {
+                    if (ImGui.CollapsingHeader(propertyName))
+                    {
+                        List<TextureConfig> textureConfigs = (List<TextureConfig>) val;
+
+                        PropertyInfo[] texConfProps = typeof(TextureConfig).GetProperties();
+
+                        int i = 1;
+
+                        foreach (TextureConfig t in list)
+                        {
+                            ImGui.Text("Texture Config " + i);
+
+                            foreach (PropertyInfo prop in texConfProps)
+                            {
+                                string displayName =
+                                    prop.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? prop.Name;
+
+                                object? o = prop.GetValue(t);
+                                ImGui.LabelText(displayName, (o == null) ? "Null" : o.ToString());
+                            }
+
+                            i++;
+                        }
+                    }
+                }
+                else
+                {
+                    string genericTypeName = type.GetGenericArguments()[0].Name;
+                    ImGui.LabelText(propertyName, "List<" + genericTypeName + ">[" + list.Count + "]");
+                }
             }
             else
                 ImGui.LabelText(propertyName, Convert.ToString(val));

--- a/Replanetizer/Frames/TextureFrame.cs
+++ b/Replanetizer/Frames/TextureFrame.cs
@@ -55,7 +55,7 @@ namespace Replanetizer.Frames
                         var targetFile = CrossFileDialog.SaveFile(filter: ".bmp;.jpg;.jpeg;.png");
                         if (targetFile.Length > 0)
                         {
-                            TextureIO.ExportTexture(t, targetFile);
+                            TextureIO.ExportTexture(t, targetFile, true);
                         }
                     }
                     ImGui.EndPopup();

--- a/Replanetizer/Frames/UpdateInfoFrame.cs
+++ b/Replanetizer/Frames/UpdateInfoFrame.cs
@@ -100,10 +100,19 @@ namespace Replanetizer.Frames
 
         public UpdateInfoFrame(Window wnd, string? url, DateTime? buildDate, DateTime? currVersionDate, string? newestReleaseTag) : base(wnd)
         {
-            aboutText = String.Format(@"Your Version: {0}
-Current Version: {1}
+            TimeSpan? diff = null;
+            if (buildDate != null && currVersionDate != null)
+            {
+                diff = currVersionDate - buildDate;
+            }
 
-Link: ", buildDate.ToString(), currVersionDate.ToString());
+
+            aboutText = String.Format(
+@"Your Version:    {0}
+Current Version: {1}
+Your version is {2} day(s) and {3} hour(s) behind.
+
+Link: ", buildDate.ToString(), currVersionDate.ToString(), diff?.Days, diff?.Hours);
 
             link = url;
 

--- a/Replanetizer/ModelLists/ModelLists.cs
+++ b/Replanetizer/ModelLists/ModelLists.cs
@@ -67,7 +67,7 @@ namespace Replanetizer.ModelLists
 
             try
             {
-                string? applicationFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string? applicationFolder = System.AppContext.BaseDirectory;
                 string listFolder = Path.Join(applicationFolder, "ModelLists");
                 var fullPath = Path.Join(listFolder, fileName);
 

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject>Replanetizer.Program</StartupObject>
     <LangVersion>9</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
@@ -21,7 +21,7 @@
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <DefineConstants>_WINDOWS</DefineConstants>
   </PropertyGroup>

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -19,6 +19,7 @@
     <ApplicationIcon>ReplanetizerIcon48px.ico</ApplicationIcon>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -17,6 +17,8 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <Nullable>enable</Nullable>
     <ApplicationIcon>ReplanetizerIcon48px.ico</ApplicationIcon>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/Replanetizer/Shaders/fs.glsl
+++ b/Replanetizer/Shaders/fs.glsl
@@ -16,6 +16,7 @@ uniform int levelObjectNumber;
 uniform vec4 fogColor;
 uniform mat4 dissolvePattern;
 uniform float objectBlendDistance;
+uniform int useTransparency;
 
 /*
  * We use one shader for all shading types.
@@ -31,7 +32,6 @@ uniform float objectBlendDistance;
  *   have specular highlights.
  * - Fog seems to be twice as bright for ties.
  * - Terrain does not use alpha cutoff.
- * - In RaC 3, ties do not use alpha cutoff. Replanetizer uses the RaC 1 and 2 behaviour.
  */
 void main() {
 	//color of the texture at the specified UV
@@ -45,12 +45,14 @@ void main() {
         if (dissolvePattern[patternPos.x][patternPos.y] < alpha) discard;
     }
 
-    // we use dithering for transparency in everything that isnt mobies (it is simple thats why)
-    if ((levelObjectType == 1 || levelObjectType == 2 || levelObjectType == 3)) {
-        vec2 pixel = vec2(gl_FragCoord.x, gl_FragCoord.y);
-        float alpha = 1.0f - textureColor.w;
-        ivec2 patternPos = ivec2(int(mod(pixel.x,4.0f)),int(mod(pixel.y,4.0f)));
-        if (dissolvePattern[patternPos.x][patternPos.y] < alpha) discard;
+    if (useTransparency == 1) {
+        // we use dithering for transparency in everything that isnt mobies (it is simple thats why)
+        if ((levelObjectType == 1 || levelObjectType == 2 || levelObjectType == 3)) {
+            vec2 pixel = vec2(gl_FragCoord.x, gl_FragCoord.y);
+            float alpha = 1.0f - textureColor.w;
+            ivec2 patternPos = ivec2(int(mod(pixel.x,4.0f)),int(mod(pixel.y,4.0f)));
+            if (dissolvePattern[patternPos.x][patternPos.y] < alpha) discard;
+        }
     }
 
 	color.xyz = textureColor.xyz * lightColor;

--- a/Replanetizer/Shaders/fs.glsl
+++ b/Replanetizer/Shaders/fs.glsl
@@ -45,7 +45,13 @@ void main() {
         if (dissolvePattern[patternPos.x][patternPos.y] < alpha) discard;
     }
 
-	if (textureColor.w < 0.1f && levelObjectType >= 2) discard;
+    // we use dithering for transparency in everything that isnt mobies (it is simple thats why)
+    if ((levelObjectType == 1 || levelObjectType == 2 || levelObjectType == 3)) {
+        vec2 pixel = vec2(gl_FragCoord.x, gl_FragCoord.y);
+        float alpha = 1.0f - textureColor.w;
+        ivec2 patternPos = ivec2(int(mod(pixel.x,4.0f)),int(mod(pixel.y,4.0f)));
+        if (dissolvePattern[patternPos.x][patternPos.y] < alpha) discard;
+    }
 
 	color.xyz = textureColor.xyz * lightColor;
 	color.w = textureColor.w;

--- a/Replanetizer/Utils/RenderableBuffer.cs
+++ b/Replanetizer/Utils/RenderableBuffer.cs
@@ -245,17 +245,35 @@ namespace Replanetizer.Utils
              * This can easily be observed on RaC 1 Kerwan where you have these ugly edges on some trees and the bottom
              * of the fading out buildings
              */
-            switch (mode)
+            switch (type)
             {
-                case 13: /* 0001101 (RaC 1)*/
-                case 15: /* 0001111 (RaC 1)*/
-                case 93: /* 1011101 (RaC 2)*/
-                case 95: /* 1011111 (RaC 2)*/
-                case 218103808: /* 1101000000000000000000000000 (RaC 1) */
-                case 117440512: /* 0111000000000000000000000000 (RaC 3) */
-                    // RaC on PS2 probably used repeat texture wrap mode as there are practically only repeat and clamp on PS2
-                    // However, it seems that the sampling worked slightly different but I am not sure how to reproduce that
-                    // behaviour
+                case RenderedObjectType.Terrain:
+                case RenderedObjectType.Shrub:
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
+                    break;
+                case RenderedObjectType.Tie:
+                    switch (mode)
+                    {
+                        case 13: /* 0001101 (RaC 1)*/
+                        case 15: /* 0001111 (RaC 1)*/
+                        case 93: /* 1011101 (RaC 2)*/
+                        case 95: /* 1011111 (RaC 2)*/
+                        case 218103808: /* 1101000000000000000000000000 (RaC 1) */
+                        case 117440512: /* 0111000000000000000000000000 (RaC 3) */
+                            //GL_MIRROR_CLAMP_TO_EDGE = 0x8743
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, 0x8743);
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, 0x8743);
+                            break;
+                        default:
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
+                            break;
+                    }
+                    break;
+                case RenderedObjectType.Moby:
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
                     break;
             }
         }
@@ -382,6 +400,7 @@ namespace Replanetizer.Utils
                     {
                         GL.BindTexture(TextureTarget.Texture2D, (conf.id > 0) ? textureIds[level.textures[conf.id]] : 0);
                         SetTransparencyMode(conf);
+                        SetTextureWrapMode(conf.mode);
                         GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
                     }
 

--- a/Replanetizer/Utils/RenderableBuffer.cs
+++ b/Replanetizer/Utils/RenderableBuffer.cs
@@ -247,7 +247,6 @@ namespace Replanetizer.Utils
              */
             switch (type)
             {
-                case RenderedObjectType.Terrain:
                 case RenderedObjectType.Shrub:
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
@@ -259,11 +258,32 @@ namespace Replanetizer.Utils
                         case 15: /* 0001111 (RaC 1)*/
                         case 93: /* 1011101 (RaC 2)*/
                         case 95: /* 1011111 (RaC 2)*/
-                        case 218103808: /* 1101000000000000000000000000 (RaC 1) */
-                        case 117440512: /* 0111000000000000000000000000 (RaC 3) */
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.MirroredRepeat);
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.MirroredRepeat);
+                            break;
+                        case 117440512: /* 0111000000000000000000000000 (RaC 1 & 3) */
                             //GL_MIRROR_CLAMP_TO_EDGE = 0x8743
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, 0x8743);
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, 0x8743);
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.ClampToEdge);
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.ClampToEdge);
+                            break;
+                        default:
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
+                            break;
+                    }
+                    break;
+                case RenderedObjectType.Terrain:
+                    switch (mode)
+                    {
+                        case 218103808: /* 1101000000000000000000000000 (RaC 1) */
+                            //GL_MIRROR_CLAMP_TO_EDGE = 0x8743
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.MirroredRepeat);
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.MirroredRepeat);
+                            break;
+                        case 83886080: /* 101000000000000000000000000 (RaC 3) */
+                            //GL_MIRROR_CLAMP_TO_EDGE = 0x8743
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
+                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
                             break;
                         default:
                             GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
@@ -400,7 +420,7 @@ namespace Replanetizer.Utils
                     {
                         GL.BindTexture(TextureTarget.Texture2D, (conf.id > 0) ? textureIds[level.textures[conf.id]] : 0);
                         SetTransparencyMode(conf);
-                        SetTextureWrapMode(conf.mode);
+                        //SetTextureWrapMode(conf.mode);
                         GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
                     }
 

--- a/Replanetizer/Utils/RenderableBuffer.cs
+++ b/Replanetizer/Utils/RenderableBuffer.cs
@@ -225,6 +225,69 @@ namespace Replanetizer.Utils
             }
         }
 
+        /*
+         * The textureConfig modes in the following are probably bitmask but more testing is required
+         * to confirm that, until then simply add all modes that are observed.
+         * Ideally write the binary + the game in which this was observed as it could be that the
+         * bitmasks differ between the games.
+         */
+
+        /// <summary>
+        /// Takes a textureConfig mode as input and sets the transparency mode based on that.
+        /// </summary>
+        private void SetTransparencyMode(int mode)
+        {
+            if (SHADER_ID_TABLE == null) return;
+
+            /*
+             * This seems to be a RaC 3 only behaviour.
+             */
+            switch (mode)
+            {
+                case 136311: /* 100001010001110111 (RaC 3) */
+                case 136279: /* 100001010001010111 (RaC 3) */
+                case 136277: /* 100001010001010101 (RaC 3) */
+                case 136533: /* 100001010101010101 (RaC 3) */
+                case 136447: /* 100001010011111111 (RaC 3) */
+                    GL.Uniform1(SHADER_ID_TABLE.uniformUseTransparency, 0);
+                    break;
+                default:
+                    GL.Uniform1(SHADER_ID_TABLE.uniformUseTransparency, 1);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Takes a textureConfig mode as input and sets the texture wrap mode based on that.
+        ///
+        /// Setting these every frame is quite expensive so consider predetermining this
+        /// by looping through all textureConfigs as it seems that all uses of a texture
+        /// use the same texture wrap mode.
+        /// </summary>
+        private void SetTextureWrapMode(int mode)
+        {
+            /*
+             * Reality is, it could be that the game always uses Repeat but the interpolation/sampling works differently
+             * which causes edges of transparent objects to not show these ugly edges, more testing is required
+             * This can easily be observed on RaC 1 Kerwan where you have these ugly edges on some trees and the bottom
+             * of the fading out buildings, obviously to see this you need to turn this function here off
+             */
+            switch (mode)
+            {
+                case 13: /* 0001101 (RaC 1)*/
+                case 15: /* 0001111 (RaC 1)*/
+                case 93: /* 1011101 (RaC 2)*/
+                case 95: /* 1011111 (RaC 2)*/
+                case 218103808: /* 1101000000000000000000000000 (RaC 1) */
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.MirroredRepeat);
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.MirroredRepeat);
+                    break;
+                case 117440512: /* 0111000000000000000000000000 (RaC 3) */
+                    // Something that doesn't seem to have an equivalent mode in OpenGL
+                    break;
+            }
+        }
+
         /// <summary>
         /// Sets an internal variable to true if the corresponding modelObject is equal to
         /// the selectedObject in which case an outline will be rendered.
@@ -346,6 +409,8 @@ namespace Replanetizer.Utils
                     foreach (TextureConfig conf in modelObject.model.textureConfig)
                     {
                         GL.BindTexture(TextureTarget.Texture2D, (conf.id > 0) ? textureIds[level.textures[conf.id]] : 0);
+                        SetTextureWrapMode(conf.mode);
+                        SetTransparencyMode(conf.mode);
                         GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
                     }
 

--- a/Replanetizer/Utils/ShaderIDTable.cs
+++ b/Replanetizer/Utils/ShaderIDTable.cs
@@ -32,6 +32,7 @@ namespace Replanetizer.Utils
         public int uniformColorLevelObjectType { get; set; }
         public int uniformColorLevelObjectNumber { get; set; }
         public int uniformAmbientColor { get; set; }
+        public int uniformUseTransparency { get; set; }
 
         // Number of lights we allocate, if you change this, you need to change it in the shader aswell.
         public static readonly int ALLOCATED_LIGHTS = 20;

--- a/Replanetizer/Window.cs
+++ b/Replanetizer/Window.cs
@@ -37,7 +37,7 @@ namespace Replanetizer
 
             try
             {
-                System.Drawing.Icon? icon = System.Drawing.Icon.ExtractAssociatedIcon(Assembly.GetExecutingAssembly().Location);
+                System.Drawing.Icon? icon = System.Drawing.Icon.ExtractAssociatedIcon(System.AppContext.BaseDirectory + "Replanetizer.exe");
                 if (icon != null)
                 {
                     using (MemoryStream ms = new MemoryStream())
@@ -60,7 +60,7 @@ namespace Replanetizer
                     }
                 }
             }
-            catch (ArgumentException)
+            catch (Exception)
             {
             }
         }


### PR DESCRIPTION
- This PR migrates the code base to .Net 6. Closes #32 
- Also any object that is not a moby now uses dithering to achieve transparency. This is supposed to be a cheap solution which is going to be replaced by proper transparency sometime in the future.
- The transparency issue that occurred in RaC 3 should now be mostly fixed. This also applies to exported textures.
- Added additional level variables. This was made possible by CreepNT and Badger41. (Only 2 variables are unknown at this point excluding Deadlocked)

