### PR TITLE
Improved renderer, spawn flags and improved transformation tools.

### DIFF
--- a/LibReplanetizer/Level Objects/Engine/Shrub.cs
+++ b/LibReplanetizer/Level Objects/Engine/Shrub.cs
@@ -19,7 +19,7 @@ namespace LibReplanetizer.LevelObjects
     {
         public const int ELEMENTSIZE = 0x70;
 
-        [Category("Attributes"), DisplayName("Draw Distance")]
+        [Category("Attributes"), DisplayName("Draw Distance"), Description("The distance at which an object will start fading out. After a distance of 8 more units, the object will stop being drawn.")]
         public float drawDistance { get; set; }
         [Category("Unknowns"), DisplayName("OFF_58: Always 0")]
         public uint off58 { get; set; }
@@ -30,11 +30,11 @@ namespace LibReplanetizer.LevelObjects
         // Changing it to red will make the shrub be very red
         // the texture remains visible so cleary the visible
         // color is some blend between texture and this
-        [Category("Attributes"), DisplayName("Static Color")]
+        [Category("Attributes"), DisplayName("Static Color"), Description("Static diffuse lighting applied to the shrub.")]
         public Color color { get; set; }
         [Category("Unknowns"), DisplayName("OFF_64: Always 0")]
         public uint off64 { get; set; }
-        [Category("Attributes"), DisplayName("Light")]
+        [Category("Attributes"), DisplayName("Light"), Description("Index of the directional light that is applied to the shrub.")]
         public ushort light { get; set; }
         [Category("Unknowns"), DisplayName("OFF_6C: Always 0")]
         public uint off6C { get; set; }

--- a/LibReplanetizer/Level Objects/Engine/Tie.cs
+++ b/LibReplanetizer/Level Objects/Engine/Tie.cs
@@ -28,7 +28,7 @@ namespace LibReplanetizer.LevelObjects
 
         [Category("Unknowns"), DisplayName("OFF_64: Always 0")]
         public uint off64 { get; set; }
-        [Category("Attributes"), DisplayName("Light")]
+        [Category("Attributes"), DisplayName("Light"), Description("Index of the directional light that is applied to the tie.")]
         public ushort light { get; set; }
         [Category("Unknowns"), DisplayName("OFF_6C: Always 0")]
         public uint off6C { get; set; }

--- a/LibReplanetizer/Level Objects/Gameplay/LevelVariables.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/LevelVariables.cs
@@ -23,23 +23,31 @@ namespace LibReplanetizer.LevelObjects
         [Category("Attributes"), DisplayName("Fog Color")]
         public Color fogColor { get; set; }
 
-        [Category("Attributes"), DisplayName("Fog Near Distance")]
+        [Category("Attributes"), DisplayName("Fog Near Distance"), Description("Distance at which fog has its near intensity. The actual distance is given by [FogNearDistance]/1024.")]
         public float fogNearDistance { get; set; }
 
-        [Category("Attributes"), DisplayName("Fog Far Distance")]
+        [Category("Attributes"), DisplayName("Fog Far Distance"), Description("Distance at which fog has its far intensity. The actual distance is given by 1024/([FogFarDistance]-[FogNearDistance]). ")]
         public float fogFarDistance { get; set; }
 
-        [Category("Attributes"), DisplayName("Fog Near Intensity")]
+        [Category("Attributes"), DisplayName("Fog Near Intensity"), Description("Intensity of the fog at its near distance. The actual intensity is given by 1-[FogNearIntensity]/255.")]
         public float fogNearIntensity { get; set; }
 
-        [Category("Attributes"), DisplayName("Fog Far Intensity")]
+        [Category("Attributes"), DisplayName("Fog Far Intensity"), Description("Intensity of the fog at its far distance. The actual intensity is given by 1-[FogFarIntensity]/255.")]
         public float fogFarIntensity { get; set; }
 
         [Category("Attributes"), DisplayName("Deathplane Z")]
         public float deathPlaneZ { get; set; }
 
+        private int _isSphericalWorld { get; set; }
         [Category("Attributes"), DisplayName("Is Spherical World?")]
-        public int isSphericalWorld { get; set; }
+        public bool isSphericalWorld
+        {
+            get { return _isSphericalWorld > 0; }
+            set
+            {
+                _isSphericalWorld = (value) ? 1 : 0;
+            }
+        }
 
         [Category("Attributes"), DisplayName("Sphere Center")]
         public Vector3 sphereCentre { get; set; }
@@ -210,7 +218,7 @@ namespace LibReplanetizer.LevelObjects
             fogNearIntensity = ReadFloat(levelVarBlock, 0x20);
             fogFarIntensity = ReadFloat(levelVarBlock, 0x24);
             deathPlaneZ = ReadFloat(levelVarBlock, 0x28);
-            isSphericalWorld = ReadInt(levelVarBlock, 0x2C);
+            _isSphericalWorld = ReadInt(levelVarBlock, 0x2C);
 
             float sphereCentreX = ReadFloat(levelVarBlock, 0x30);
             float sphereCentreY = ReadFloat(levelVarBlock, 0x34);
@@ -285,7 +293,7 @@ namespace LibReplanetizer.LevelObjects
             fogNearIntensity = ReadFloat(levelVarBlock, 0x20);
             fogFarIntensity = ReadFloat(levelVarBlock, 0x24);
             deathPlaneZ = ReadFloat(levelVarBlock, 0x28);
-            isSphericalWorld = ReadInt(levelVarBlock, 0x2C);
+            _isSphericalWorld = ReadInt(levelVarBlock, 0x2C);
 
             float sphereCentreX = ReadFloat(levelVarBlock, 0x30);
             float sphereCentreY = ReadFloat(levelVarBlock, 0x34);
@@ -370,7 +378,7 @@ namespace LibReplanetizer.LevelObjects
             fogNearIntensity = ReadFloat(levelVarBlock, 0x20);
             fogFarIntensity = ReadFloat(levelVarBlock, 0x24);
             deathPlaneZ = ReadFloat(levelVarBlock, 0x28);
-            isSphericalWorld = ReadInt(levelVarBlock, 0x2C);
+            _isSphericalWorld = ReadInt(levelVarBlock, 0x2C);
 
             float sphereCentreX = ReadFloat(levelVarBlock, 0x30);
             float sphereCentreY = ReadFloat(levelVarBlock, 0x34);
@@ -478,7 +486,7 @@ namespace LibReplanetizer.LevelObjects
             WriteFloat(bytes, 0x20, fogNearIntensity);
             WriteFloat(bytes, 0x24, fogFarIntensity);
             WriteFloat(bytes, 0x28, deathPlaneZ);
-            WriteInt(bytes, 0x2C, isSphericalWorld);
+            WriteInt(bytes, 0x2C, _isSphericalWorld);
 
             WriteFloat(bytes, 0x30, sphereCentre.X);
             WriteFloat(bytes, 0x34, sphereCentre.Y);
@@ -543,7 +551,7 @@ namespace LibReplanetizer.LevelObjects
             WriteFloat(bytes, 0x20, fogNearIntensity);
             WriteFloat(bytes, 0x24, fogFarIntensity);
             WriteFloat(bytes, 0x28, deathPlaneZ);
-            WriteInt(bytes, 0x2C, isSphericalWorld);
+            WriteInt(bytes, 0x2C, _isSphericalWorld);
 
             WriteFloat(bytes, 0x30, sphereCentre.X);
             WriteFloat(bytes, 0x34, sphereCentre.Y);
@@ -611,7 +619,7 @@ namespace LibReplanetizer.LevelObjects
             WriteFloat(bytes, 0x20, fogNearIntensity);
             WriteFloat(bytes, 0x24, fogFarIntensity);
             WriteFloat(bytes, 0x28, deathPlaneZ);
-            WriteInt(bytes, 0x2C, isSphericalWorld);
+            WriteInt(bytes, 0x2C, _isSphericalWorld);
 
             WriteFloat(bytes, 0x30, sphereCentre.X);
             WriteFloat(bytes, 0x34, sphereCentre.Y);

--- a/LibReplanetizer/Level Objects/Gameplay/Moby.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Moby.cs
@@ -24,7 +24,7 @@ namespace LibReplanetizer.LevelObjects
         [Category("Attributes"), DisplayName("Mission ID"), Description("Every planet has a set of missions. If a moby is assigned to a mission, its spawning behaviour can be based on whether the mission is completed.")]
         public int missionID { get; set; }
 
-        [Category("Attributes"), DisplayName("Spawn Type Bitmask"), Description("Each bit corresponds to a spawn related boolean.")]
+        [Category("Attributes"), DisplayName("Spawn Type Bitmask"), Description("Each bit corresponds to a spawn related boolean. If this value is zero then the game determines through other means how to spawn this moby.")]
         public int spawnType { get; set; }
 
         [Category("Attributes"), DisplayName("Spawn Before Mission Completion?"), Description("Moby will still spawn after mission completion if there was no interaction with it yet.")]
@@ -225,7 +225,7 @@ namespace LibReplanetizer.LevelObjects
         [Category("Attributes"), DisplayName("pVars")]
         public byte[] pVars { get; set; }
 
-        public long pVarMemoryAddress;
+        private long pVarMemoryAddress;
 
         [Category("Unknowns"), DisplayName("aUnknown 10")]
         public int unk10 { get; set; }

--- a/LibReplanetizer/Level Objects/Gameplay/Moby.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Moby.cs
@@ -87,7 +87,7 @@ namespace LibReplanetizer.LevelObjects
             }
         }
 
-        [Category("Attributes"), DisplayName("Spawn Before Death?"), Description("Moby will still spawn after death if there was no interaction with it yet.")]
+        [Category("Attributes"), DisplayName("Spawn Before Death?"), Description("Moby will still spawn after death if there was no interaction with it yet. This moby will always spawn when the level is loaded.")]
         public bool spawnBeforeDeath
         {
             get
@@ -127,7 +127,7 @@ namespace LibReplanetizer.LevelObjects
             }
         }
 
-        [Category("Unknowns"), DisplayName("Data Value")]
+        [Category("Attributes"), DisplayName("Data Value"), Description("This value probably defines instance specific behaviour. The exact behaviour any value corresponds to probably depends on the specific moby class.")]
         public int dataval { get; set; }
 
         [Category("Attributes"), DisplayName("Bolt Drop")]

--- a/LibReplanetizer/Level Objects/Gameplay/Moby.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Moby.cs
@@ -24,20 +24,108 @@ namespace LibReplanetizer.LevelObjects
         [Category("Attributes"), DisplayName("Mission ID"), Description("Every planet has a set of missions. If a moby is assigned to a mission, its spawning behaviour can be based on whether the mission is completed.")]
         public int missionID { get; set; }
 
+        [Category("Attributes"), DisplayName("Spawn Type Bitmask"), Description("Each bit corresponds to a spawn related boolean.")]
+        public int spawnType { get; set; }
+
         [Category("Attributes"), DisplayName("Spawn Before Mission Completion?"), Description("Moby will still spawn after mission completion if there was no interaction with it yet.")]
-        public bool spawnBeforeMissionCompletion { get; set; }
+        public bool spawnBeforeMissionCompletion
+        {
+            get
+            {
+                return (spawnType & 0b00001) > 0;
+            }
+            set
+            {
+                if (value)
+                {
+                    spawnType |= 0b00001;
+                }
+                else
+                {
+                    spawnType &= ~0b00001;
+                }
+            }
+        }
 
         [Category("Attributes"), DisplayName("Spawn After Mission Completion?")]
-        public bool spawnAfterMissionCompletion { get; set; }
+        public bool spawnAfterMissionCompletion
+        {
+            get
+            {
+                return (spawnType & 0b00010) > 0;
+            }
+            set
+            {
+                if (value)
+                {
+                    spawnType |= 0b00010;
+                }
+                else
+                {
+                    spawnType &= ~0b00010;
+                }
+            }
+        }
 
         [Category("Attributes"), DisplayName("Is Crate?")]
-        public bool isCrate { get; set; }
+        public bool isCrate
+        {
+            get
+            {
+                return (spawnType & 0b00100) > 0;
+            }
+            set
+            {
+                if (value)
+                {
+                    spawnType |= 0b00100;
+                }
+                else
+                {
+                    spawnType &= ~0b00100;
+                }
+            }
+        }
 
         [Category("Attributes"), DisplayName("Spawn Before Death?"), Description("Moby will still spawn after death if there was no interaction with it yet.")]
-        public bool spawnBeforeDeath { get; set; }
+        public bool spawnBeforeDeath
+        {
+            get
+            {
+                return (spawnType & 0b01000) > 0;
+            }
+            set
+            {
+                if (value)
+                {
+                    spawnType |= 0b01000;
+                }
+                else
+                {
+                    spawnType &= ~0b01000;
+                }
+            }
+        }
 
         [Category("Attributes"), DisplayName("Is Spawner?")]
-        public bool isSpawner { get; set; }
+        public bool isSpawner
+        {
+            get
+            {
+                return (spawnType & 0b10000) > 0;
+            }
+            set
+            {
+                if (value)
+                {
+                    spawnType |= 0b10000;
+                }
+                else
+                {
+                    spawnType &= ~0b10000;
+                }
+            }
+        }
 
         [Category("Unknowns"), DisplayName("Data Value")]
         public int dataval { get; set; }
@@ -194,11 +282,7 @@ namespace LibReplanetizer.LevelObjects
             this.dataval = referenceMoby.dataval;
             this.model = referenceMoby.model;
             this.modelID = referenceMoby.modelID;
-            this.spawnBeforeMissionCompletion = referenceMoby.spawnBeforeMissionCompletion;
-            this.spawnAfterMissionCompletion = referenceMoby.spawnAfterMissionCompletion;
-            this.isCrate = referenceMoby.isCrate;
-            this.spawnBeforeDeath = referenceMoby.spawnBeforeDeath;
-            this.isSpawner = referenceMoby.isSpawner;
+            this.spawnType = referenceMoby.spawnType;
             this.updateDistance = referenceMoby.updateDistance;
             this.light = referenceMoby.light;
             this.color = referenceMoby.color;
@@ -262,7 +346,7 @@ namespace LibReplanetizer.LevelObjects
         {
             int offset = num * game.mobyElemSize;
             missionID = ReadInt(mobyBlock, offset + 0x04);
-            int spawnType = ReadInt(mobyBlock, offset + 0x08);
+            spawnType = ReadInt(mobyBlock, offset + 0x08);
             mobyID = ReadInt(mobyBlock, offset + 0x0C);
 
             bolts = ReadInt(mobyBlock, offset + 0x10);
@@ -306,12 +390,6 @@ namespace LibReplanetizer.LevelObjects
             rotation = new Quaternion(rotx, roty, rotz);
             scale = new Vector3(scaleHolder, scaleHolder, scaleHolder);
 
-            spawnBeforeMissionCompletion = (spawnType & 0b00001) > 0;
-            spawnAfterMissionCompletion = (spawnType & 0b00010) > 0;
-            isCrate = (spawnType & 0b00100) > 0;
-            spawnBeforeDeath = (spawnType & 0b01000) > 0;
-            isSpawner = (spawnType & 0b10000) > 0;
-
             model = mobyModels.Find(mobyModel => mobyModel.id == modelID);
             UpdateTransformMatrix();
         }
@@ -322,7 +400,7 @@ namespace LibReplanetizer.LevelObjects
 
             missionID = ReadInt(mobyBlock, offset + 0x04);
             dataval = ReadInt(mobyBlock, offset + 0x08);
-            int spawnType = ReadInt(mobyBlock, offset + 0x0C);
+            spawnType = ReadInt(mobyBlock, offset + 0x0C);
 
             mobyID = ReadInt(mobyBlock, offset + 0x10);
             bolts = ReadInt(mobyBlock, offset + 0x14);
@@ -370,18 +448,6 @@ namespace LibReplanetizer.LevelObjects
             position = new Vector3(x, y, z);
             rotation = new Quaternion(rotx, roty, rotz);
             scale = new Vector3(scaleHolder); //Mobys only use the X axis of scale
-
-            spawnBeforeMissionCompletion = (spawnType & 0b00001) > 0;
-            spawnAfterMissionCompletion = (spawnType & 0b00010) > 0;
-            isCrate = (spawnType & 0b00100) > 0;
-            spawnBeforeDeath = (spawnType & 0b01000) > 0;
-            isSpawner = (spawnType & 0b10000) > 0;
-
-            spawnBeforeMissionCompletion = (spawnType & 0b00001) > 0;
-            spawnAfterMissionCompletion = (spawnType & 0b00010) > 0;
-            isCrate = (spawnType & 0b00100) > 0;
-            spawnBeforeDeath = (spawnType & 0b01000) > 0;
-            isSpawner = (spawnType & 0b10000) > 0;
 
             model = mobyModels.Find(mobyModel => mobyModel.id == modelID);
             UpdateTransformMatrix();
@@ -461,13 +527,6 @@ namespace LibReplanetizer.LevelObjects
         {
             Vector3 eulerAngles = rotation.ToEulerAngles();
 
-            int spawnType = 0;
-            spawnType += (spawnBeforeMissionCompletion) ? 0b00001 : 0;
-            spawnType += (spawnAfterMissionCompletion) ? 0b00010 : 0;
-            spawnType += (isCrate) ? 0b00100 : 0;
-            spawnType += (spawnBeforeDeath) ? 0b01000 : 0;
-            spawnType += (isSpawner) ? 0b10000 : 0;
-
             byte[] buffer = new byte[game.mobyElemSize];
 
             WriteInt(buffer, 0x00, game.mobyElemSize);
@@ -517,13 +576,6 @@ namespace LibReplanetizer.LevelObjects
         private byte[] ToByteArrayRC23()
         {
             Vector3 eulerAngles = rotation.ToEulerAngles();
-
-            int spawnType = 0;
-            spawnType += (spawnBeforeMissionCompletion) ? 0b00001 : 0;
-            spawnType += (spawnAfterMissionCompletion) ? 0b00010 : 0;
-            spawnType += (isCrate) ? 0b00100 : 0;
-            spawnType += (spawnBeforeDeath) ? 0b01000 : 0;
-            spawnType += (isSpawner) ? 0b10000 : 0;
 
             byte[] buffer = new byte[game.mobyElemSize];
 

--- a/LibReplanetizer/LibReplanetizer.csproj
+++ b/LibReplanetizer/LibReplanetizer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.0.5" />
+    <PackageReference Include="NLog" Version="5.1.2" />
     <PackageReference Include="OpenTK.Mathematics" Version="4.7.5" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />

--- a/LibReplanetizer/LibReplanetizer.csproj
+++ b/LibReplanetizer/LibReplanetizer.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.1.2" />
-    <PackageReference Include="OpenTK.Mathematics" Version="4.7.5" />
+    <PackageReference Include="NLog" Version="5.1.3" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.7.7" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
   </ItemGroup>

--- a/LibReplanetizer/Models/MobyModel.cs
+++ b/LibReplanetizer/Models/MobyModel.cs
@@ -63,9 +63,13 @@ namespace LibReplanetizer.Models
         [Category("Attributes"), DisplayName("Bone Datas")]
         public List<BoneData> boneDatas { get; set; } = new List<BoneData>();
 
-
+        [Category("Unknowns"), DisplayName("Other Buffer")]
         public List<byte> otherBuffer { get; set; } = new List<byte>();
+
+        [Category("Unknowns"), DisplayName("Other Texture Configurations")]
         public List<TextureConfig> otherTextureConfigs { get; set; } = new List<TextureConfig>();
+
+        [Category("Unknowns"), DisplayName("Other Index Buffer")]
         public List<ushort> otherIndexBuffer { get; set; } = new List<ushort>();
         public Skeleton? skeleton = null;
         [Category("Attributes"), DisplayName("Is Model")]

--- a/LibReplanetizer/Models/TextureConfig.cs
+++ b/LibReplanetizer/Models/TextureConfig.cs
@@ -10,17 +10,19 @@ using System.ComponentModel;
 namespace LibReplanetizer
 {
 
-    /*
-     * Only those two modes are used by the game.
-     */
-    public enum TextureConfigWrapMode
-    {
-        Repeat = 0,
-        ClampEdge = 1
-    }
-
     public class TextureConfig
     {
+        public static readonly string[] WRAP_MODE_STRINGS = { "Repeat", "ClampEdge" };
+
+        /*
+         * Only those two modes are used by the game.
+         */
+        public enum WrapMode
+        {
+            Repeat = 0,
+            ClampEdge = 1
+        }
+
         [Category("Attributes"), DisplayName("Texture ID")]
         public int id { get; set; }
         [Category("Attributes"), DisplayName("Vertex Start Index")]
@@ -29,13 +31,109 @@ namespace LibReplanetizer
         public int size { get; set; }
         [Category("Attributes"), DisplayName("Mode")]
         public int mode { get; set; }
+        public WrapMode wrapModeS
+        {
+            get
+            {
+                if ((mode & 0b01) > 0)
+                {
+                    return (((mode & 0b10) > 0)) ? WrapMode.ClampEdge : WrapMode.Repeat;
+                }
 
-        /*
-         * The textureConfig modes in the following are probably bitmask but more testing is required
-         * to confirm that, until then simply add all modes that are observed.
-         * Ideally write the binary + the game in which this was observed as it could be that the
-         * bitmasks differ between the games.
-         */
+                if (((mode >> 24) & 0b01) > 0)
+                {
+                    return ((((mode >> 24) & 0b10) > 0)) ? WrapMode.ClampEdge : WrapMode.Repeat;
+                }
+
+                return WrapMode.Repeat;
+            }
+            set
+            {
+                if ((mode & 0b01) > 0)
+                {
+                    switch (value)
+                    {
+                        case WrapMode.Repeat:
+                            mode = mode & (~0b10);
+                            break;
+                        case WrapMode.ClampEdge:
+                            mode = mode | 0b10;
+                            break;
+                        default:
+                            break;
+                    }
+                    return;
+                }
+
+                if (((mode >> 24) & 0b01) > 0)
+                {
+                    switch (value)
+                    {
+                        case WrapMode.Repeat:
+                            mode = mode & ~(0b10 << 24);
+                            break;
+                        case WrapMode.ClampEdge:
+                            mode = mode | (0b10 << 24);
+                            break;
+                        default:
+                            break;
+                    }
+                    return;
+                }
+            }
+        }
+
+        public WrapMode wrapModeT
+        {
+            get
+            {
+                if (((mode >> 2) & 0b01) > 0)
+                {
+                    return ((((mode >> 2) & 0b10) > 0)) ? WrapMode.ClampEdge : WrapMode.Repeat;
+                }
+
+                if (((mode >> 26) & 0b01) > 0)
+                {
+                    return ((((mode >> 26) & 0b10) > 0)) ? WrapMode.ClampEdge : WrapMode.Repeat;
+                }
+
+                return WrapMode.Repeat;
+            }
+            set
+            {
+                if (((mode >> 2) & 0b01) > 0)
+                {
+                    switch (value)
+                    {
+                        case WrapMode.Repeat:
+                            mode = mode & ~(0b10 << 2);
+                            break;
+                        case WrapMode.ClampEdge:
+                            mode = mode | (0b10 << 2);
+                            break;
+                        default:
+                            break;
+                    }
+                    return;
+                }
+
+                if (((mode >> 26) & 0b01) > 0)
+                {
+                    switch (value)
+                    {
+                        case WrapMode.Repeat:
+                            mode = mode & ~(0b10 << 26);
+                            break;
+                        case WrapMode.ClampEdge:
+                            mode = mode | (0b10 << 26);
+                            break;
+                        default:
+                            break;
+                    }
+                    return;
+                }
+            }
+        }
 
         public bool IgnoresTransparency()
         {
@@ -95,41 +193,5 @@ namespace LibReplanetizer
         // The higher bit is the value of the feature.
         // It remains to be identified what all these features are and why they are shifted by 24 bits sometimes.
         //
-
-        /// <summary>
-        /// Returns the texture wrapping mode for the S coordinate.
-        /// </summary>
-        public TextureConfigWrapMode GetWrapModeS()
-        {
-            if ((mode & 0b01) > 0)
-            {
-                return (((mode & 0b10) > 0)) ? TextureConfigWrapMode.ClampEdge : TextureConfigWrapMode.Repeat;
-            }
-
-            if (((mode >> 24) & 0b01) > 0)
-            {
-                return ((((mode >> 24) & 0b10) > 0)) ? TextureConfigWrapMode.ClampEdge : TextureConfigWrapMode.Repeat;
-            }
-
-            return TextureConfigWrapMode.Repeat;
-        }
-
-        /// <summary>
-        /// Returns the texture wrapping mode for the T coordinate.
-        /// </summary>
-        public TextureConfigWrapMode GetWrapModeT()
-        {
-            if (((mode >> 2) & 0b01) > 0)
-            {
-                return ((((mode >> 2) & 0b10) > 0)) ? TextureConfigWrapMode.ClampEdge : TextureConfigWrapMode.Repeat;
-            }
-
-            if (((mode >> 26) & 0b01) > 0)
-            {
-                return ((((mode >> 26) & 0b10) > 0)) ? TextureConfigWrapMode.ClampEdge : TextureConfigWrapMode.Repeat;
-            }
-
-            return TextureConfigWrapMode.Repeat;
-        }
     }
 }

--- a/LibReplanetizer/Models/TextureConfig.cs
+++ b/LibReplanetizer/Models/TextureConfig.cs
@@ -55,6 +55,7 @@ namespace LibReplanetizer
 
         // In the following are some observations of different modes and their corresponding wrap mode as reported by Renderdoc.
         // The ? just says that this has not yet been confirmed through Renderdoc.
+        // Mobies seem to be broken as they all use the repeat mode even when they clearly shouldn't based on the art.
 
         // A RaC 1 database of TextureWrapMode mappings
         // Terrain:

--- a/LibReplanetizer/Models/TextureConfig.cs
+++ b/LibReplanetizer/Models/TextureConfig.cs
@@ -31,6 +31,7 @@ namespace LibReplanetizer
         public int size { get; set; }
         [Category("Attributes"), DisplayName("Mode")]
         public int mode { get; set; }
+        [Category("Attributes"), DisplayName("Texture Wrap S")]
         public WrapMode wrapModeS
         {
             get
@@ -83,6 +84,7 @@ namespace LibReplanetizer
             }
         }
 
+        [Category("Attributes"), DisplayName("Texture Wrap T")]
         public WrapMode wrapModeT
         {
             get

--- a/LibReplanetizer/Models/TextureConfig.cs
+++ b/LibReplanetizer/Models/TextureConfig.cs
@@ -9,6 +9,16 @@ using System.ComponentModel;
 
 namespace LibReplanetizer
 {
+
+    /*
+     * Only those two modes are used by the game.
+     */
+    public enum TextureConfigWrapMode
+    {
+        Repeat = 0,
+        ClampEdge = 1
+    }
+
     public class TextureConfig
     {
         [Category("Attributes"), DisplayName("Texture ID")]
@@ -41,6 +51,84 @@ namespace LibReplanetizer
                 default:
                     return false;
             }
+        }
+
+        // In the following are some observations of different modes and their corresponding wrap mode as reported by Renderdoc.
+        // The ? just says that this has not yet been confirmed through Renderdoc.
+
+        // A RaC 1 database of TextureWrapMode mappings
+        // Terrain:
+        // 0000000000000000000000000101 (000000005): ?
+        // 0000000000000000000000000111 (000000007): ?
+        // 0000000000000000000000001101 (000000013): ?
+        // 0000000000000000000000001111 (000000015): ?
+        // Tie:
+        // 0000000000000000000000000101 (000000005): ?
+        // 0000000000000000000000000111 (000000007): ?
+        // 0000000000000000000000001101 (000000013): ?
+        // 0000000000000000000000001111 (000000015): ?
+        // Shrub:
+        // 0101000000000000000000000000 (083886080): ?
+        // 0111000000000000000000000000 (117440512): ?
+        // Moby:
+        // 0101000000000000000000000000 (083886080): ?
+
+        // A RaC 2 database of TextureWrapMode mappings
+        // Terrain:
+        // 0111000000000000000000000000 (117440512): S = ClampEdge, T = Repeat
+        // 1111000000000000000000000000 (251658240): S = ClampEdge, T = ClampEdge
+        // 1101000000000000000000000000 (218103808): S = Repeat,    T = ClampEdge
+        // Tie:
+        // 0000000000000000000001010101 (000000085): S = Repeat,    T = Repeat
+        // 0000000000000000000001011101 (000000093): S = Repeat,    T = ClampEdge
+        // 0000000000000000000001011111 (000000095): S = ClampEdge, T = ClampEdge
+        // Shrub:
+        // 1111000000000000000000000000 (251658240): S = ClampEdge, T = ClampEdge
+        // Moby:
+        // 0101000000000000000000000000 (083886080): S = Repeat,    T = Repeat
+
+        //
+        // It becomes apparent that the texture config mode works the following way:
+        // Each feature consists of two bits.
+        // The lower bit signifies whether a feature is present / set.
+        // The higher bit is the value of the feature.
+        // It remains to be identified what all these features are and why they are shifted by 24 bits sometimes.
+        //
+
+        /// <summary>
+        /// Returns the texture wrapping mode for the S coordinate.
+        /// </summary>
+        public TextureConfigWrapMode GetWrapModeS()
+        {
+            if ((mode & 0b01) > 0)
+            {
+                return (((mode & 0b10) > 0)) ? TextureConfigWrapMode.ClampEdge : TextureConfigWrapMode.Repeat;
+            }
+
+            if (((mode >> 24) & 0b01) > 0)
+            {
+                return ((((mode >> 24) & 0b10) > 0)) ? TextureConfigWrapMode.ClampEdge : TextureConfigWrapMode.Repeat;
+            }
+
+            return TextureConfigWrapMode.Repeat;
+        }
+
+        /// <summary>
+        /// Returns the texture wrapping mode for the T coordinate.
+        /// </summary>
+        public TextureConfigWrapMode GetWrapModeT()
+        {
+            if (((mode >> 2) & 0b01) > 0)
+            {
+                return ((((mode >> 2) & 0b10) > 0)) ? TextureConfigWrapMode.ClampEdge : TextureConfigWrapMode.Repeat;
+            }
+
+            if (((mode >> 26) & 0b01) > 0)
+            {
+                return ((((mode >> 26) & 0b10) > 0)) ? TextureConfigWrapMode.ClampEdge : TextureConfigWrapMode.Repeat;
+            }
+
+            return TextureConfigWrapMode.Repeat;
         }
     }
 }

--- a/LibReplanetizer/Serializers/Exporters/ColladaExporter.cs
+++ b/LibReplanetizer/Serializers/Exporters/ColladaExporter.cs
@@ -141,8 +141,19 @@ namespace LibReplanetizer
                 }
             }
 
+            // Duplicate single frame animations so that they are visible in tools like Blender
+            if (anim.frames.Count == 1)
+            {
+                timeString += (frameStartTime).ToString("G", en_US) + " ";
+            }
+
             string interpString = "";
             for (int j = 0; j < anim.frames.Count; j++)
+            {
+                interpString += "LINEAR ";
+            }
+
+            if (anim.frames.Count == 1)
             {
                 interpString += "LINEAR ";
             }
@@ -165,6 +176,10 @@ namespace LibReplanetizer
                 foreach (Frame frame in anim.frames)
                 {
                     WriteAnimationFrameOfBone(colladaStream, frame, k, model);
+                }
+                if (anim.frames.Count == 1)
+                {
+                    WriteAnimationFrameOfBone(colladaStream, anim.frames[0], k, model);
                 }
                 colladaStream.WriteLine("</float_array>");
                 colladaStream.WriteLine(indent + "\t\t\t<technique_common>");
@@ -658,9 +673,15 @@ namespace LibReplanetizer
                             }
                             else
                             {
+                                int k = 0;
                                 for (int i = 0; i < anims.Count; i++)
                                 {
-                                    WriteAnimation(colladaStream, anims[i], moby.boneCount, "Anim" + i.ToString(), moby, "\t\t");
+                                    if (anims[i].frames.Count != 0)
+                                    {
+                                        WriteAnimation(colladaStream, anims[i], moby.boneCount, "Anim" + k.ToString(), moby, "\t\t");
+                                        k++;
+                                    }
+                                    
                                 }
                             }
                         }
@@ -736,13 +757,28 @@ namespace LibReplanetizer
 
                 if (dir == null) dir = "";
 
-                int numFilesExported = ((MobyModel) model).animations.Count;
+                List<Animation> anims;
+                if (model.id == 0)
+                {
+                    anims = level.playerAnimations;
+                }
+                else
+                {
+                    anims = ((MobyModel) model).animations;
+                }
 
-                for (int i = 0; i < numFilesExported; i++)
+                List<int> nonzeroAnimations = new List<int>();
+
+                for (int i = 0; i < anims.Count; i++)
+                {
+                    if (anims[i].frames.Count != 0) nonzeroAnimations.Add(i);
+                }
+
+                for (int i = 0; i < nonzeroAnimations.Count; i++)
                 {
                     string filePath = Path.Combine(dir, fileName + "_" + i.ToString() + fileExt);
 
-                    WriteData(filePath, level, model, true, i);
+                    WriteData(filePath, level, model, true, nonzeroAnimations[i]);
                 }
             }
             else

--- a/LibReplanetizer/Serializers/Exporters/ColladaExporter.cs
+++ b/LibReplanetizer/Serializers/Exporters/ColladaExporter.cs
@@ -33,6 +33,28 @@ namespace LibReplanetizer
             return ".dae";
         }
 
+        private enum ColladaFXSamplerWrapCommon
+        {
+            WRAP = 0, //GL_REPEAT
+            MIRROR = 1, // GL_MIRRORED_REPEAT
+            CLAMP = 2, // GL_CLAMP_TO_EDGE
+            BORDER = 3, // GL_CLAMP_TO_BORDER
+            NONE = 4 // GL_CLAMP_TO_BORDER
+        };
+
+        private ColladaFXSamplerWrapCommon GetFXSamplerWrapCommon(TextureConfigWrapMode wrapMode)
+        {
+            switch (wrapMode)
+            {
+                case TextureConfigWrapMode.Repeat:
+                    return ColladaFXSamplerWrapCommon.WRAP;
+                case TextureConfigWrapMode.ClampEdge:
+                    return ColladaFXSamplerWrapCommon.CLAMP;
+                default:
+                    return ColladaFXSamplerWrapCommon.NONE;
+            }
+        }
+
         private void WriteSkeleton(StreamWriter colladaStream, Skeleton skeleton, float size, string indent = "")
         {
             Matrix3x4 trans = skeleton.bone.transformation;
@@ -356,8 +378,8 @@ namespace LibReplanetizer
                     colladaStream.WriteLine("\t\t\t\t<newparam sid=\"sampler_" + config.id + "\">");
                     colladaStream.WriteLine("\t\t\t\t\t<sampler2D>");
                     colladaStream.WriteLine("\t\t\t\t\t\t<source>surface_" + config.id + "</source>");
-                    colladaStream.WriteLine("\t\t\t\t\t\t<wrap_s>WRAP</wrap_s>");
-                    colladaStream.WriteLine("\t\t\t\t\t\t<wrap_t>WRAP</wrap_t>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<wrap_s>" + GetFXSamplerWrapCommon(config.GetWrapModeS()).ToString() + "</wrap_s>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<wrap_t>" + GetFXSamplerWrapCommon(config.GetWrapModeT()).ToString() + "</wrap_t>");
                     colladaStream.WriteLine("\t\t\t\t\t\t<minfilter>LINEAR_MIPMAP_LINEAR</minfilter>");
                     colladaStream.WriteLine("\t\t\t\t\t\t<magfilter>LINEAR</magfilter>");
                     colladaStream.WriteLine("\t\t\t\t\t</sampler2D>");
@@ -681,7 +703,7 @@ namespace LibReplanetizer
                                         WriteAnimation(colladaStream, anims[i], moby.boneCount, "Anim" + k.ToString(), moby, "\t\t");
                                         k++;
                                     }
-                                    
+
                                 }
                             }
                         }

--- a/LibReplanetizer/Serializers/Exporters/ColladaExporter.cs
+++ b/LibReplanetizer/Serializers/Exporters/ColladaExporter.cs
@@ -42,13 +42,13 @@ namespace LibReplanetizer
             NONE = 4 // GL_CLAMP_TO_BORDER
         };
 
-        private ColladaFXSamplerWrapCommon GetFXSamplerWrapCommon(TextureConfigWrapMode wrapMode)
+        private ColladaFXSamplerWrapCommon GetFXSamplerWrapCommon(TextureConfig.WrapMode wrapMode)
         {
             switch (wrapMode)
             {
-                case TextureConfigWrapMode.Repeat:
+                case TextureConfig.WrapMode.Repeat:
                     return ColladaFXSamplerWrapCommon.WRAP;
-                case TextureConfigWrapMode.ClampEdge:
+                case TextureConfig.WrapMode.ClampEdge:
                     return ColladaFXSamplerWrapCommon.CLAMP;
                 default:
                     return ColladaFXSamplerWrapCommon.NONE;
@@ -378,8 +378,8 @@ namespace LibReplanetizer
                     colladaStream.WriteLine("\t\t\t\t<newparam sid=\"sampler_" + config.id + "\">");
                     colladaStream.WriteLine("\t\t\t\t\t<sampler2D>");
                     colladaStream.WriteLine("\t\t\t\t\t\t<source>surface_" + config.id + "</source>");
-                    colladaStream.WriteLine("\t\t\t\t\t\t<wrap_s>" + GetFXSamplerWrapCommon(config.GetWrapModeS()).ToString() + "</wrap_s>");
-                    colladaStream.WriteLine("\t\t\t\t\t\t<wrap_t>" + GetFXSamplerWrapCommon(config.GetWrapModeT()).ToString() + "</wrap_t>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<wrap_s>" + GetFXSamplerWrapCommon(config.wrapModeS).ToString() + "</wrap_s>");
+                    colladaStream.WriteLine("\t\t\t\t\t\t<wrap_t>" + GetFXSamplerWrapCommon(config.wrapModeT).ToString() + "</wrap_t>");
                     colladaStream.WriteLine("\t\t\t\t\t\t<minfilter>LINEAR_MIPMAP_LINEAR</minfilter>");
                     colladaStream.WriteLine("\t\t\t\t\t\t<magfilter>LINEAR</magfilter>");
                     colladaStream.WriteLine("\t\t\t\t\t</sampler2D>");

--- a/LibReplanetizer/Serializers/Exporters/ExporterUtils.cs
+++ b/LibReplanetizer/Serializers/Exporters/ExporterUtils.cs
@@ -154,6 +154,7 @@ namespace LibReplanetizer
         public ExporterModelSettings.Format format = ExporterModelSettings.Format.Collada;
         public ExporterModelSettings.AnimationChoice animationChoice = ExporterModelSettings.AnimationChoice.None;
         public bool exportMtlFile = true;
+        public bool extendedFeatures = false;
 
         public ExporterModelSettings()
         {

--- a/LibReplanetizer/Serializers/Exporters/WavefrontExporter.cs
+++ b/LibReplanetizer/Serializers/Exporters/WavefrontExporter.cs
@@ -140,7 +140,7 @@ namespace LibReplanetizer
                 if (usedMtls.Contains(modelTextureID))
                     continue;
 
-                bool clampUV = (conf.GetWrapModeS() == TextureConfigWrapMode.ClampEdge && conf.GetWrapModeT() == TextureConfigWrapMode.ClampEdge);
+                bool clampUV = (conf.wrapModeS == TextureConfig.WrapMode.ClampEdge && conf.wrapModeT == TextureConfig.WrapMode.ClampEdge);
                 WriteMaterial(mtlfs, modelTextureID.ToString(), clampUV);
                 usedMtls.Add(modelTextureID);
             }
@@ -600,7 +600,7 @@ namespace LibReplanetizer
                     TextureConfig conf = model.textureConfig[textureNum];
 
                     materialID = conf.id;
-                    clampMaterial = (conf.GetWrapModeS() == TextureConfigWrapMode.ClampEdge && conf.GetWrapModeS() == TextureConfigWrapMode.ClampEdge) ? true : false;
+                    clampMaterial = (conf.wrapModeS == TextureConfig.WrapMode.ClampEdge && conf.wrapModeT == TextureConfig.WrapMode.ClampEdge) ? true : false;
                 }
 
                 if (materialID >= faces.Length || materialID < 0)

--- a/LibReplanetizer/Serializers/Exporters/WavefrontExporter.cs
+++ b/LibReplanetizer/Serializers/Exporters/WavefrontExporter.cs
@@ -127,7 +127,15 @@ namespace LibReplanetizer
             mtlfs.WriteLine("d 1.000000");
             mtlfs.WriteLine("illum 1");
             // The Wavefront Obj standard only defines clamping on all or no axis.
-            mtlfs.WriteLine("map_Kd -clamp " + ((clampUV) ? "on" : "off") + " " + id + ".png");
+            if (modelSettings.extendedFeatures)
+            {
+                mtlfs.WriteLine("map_Kd -clamp " + ((clampUV) ? "on" : "off") + " " + id + ".png");
+            }
+            else
+            {
+                mtlfs.WriteLine("map_Kd " + id + ".png");
+            }
+
         }
 
         private void WriteMaterial(StreamWriter? mtlfs, Model? model, List<int> usedMtls)

--- a/LibReplanetizer/Utilities.cs
+++ b/LibReplanetizer/Utilities.cs
@@ -38,8 +38,8 @@ namespace LibReplanetizer
 
         public static Vector3 MouseToWorldRay(Matrix4 projection, Matrix4 view, Size viewport, Vector2 mouse)
         {
-            Vector3 pos1 = UnProject(ref projection, view, viewport, new Vector3(mouse.X, mouse.Y, 0.1f)); // near
-            Vector3 pos2 = UnProject(ref projection, view, viewport, new Vector3(mouse.X, mouse.Y, 800f));  // far
+            Vector3 pos1 = UnProject(ref projection, view, viewport, new Vector3(mouse.X, mouse.Y, 0.1f));      // near
+            Vector3 pos2 = UnProject(ref projection, view, viewport, new Vector3(mouse.X, mouse.Y, 1024.0f));   // far
             return pos1 - pos2;
         }
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -1027,12 +1027,14 @@ namespace Replanetizer.Frames
 
         private void HandleToolUpdates(Vector3 mouseRay, Vector3 direction)
         {
-            Vector3 magnitude = mouseRay - prevMouseRay;
-
             if (toolbox.tool is BasicTransformTool basicTool)
-                basicTool.Transform(selectedObjects, direction, magnitude);
+            {
+                TransformToolData toolData = new TransformToolData(camera, prevMouseRay, mouseRay, direction);
+                basicTool.Transform(selectedObjects, toolData);
+            }
             else if (toolbox.tool is VertexTranslationTool vertexTranslationTool)
             {
+                Vector3 magnitude = mouseRay - prevMouseRay;
                 vertexTranslationTool.Transform(selectedObjects, direction, magnitude);
                 if (hook is { hookWorking: true } &&
                     selectedObjects.TryGetOne(out var obj) && obj is Spline spline)

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -1440,17 +1440,8 @@ namespace Replanetizer.Frames
                 if (hook != null) hook.UpdateMobys(level.mobs, level.mobyModels);
 
                 GL.Uniform1(shaderIDTable.uniformLevelObjectType, (int) RenderedObjectType.Moby);
-
-                if (enableTransparency)
-                {
-                    GL.Enable(EnableCap.Blend);
-                    GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
-                }
-
                 foreach (RenderableBuffer buffer in mobiesBuffers)
                     RenderBuffer(buffer);
-
-                GL.Disable(EnableCap.Blend);
             }
 
             GL.UseProgram(shaderIDTable.shaderColor);

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -539,10 +539,7 @@ namespace Replanetizer.Frames
             shaderIDTable.uniformColor = GL.GetUniformLocation(shaderIDTable.shaderColor, "incolor");
 
             shaderIDTable.uniformFogColor = GL.GetUniformLocation(shaderIDTable.shaderMain, "fogColor");
-            shaderIDTable.uniformFogNearDist = GL.GetUniformLocation(shaderIDTable.shaderMain, "fogNearDistance");
-            shaderIDTable.uniformFogFarDist = GL.GetUniformLocation(shaderIDTable.shaderMain, "fogFarDistance");
-            shaderIDTable.uniformFogNearIntensity = GL.GetUniformLocation(shaderIDTable.shaderMain, "fogNearIntensity");
-            shaderIDTable.uniformFogFarIntensity = GL.GetUniformLocation(shaderIDTable.shaderMain, "fogFarIntensity");
+            shaderIDTable.uniformFogParams = GL.GetUniformLocation(shaderIDTable.shaderMain, "fogParams");
             shaderIDTable.uniformUseFog = GL.GetUniformLocation(shaderIDTable.shaderMain, "useFog");
 
             shaderIDTable.uniformObjectBlendDistance = GL.GetUniformLocation(shaderIDTable.shaderMain, "objectBlendDistance");
@@ -1401,10 +1398,11 @@ namespace Replanetizer.Frames
             if (level.levelVariables != null)
             {
                 GL.Uniform4(shaderIDTable.uniformFogColor, level.levelVariables.fogColor);
-                GL.Uniform1(shaderIDTable.uniformFogNearDist, level.levelVariables.fogNearDistance);
-                GL.Uniform1(shaderIDTable.uniformFogFarDist, level.levelVariables.fogFarDistance);
-                GL.Uniform1(shaderIDTable.uniformFogNearIntensity, level.levelVariables.fogNearIntensity / 255.0f);
-                GL.Uniform1(shaderIDTable.uniformFogFarIntensity, level.levelVariables.fogFarIntensity / 255.0f);
+                GL.Uniform4(shaderIDTable.uniformFogParams,
+                            level.levelVariables.fogNearDistance / 1024.0f,
+                            1024.0f / (level.levelVariables.fogFarDistance - level.levelVariables.fogNearDistance),
+                            1.0f - level.levelVariables.fogNearIntensity / 255.0f,
+                            1.0f - level.levelVariables.fogFarIntensity / 255.0f);
                 GL.Uniform1(shaderIDTable.uniformUseFog, (enableFog) ? 1 : 0);
             }
 

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -573,6 +573,8 @@ namespace Replanetizer.Frames
                 {
                     GL.BindTexture(TextureTarget.Texture2D, (conf.id >= 0 && conf.id < selectedTextureSet.Count) ? levelFrame.textureIds[selectedTextureSet[conf.id]] : 0);
                     GL.Uniform1(shaderIDTable.uniformUseTransparency, (conf.IgnoresTransparency()) ? 0 : 1);
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) ((conf.wrapModeS == TextureConfig.WrapMode.Repeat) ? TextureWrapMode.Repeat : TextureWrapMode.ClampToEdge));
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) ((conf.wrapModeT == TextureConfig.WrapMode.Repeat) ? TextureWrapMode.Repeat : TextureWrapMode.ClampToEdge));
                     GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
                 }
 

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -115,7 +115,7 @@ namespace Replanetizer.Frames
 
                 ImGui.SetNextWindowSize(startSize);
             }
-                
+
             if (ImGui.Begin(frameName, ref isOpen, ImGuiWindowFlags.NoSavedSettings))
             {
                 Render(deltaTime);
@@ -260,7 +260,7 @@ namespace Replanetizer.Frames
             ImGui.SetColumnWidth(0, 250);
             ImGui.SetColumnWidth(1, (float) width);
             ImGui.SetColumnWidth(2, 320);
-            RenderTree();    
+            RenderTree();
             ImGui.NextColumn();
 
             Tick(deltaTime);
@@ -387,7 +387,7 @@ namespace Replanetizer.Frames
             selectedObjectInstances.Clear();
 
             if (selectedModel == null)
-            { 
+            {
                 return;
             }
 
@@ -576,6 +576,7 @@ namespace Replanetizer.Frames
                 foreach (TextureConfig conf in selectedModel.textureConfig)
                 {
                     GL.BindTexture(TextureTarget.Texture2D, (conf.id >= 0 && conf.id < selectedTextureSet.Count) ? levelFrame.textureIds[selectedTextureSet[conf.id]] : 0);
+                    GL.Uniform1(shaderIDTable.uniformUseTransparency, (conf.IgnoresTransparency()) ? 0 : 1);
                     GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
                 }
 

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -315,6 +315,7 @@ namespace Replanetizer.Frames
                     if (exportSettings.format == ExporterModelSettings.Format.Wavefront)
                     {
                         ImGui.Checkbox("Include MTL File", ref exportSettings.exportMtlFile);
+                        ImGui.Checkbox("Extended Features", ref exportSettings.extendedFeatures);
                     }
 
                     if (ImGui.Button("Export model"))

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -99,7 +99,7 @@ namespace Replanetizer.Frames
             if (selectedObject == null)
                 return;
 
-            var objProps = selectedObject.GetType().GetProperties();
+            PropertyInfo[] objProps = selectedObject.GetType().GetProperties();
             foreach (var prop in objProps)
             {
                 string category =
@@ -165,6 +165,7 @@ namespace Replanetizer.Frames
         {
             object? val = propertyInfo.GetValue(selectedObject);
             Type? type = propertyInfo.GetSetMethod() == null ? null : propertyInfo.PropertyType;
+            string? description = propertyInfo.GetCustomAttribute<DescriptionAttribute>()?.Description ?? null;
 
             if (val == null)
             {
@@ -223,6 +224,15 @@ namespace Replanetizer.Frames
             {
                 float v = (float) val;
                 if (ImGui.InputFloat(propertyName, ref v))
+                {
+                    propertyInfo.SetValue(selectedObject, v);
+                    UpdateLevelFrame();
+                }
+            }
+            else if (type == typeof(bool))
+            {
+                bool v = (bool) val;
+                if (ImGui.Checkbox(propertyName, ref v))
                 {
                     propertyInfo.SetValue(selectedObject, v);
                     UpdateLevelFrame();
@@ -414,7 +424,24 @@ namespace Replanetizer.Frames
                 }
             }
             else
+            {
                 ImGui.LabelText(propertyName, Convert.ToString(val));
+            }
+
+            if (description != null)
+            {
+                ImGui.SameLine();
+
+                ImGui.TextDisabled("(?)");
+                if (ImGui.IsItemHovered())
+                {
+                    ImGui.BeginTooltip();
+                    ImGui.PushTextWrapPos(ImGui.GetFontSize() * 40.0f);
+                    ImGui.TextUnformatted(description);
+                    ImGui.PopTextWrapPos();
+                    ImGui.EndTooltip();
+                }
+            }
         }
     }
 }

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -62,7 +62,7 @@ namespace Replanetizer.Frames
         private Dictionary<string, Dictionary<string, PropertyInfo>> properties = new();
 
         public PropertyFrame(
-            Window wnd, LevelFrame? levelFrame = null, string? overrideFrameName = null, 
+            Window wnd, LevelFrame? levelFrame = null, string? overrideFrameName = null,
             bool listenToCallbacks = false, bool hideCallbackButton = false) : base(wnd)
         {
             if (overrideFrameName is { Length: > 0 })
@@ -371,24 +371,37 @@ namespace Replanetizer.Frames
                 {
                     if (ImGui.CollapsingHeader(propertyName))
                     {
-                        List<TextureConfig> textureConfigs = (List<TextureConfig>) val;
-
-                        PropertyInfo[] texConfProps = typeof(TextureConfig).GetProperties();
-
                         int i = 1;
 
                         foreach (TextureConfig t in list)
                         {
+                            ImGui.PushID("TextureConfig" + i);
+
                             ImGui.Text("Texture Config " + i);
 
-                            foreach (PropertyInfo prop in texConfProps)
+                            int id = t.id;
+                            if (ImGui.InputInt("Texture ID", ref id))
                             {
-                                string displayName =
-                                    prop.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? prop.Name;
-
-                                object? o = prop.GetValue(t);
-                                ImGui.LabelText(displayName, (o == null) ? "Null" : o.ToString());
+                                t.id = id;
                             }
+
+                            ImGui.LabelText("Face Start", t.start.ToString());
+                            ImGui.LabelText("Face Count", t.size.ToString());
+                            ImGui.LabelText("Mode", t.mode.ToString());
+
+                            int wrapModeS = (int) t.wrapModeS;
+                            if (ImGui.Combo("Texture Wrap S" + " ###" + i, ref wrapModeS, TextureConfig.WRAP_MODE_STRINGS, TextureConfig.WRAP_MODE_STRINGS.Length))
+                            {
+                                t.wrapModeS = (TextureConfig.WrapMode) wrapModeS;
+                            }
+
+                            int wrapModeT = (int) t.wrapModeT;
+                            if (ImGui.Combo("Texture Wrap T", ref wrapModeT, TextureConfig.WRAP_MODE_STRINGS, TextureConfig.WRAP_MODE_STRINGS.Length))
+                            {
+                                t.wrapModeT = (TextureConfig.WrapMode) wrapModeT;
+                            }
+
+                            ImGui.PopID();
 
                             i++;
                         }

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -38,9 +38,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ImGui.NET" Version="1.88.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NLog" Version="5.0.5" />
+    <PackageReference Include="ImGui.NET" Version="1.89.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="NLog" Version="5.1.2" />
     <PackageReference Include="OpenTK" Version="4.7.5" />
     <PackageReference Include="OpenTK.Mathematics" Version="4.7.5" />
     <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.7.5" />

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -39,11 +39,11 @@
 
   <ItemGroup>
     <PackageReference Include="ImGui.NET" Version="1.89.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="NLog" Version="5.1.2" />
-    <PackageReference Include="OpenTK" Version="4.7.5" />
-    <PackageReference Include="OpenTK.Mathematics" Version="4.7.5" />
-    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.7.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NLog" Version="5.1.3" />
+    <PackageReference Include="OpenTK" Version="4.7.7" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.7.7" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.7.7" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 

--- a/Replanetizer/Shaders/fs.glsl
+++ b/Replanetizer/Shaders/fs.glsl
@@ -46,13 +46,10 @@ void main() {
     }
 
     if (useTransparency == 1) {
-        // we use dithering for transparency in everything that isnt mobies (it is simple thats why)
-        if ((levelObjectType == 1 || levelObjectType == 2 || levelObjectType == 3)) {
-            vec2 pixel = vec2(gl_FragCoord.x, gl_FragCoord.y);
-            float alpha = 1.0f - textureColor.w;
-            ivec2 patternPos = ivec2(int(mod(pixel.x,4.0f)),int(mod(pixel.y,4.0f)));
-            if (dissolvePattern[patternPos.x][patternPos.y] < alpha) discard;
-        }
+        vec2 pixel = vec2(gl_FragCoord.x, gl_FragCoord.y);
+        float alpha = 1.0f - textureColor.w;
+        ivec2 patternPos = ivec2(int(mod(pixel.x + levelObjectNumber,4.0f)), int(mod(pixel.y,4.0f)));
+        if (dissolvePattern[patternPos.x][patternPos.y] < alpha) discard;
     }
 
 	color.xyz = textureColor.xyz * lightColor * 2.0f;

--- a/Replanetizer/Shaders/fs.glsl
+++ b/Replanetizer/Shaders/fs.glsl
@@ -55,10 +55,10 @@ void main() {
         }
     }
 
-	color.xyz = textureColor.xyz * lightColor;
+	color.xyz = textureColor.xyz * lightColor * 2.0f;
 	color.w = textureColor.w;
 
-	color.xyz = mix(color.xyz, fogColor.xyz, fogBlend);
+	color.xyz = (fogColor.xyz - color.xyz) * fogBlend + color.xyz;
 
 	id = (levelObjectType << 24) | levelObjectNumber;
 }

--- a/Replanetizer/Shaders/skyvs.glsl
+++ b/Replanetizer/Shaders/skyvs.glsl
@@ -19,5 +19,6 @@ void main() {
 	// UV of the vertex. No special space for this one.
 	UV = vertexUV;
 
-	lightColor = vertexRGBA;
+	lightColor.xyz = vertexRGBA.xyz * 0.5f;
+    lightColor.w = vertexRGBA.w;
 }

--- a/Replanetizer/Shaders/vs.glsl
+++ b/Replanetizer/Shaders/vs.glsl
@@ -44,26 +44,29 @@ void main() {
 	UV = vertexUV;
 
     // Light color is precomputed on PS3 but we do it here instead.
-	lightColor = vec3(1.0f);
+	vec3 directionalLight = vec3(0.0f);
+    if (levelObjectType >= 1 && levelObjectType <= 4) {
+        int index = lightIndex;
 
-	int index = lightIndex;
-	vec3 diffuseColor = vec3(0.0f);
+        if (levelObjectType == 1) {
+            index = min(ALLOCATED_LIGHTS - 1, int(vertexTerrainLight));
+        }
 
-	if (levelObjectType == 1) {
-		index = min(ALLOCATED_LIGHTS - 1, int(vertexTerrainLight));
-	}
+        Light l = light[index];
 
-	Light l = light[index];
+        directionalLight += max(0.0f, -dot(l.direction1.xyz, normal)) * l.color1.xyz;
+        directionalLight += max(0.0f, -dot(l.direction2.xyz, normal)) * l.color2.xyz;
+    }
 
-	diffuseColor += max(0.0f, -dot(l.direction1.xyz, normal)) * l.color1.xyz;
-	diffuseColor += max(0.0f, -dot(l.direction2.xyz, normal)) * l.color2.xyz;
-
+    vec3 diffuseLight = vec3(1.0f);
 	if (levelObjectType == 1 || levelObjectType == 3) {
-		lightColor = mix(vertexRGBA.xyz, diffuseColor, 0.5f);
+        diffuseLight = vertexRGBA.xyz;
 	}
 	else if (levelObjectType == 2 || levelObjectType == 4) {
-		lightColor = mix(staticColor.xyz, diffuseColor, 0.5f);
+        diffuseLight = staticColor.xyz;
 	}
+
+    lightColor = mix(diffuseLight, directionalLight, 0.5f);
 
 	fogBlend = 0.0f;
 

--- a/Replanetizer/Tools/BasicTransformTool.cs
+++ b/Replanetizer/Tools/BasicTransformTool.cs
@@ -21,17 +21,10 @@ namespace Replanetizer.Tools
         //   and pivot throughout the entire user interaction. This can also
         //   help in optimizing matrix operations, as we can combine matrices
         //   once and reuse them.
-        public abstract void Transform(LevelObject obj, Vector3 vec, Vector3 pivot);
+        public abstract void Transform(LevelObject obj, Vector3 pivot, TransformToolData data);
 
-        public void Transform(
-            LevelObject obj, Vector3 direction, Vector3 magnitude, Vector3 pivot)
+        public void Transform(Selection selection, TransformToolData data)
         {
-            Transform(obj, ProcessVec(direction, magnitude), pivot);
-        }
-
-        public void Transform(Selection selection, Vector3 direction, Vector3 magnitude)
-        {
-            Vector3 vec = ProcessVec(direction, magnitude);
             Vector3 pivot = selection.mean;
             foreach (var obj in selection)
             {
@@ -39,7 +32,7 @@ namespace Replanetizer.Tools
 
                 if (toolbox.pivotPositioning == PivotPositioning.IndividualOrigins)
                     pivot = obj.position;
-                Transform(obj, vec, pivot);
+                Transform(obj, pivot, data);
             }
         }
     }

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -20,14 +20,60 @@ namespace Replanetizer.Tools
         public RotationTool(Toolbox toolbox) : base(toolbox)
         {
             const float length = 1.5f;
+            const float thickness = length / 2.0f;
+            const float thickness2 = length / 3.0f;
 
             vb = new[]{
-                -length,    0,          0,
-                length,     0,          0,
-                0,          -length,    0,
-                0,          length,     0,
-                0,          0,          -length,
-                0,          0,          length,
+                thickness,     -thickness2,   0,
+                thickness,     thickness2,     0,
+                length,         0,              0,
+
+                -thickness,     - thickness2,   0,
+                -thickness,     thickness2,     0,
+                -length,         0,              0,
+
+
+                thickness,     0,   - thickness2,
+                thickness,     0,     thickness2,
+                length,         0,              0,
+
+                -thickness,     0,   - thickness2,
+                -thickness,     0,     thickness2,
+                -length,         0,              0,
+
+
+                -thickness2,    thickness,     0,
+                thickness2,     thickness,     0,
+                0,              length,         0,
+
+                -thickness2,    -thickness,    0,
+                thickness2,     -thickness,    0,
+                0,              -length,        0,
+
+                0,    thickness,     -thickness2,
+                0,     thickness,     thickness2,
+                0,              length,         0,
+
+                0,    -thickness,    -thickness2,
+                0,     -thickness,    thickness2,
+                0,              -length,        0,
+
+
+                -thickness2,    0,              -thickness,
+                thickness2,     0,              -thickness,
+                0,              0,              -length,
+
+                -thickness2,    0,              thickness,
+                thickness2,     0,              thickness,
+                0,              0,              length,
+
+                0,    -thickness2,              -thickness,
+                0,     thickness2,              -thickness,
+                0,              0,              -length,
+
+                0,    -thickness2,              thickness,
+                0,     thickness2,              thickness,
+                0,              0,              length,
             };
         }
 
@@ -39,15 +85,24 @@ namespace Replanetizer.Tools
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(1, 0, 0, 1));
-            GL.DrawArrays(PrimitiveType.LineStrip, 0, 2);
+            GL.DrawArrays(PrimitiveType.Triangles, 0, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 3, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 6, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 9, 3);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 1);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(0, 1, 0, 1));
-            GL.DrawArrays(PrimitiveType.LineStrip, 2, 2);
+            GL.DrawArrays(PrimitiveType.Triangles, 12, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 15, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 18, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 21, 3);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 2);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(0, 0, 1, 1));
-            GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
+            GL.DrawArrays(PrimitiveType.Triangles, 24, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 27, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 30, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 33, 3);
         }
 
         public override void Transform(LevelObject obj, Vector3 pivot, TransformToolData data)

--- a/Replanetizer/Tools/RotationTool.cs
+++ b/Replanetizer/Tools/RotationTool.cs
@@ -9,6 +9,7 @@ using LibReplanetizer.LevelObjects;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using Replanetizer.Frames;
+using Replanetizer.Utils;
 
 namespace Replanetizer.Tools
 {
@@ -49,10 +50,10 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
         }
 
-        public override void Transform(LevelObject obj, Vector3 vec, Vector3 pivot)
+        public override void Transform(LevelObject obj, Vector3 pivot, TransformToolData data)
         {
             var mat = obj.modelMatrix;
-            var rotPivot = Matrix4.CreateFromQuaternion(Quaternion.FromEulerAngles(vec));
+            var rotPivot = Matrix4.CreateFromQuaternion(Quaternion.FromEulerAngles(data.vec));
 
             if (toolbox.transformSpace == TransformSpace.Global)
             {

--- a/Replanetizer/Tools/ScalingTool.cs
+++ b/Replanetizer/Tools/ScalingTool.cs
@@ -9,6 +9,7 @@ using LibReplanetizer.LevelObjects;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using Replanetizer.Frames;
+using Replanetizer.Utils;
 
 namespace Replanetizer.Tools
 {
@@ -49,10 +50,10 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
         }
 
-        public override void Transform(LevelObject obj, Vector3 vec, Vector3 pivot)
+        public override void Transform(LevelObject obj, Vector3 pivot, TransformToolData data)
         {
             var mat = obj.modelMatrix;
-            var scale = Matrix4.CreateScale(vec);
+            var scale = Matrix4.CreateScale(data.vec);
 
             if (toolbox.transformSpace == TransformSpace.Global)
             {

--- a/Replanetizer/Tools/ScalingTool.cs
+++ b/Replanetizer/Tools/ScalingTool.cs
@@ -10,6 +10,7 @@ using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using Replanetizer.Frames;
 using Replanetizer.Utils;
+using System;
 
 namespace Replanetizer.Tools
 {
@@ -20,14 +21,60 @@ namespace Replanetizer.Tools
         public ScalingTool(Toolbox toolbox) : base(toolbox)
         {
             const float length = 1f;
+            const float thickness = length / 2.0f;
+            const float thickness2 = length / 3.0f;
 
             vb = new[]{
-                -length,    0,          0,
-                length,     0,          0,
-                0,          -length,    0,
-                0,          length,     0,
-                0,          0,          -length,
-                0,          0,          length,
+                thickness,     -thickness2,   0,
+                thickness,     thickness2,     0,
+                length,         0,              0,
+
+                -thickness,     - thickness2,   0,
+                -thickness,     thickness2,     0,
+                -length,         0,              0,
+
+
+                thickness,     0,   - thickness2,
+                thickness,     0,     thickness2,
+                length,         0,              0,
+
+                -thickness,     0,   - thickness2,
+                -thickness,     0,     thickness2,
+                -length,         0,              0,
+
+
+                -thickness2,    thickness,     0,
+                thickness2,     thickness,     0,
+                0,              length,         0,
+
+                -thickness2,    -thickness,    0,
+                thickness2,     -thickness,    0,
+                0,              -length,        0,
+
+                0,    thickness,     -thickness2,
+                0,     thickness,     thickness2,
+                0,              length,         0,
+
+                0,    -thickness,    -thickness2,
+                0,     -thickness,    thickness2,
+                0,              -length,        0,
+
+
+                -thickness2,    0,              -thickness,
+                thickness2,     0,              -thickness,
+                0,              0,              -length,
+
+                -thickness2,    0,              thickness,
+                thickness2,     0,              thickness,
+                0,              0,              length,
+
+                0,    -thickness2,              -thickness,
+                0,     thickness2,              -thickness,
+                0,              0,              -length,
+
+                0,    -thickness2,              thickness,
+                0,     thickness2,              thickness,
+                0,              0,              length,
             };
         }
 
@@ -39,43 +86,53 @@ namespace Replanetizer.Tools
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 0);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(1, 0, 0, 1));
-            GL.DrawArrays(PrimitiveType.LineStrip, 0, 2);
+            GL.DrawArrays(PrimitiveType.Triangles, 0, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 3, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 6, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 9, 3);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 1);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(0, 1, 0, 1));
-            GL.DrawArrays(PrimitiveType.LineStrip, 2, 2);
+            GL.DrawArrays(PrimitiveType.Triangles, 12, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 15, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 18, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 21, 3);
 
             GL.Uniform1(frame.shaderIDTable.uniformColorLevelObjectNumber, 2);
             GL.Uniform4(frame.shaderIDTable.uniformColor, new Vector4(0, 0, 1, 1));
-            GL.DrawArrays(PrimitiveType.LineStrip, 4, 2);
+            GL.DrawArrays(PrimitiveType.Triangles, 24, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 27, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 30, 3);
+            GL.DrawArrays(PrimitiveType.Triangles, 33, 3);
         }
 
         public override void Transform(LevelObject obj, Vector3 pivot, TransformToolData data)
         {
-            var mat = obj.modelMatrix;
-            var scale = Matrix4.CreateScale(data.vec);
+            // TODO: For the global transformation space a different method could be used
+            // that scales along the correct axis
+            float prevDist = getLineIntersectionDist(pivot, data.axisDir, data.cameraPos, data.mousePrevDir);
+            float currDist = getLineIntersectionDist(pivot, data.axisDir, data.cameraPos, data.mouseCurrDir);
 
-            if (toolbox.transformSpace == TransformSpace.Global)
-            {
-                var transPivot = Matrix4.CreateTranslation(pivot);
-                mat = mat * transPivot.Inverted() * scale * transPivot;
-            }
-            else if (toolbox.transformSpace == TransformSpace.Local)
-            {
-                var transPivotOffset = Matrix4.CreateTranslation(obj.position - pivot);
-                var transObj = Matrix4.CreateTranslation(obj.position);
-                var rotObj = Matrix4.CreateFromQuaternion(obj.rotation);
-                mat =
-                    mat *
-                    // Move to origin and remove rotation
-                    transObj.Inverted() * rotObj.Inverted() *
-                    // Offset by the pivot, scale, and undo pivot offset
-                    transPivotOffset * scale * transPivotOffset.Inverted() *
-                    // Add back object rotation and position
-                    rotObj * transObj;
-            }
+            float prevScale = MathF.Abs(prevDist);
+            float currScale = MathF.Abs(currDist);
 
-            obj.SetFromMatrix(mat);
+            float sign = MathF.Sign(prevDist * currDist);
+            float change = currScale - prevScale;
+
+            // Otherwise we flip signs on all axis
+            // It is a bit tricky, when should we flip and when shouldn't we?
+            // Also sometimes the signs flip for just one frame so we
+            // make sure that that only happens when we are close to 0
+            float signX = (obj.scale.X < 1.0f && data.axisDir.X != 0.0f) ? sign : 1.0f;
+            float signY = (obj.scale.Y < 1.0f && data.axisDir.Y != 0.0f) ? sign : 1.0f;
+            float signZ = (obj.scale.Z < 1.0f && data.axisDir.Z != 0.0f) ? sign : 1.0f;
+
+            float scaleX = signX * MathF.Max(0.01f, (data.axisDir.X * change / prevScale + 1.0f));
+            float scaleY = signY * MathF.Max(0.01f, (data.axisDir.Y * change / prevScale + 1.0f));
+            float scaleZ = signZ * MathF.Max(0.01f, (data.axisDir.Z * change / prevScale + 1.0f));
+
+            obj.scale *= new Vector3(scaleX, scaleY, scaleZ);
+            obj.UpdateTransformMatrix();
         }
 
         protected override Vector3 ProcessVec(Vector3 direction, Vector3 magnitude)

--- a/Replanetizer/Tools/Tool.cs
+++ b/Replanetizer/Tools/Tool.cs
@@ -106,6 +106,30 @@ namespace Replanetizer.Tools
             return direction * magnitude * transformMultiplier;
         }
 
+        /// <summary>
+        /// Computes the intersection of the lines x + a * dx and y + b * dy. The returned float f is such that x + f * dx is the intersection.
+        /// If no intersection is given then the corresponding value for the closest approach is returned.
+        /// Note: That last one is a happy coincidence, I did not verify this but it seems to work. :)
+        /// </summary>
+        protected float getLineIntersectionDist(Vector3 x, Vector3 dx, Vector3 y, Vector3 dy)
+        {
+            Vector3 g = y - x;
+            Vector3 h = Vector3.Cross(dy, g);
+            Vector3 k = Vector3.Cross(dy, dx);
+
+            float ha = h.Length;
+            float ka = k.Length;
+
+            if (ha == 0.0f || ka == 0.0f)
+            {
+                return 0.0f;
+            }
+
+            float sign = (Vector3.Dot(h, k) >= 0.0f) ? 1.0f : -1.0f;
+
+            return (ha / ka) * sign;
+        }
+
         public virtual void Reset()
         {
         }

--- a/Replanetizer/Tools/TransformToolData.cs
+++ b/Replanetizer/Tools/TransformToolData.cs
@@ -1,0 +1,54 @@
+// Copyright (C) 2018-2023, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using LibReplanetizer.LevelObjects;
+using OpenTK.Mathematics;
+using Replanetizer.Utils;
+
+namespace Replanetizer.Tools
+{
+    public class TransformToolData
+    {
+        public Vector3 cameraPos;
+        public Vector3 mousePrevDir;
+        public Vector3 mouseCurrDir;
+        private bool _mouseDiffDirComputed = false;
+        private Vector3 _mouseDiffDir;
+        public Vector3 mouseDiffDir
+        {
+            get
+            {
+                if (_mouseDiffDirComputed) return _mouseDiffDir;
+                _mouseDiffDir = mouseCurrDir - mousePrevDir;
+                _mouseDiffDirComputed = true;
+                return _mouseDiffDir;
+            }
+        }
+        private bool _vecComputed = false;
+        private Vector3 _vec;
+        public Vector3 vec
+        {
+            get
+            {
+                if (_vecComputed) return _vec;
+                _vec = axisDir * mouseDiffDir * 50.0f;
+                _vecComputed = true;
+                return _vec;
+            }
+        }
+        public Vector3 axisDir;
+
+
+        public TransformToolData(Camera camera, Vector3 mousePrevDir, Vector3 mouseCurrDir, Vector3 axisDir)
+        {
+            this.cameraPos = camera.position;
+            this.mousePrevDir = mousePrevDir;
+            this.mouseCurrDir = mouseCurrDir;
+            this.axisDir = axisDir;
+        }
+    }
+}

--- a/Replanetizer/Tools/TranslationTool.cs
+++ b/Replanetizer/Tools/TranslationTool.cs
@@ -20,57 +20,59 @@ namespace Replanetizer.Tools
         public TranslationTool(Toolbox toolbox) : base(toolbox)
         {
             const float length = 2.0f;
+            const float thickness = length / 2.0f;
+            const float thickness2 = length / 3.0f;
 
             vb = new[]{
-                length / 2,     - length / 3,   0,
-                length / 2,     length / 3,     0,
+                thickness,     -thickness2,   0,
+                thickness,     thickness2,     0,
                 length,         0,              0,
 
-                -length / 2,     - length / 3,   0,
-                -length / 2,     length / 3,     0,
+                -thickness,     - thickness2,   0,
+                -thickness,     thickness2,     0,
                 -length,         0,              0,
 
 
-                length / 2,     0,   - length / 3,
-                length / 2,     0,     length / 3,
+                thickness,     0,   - thickness2,
+                thickness,     0,     thickness2,
                 length,         0,              0,
 
-                -length / 2,     0,   - length / 3,
-                -length / 2,     0,     length / 3,
+                -thickness,     0,   - thickness2,
+                -thickness,     0,     thickness2,
                 -length,         0,              0,
 
 
-                -length / 3,    length / 2,     0,
-                length / 3,     length / 2,     0,
+                -thickness2,    thickness,     0,
+                thickness2,     thickness,     0,
                 0,              length,         0,
 
-                -length / 3,    -length / 2,    0,
-                length / 3,     -length / 2,    0,
+                -thickness2,    -thickness,    0,
+                thickness2,     -thickness,    0,
                 0,              -length,        0,
 
-                0,    length / 2,     -length / 3,
-                0,     length / 2,     length / 3,
+                0,    thickness,     -thickness2,
+                0,     thickness,     thickness2,
                 0,              length,         0,
 
-                0,    -length / 2,    -length / 3,
-                0,     -length / 2,    length / 3,
+                0,    -thickness,    -thickness2,
+                0,     -thickness,    thickness2,
                 0,              -length,        0,
 
 
-                -length / 3,    0,              -length / 2,
-                length / 3,     0,              -length / 2,
+                -thickness2,    0,              -thickness,
+                thickness2,     0,              -thickness,
                 0,              0,              -length,
 
-                -length / 3,    0,              length / 2,
-                length / 3,     0,              length / 2,
+                -thickness2,    0,              thickness,
+                thickness2,     0,              thickness,
                 0,              0,              length,
 
-                0,    -length / 3,              -length / 2,
-                0,     length / 3,              -length / 2,
+                0,    -thickness2,              -thickness,
+                0,     thickness2,              -thickness,
                 0,              0,              -length,
 
-                0,    -length / 3,              length / 2,
-                0,     length / 3,              length / 2,
+                0,    -thickness2,              thickness,
+                0,     thickness2,              thickness,
                 0,              0,              length,
             };
         }
@@ -103,36 +105,13 @@ namespace Replanetizer.Tools
             GL.DrawArrays(PrimitiveType.Triangles, 33, 3);
         }
 
-        /// <summary>
-        /// Computes the intersection of the lines x + a * dx and y + b * dy. The returned float f is such that x + f * dx is the intersection.
-        /// The function returns 0.0f is no intersection was found.
-        /// </summary>
-        private float getLineIntersectionDist(Vector3 x, Vector3 dx, Vector3 y, Vector3 dy)
-        {
-            Vector3 g = y - x;
-            Vector3 h = Vector3.Cross(dy, g);
-            Vector3 k = Vector3.Cross(dy, dx);
-
-            float ha = h.Length;
-            float ka = k.Length;
-
-            if (ha == 0.0f || ka == 0.0f)
-            {
-                return 0.0f;
-            }
-
-            float sign = (Vector3.Dot(h, k) >= 0.0f) ? 1.0f : -1.0f;
-
-            return (ha / ka) * sign;
-        }
-
         public override void Transform(LevelObject obj, Vector3 pivot, TransformToolData data)
         {
             Matrix4 mat = obj.modelMatrix;
 
             if (toolbox.transformSpace == TransformSpace.Global)
             {
-                float startDist = getLineIntersectionDist(data.cameraPos, data.mousePrevDir, obj.position, data.axisDir);
+                float startDist = getLineIntersectionDist(data.cameraPos, data.mousePrevDir, pivot, data.axisDir);
                 Vector3 startPos = data.cameraPos + startDist * data.mousePrevDir;
 
                 float finalDist = getLineIntersectionDist(startPos, data.axisDir, data.cameraPos, data.mouseCurrDir);
@@ -144,7 +123,7 @@ namespace Replanetizer.Tools
             {
                 Vector3 aDir = (mat.Inverted() * new Vector4(data.axisDir, 0.0f)).Xyz;
 
-                float startDist = getLineIntersectionDist(data.cameraPos, data.mousePrevDir, obj.position, aDir);
+                float startDist = getLineIntersectionDist(data.cameraPos, data.mousePrevDir, pivot, aDir);
                 Vector3 startPos = data.cameraPos + startDist * data.mousePrevDir;
 
                 float finalDist = getLineIntersectionDist(startPos, aDir, data.cameraPos, data.mouseCurrDir);

--- a/Replanetizer/Utils/Camera.cs
+++ b/Replanetizer/Utils/Camera.cs
@@ -21,7 +21,7 @@ namespace Replanetizer.Utils
         public float fovy { get; set; } = (float) 3 / MathF.PI;
         public float aspect { get; set; } = (float) 16 / 9;
         public float near { get; set; } = 0.1f;
-        public float far { get; set; } = 10000.0f;
+        public float far { get; set; } = 1024.0f;
 
         /// <summary>
         /// The frustum is defined by 6 planes which are each defined by a point and a normal.

--- a/Replanetizer/Utils/RenderableBuffer.cs
+++ b/Replanetizer/Utils/RenderableBuffer.cs
@@ -246,27 +246,24 @@ namespace Replanetizer.Utils
              * of the fading out buildings.
              */
 
-            TextureConfigWrapMode wrapModeS = conf.GetWrapModeS();
-            TextureConfigWrapMode wrapModeT = conf.GetWrapModeT();
-
-            switch (wrapModeS)
+            switch (conf.wrapModeS)
             {
-                case TextureConfigWrapMode.Repeat:
+                case TextureConfig.WrapMode.Repeat:
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
                     break;
-                case TextureConfigWrapMode.ClampEdge:
+                case TextureConfig.WrapMode.ClampEdge:
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.ClampToEdge);
                     break;
                 default:
                     break;
             }
 
-            switch (wrapModeT)
+            switch (conf.wrapModeT)
             {
-                case TextureConfigWrapMode.Repeat:
+                case TextureConfig.WrapMode.Repeat:
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
                     break;
-                case TextureConfigWrapMode.ClampEdge:
+                case TextureConfig.WrapMode.ClampEdge:
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.ClampToEdge);
                     break;
                 default:

--- a/Replanetizer/Utils/RenderableBuffer.cs
+++ b/Replanetizer/Utils/RenderableBuffer.cs
@@ -236,64 +236,40 @@ namespace Replanetizer.Utils
         }
 
         /// <summary>
-        /// Takes a textureConfig mode as input and sets the texture wrap mode based on that.
+        /// Takes a textureConfig as input and sets the texture wrap modes based on that.
         /// </summary>
-        private void SetTextureWrapMode(int mode)
+        private void SetTextureWrapMode(TextureConfig conf)
         {
             /*
              * There is an issue with opaque edges in some transparent objects
              * This can easily be observed on RaC 1 Kerwan where you have these ugly edges on some trees and the bottom
-             * of the fading out buildings
+             * of the fading out buildings.
              */
-            switch (type)
+
+            TextureConfigWrapMode wrapModeS = conf.GetWrapModeS();
+            TextureConfigWrapMode wrapModeT = conf.GetWrapModeT();
+
+            switch (wrapModeS)
             {
-                case RenderedObjectType.Shrub:
+                case TextureConfigWrapMode.Repeat:
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
+                    break;
+                case TextureConfigWrapMode.ClampEdge:
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.ClampToEdge);
+                    break;
+                default:
+                    break;
+            }
+
+            switch (wrapModeT)
+            {
+                case TextureConfigWrapMode.Repeat:
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
                     break;
-                case RenderedObjectType.Tie:
-                    switch (mode)
-                    {
-                        case 13: /* 0001101 (RaC 1)*/
-                        case 15: /* 0001111 (RaC 1)*/
-                        case 93: /* 1011101 (RaC 2)*/
-                        case 95: /* 1011111 (RaC 2)*/
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.MirroredRepeat);
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.MirroredRepeat);
-                            break;
-                        case 117440512: /* 0111000000000000000000000000 (RaC 1 & 3) */
-                            //GL_MIRROR_CLAMP_TO_EDGE = 0x8743
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.ClampToEdge);
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.ClampToEdge);
-                            break;
-                        default:
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
-                            break;
-                    }
+                case TextureConfigWrapMode.ClampEdge:
+                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.ClampToEdge);
                     break;
-                case RenderedObjectType.Terrain:
-                    switch (mode)
-                    {
-                        case 218103808: /* 1101000000000000000000000000 (RaC 1) */
-                            //GL_MIRROR_CLAMP_TO_EDGE = 0x8743
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.MirroredRepeat);
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.MirroredRepeat);
-                            break;
-                        case 83886080: /* 101000000000000000000000000 (RaC 3) */
-                            //GL_MIRROR_CLAMP_TO_EDGE = 0x8743
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
-                            break;
-                        default:
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
-                            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
-                            break;
-                    }
-                    break;
-                case RenderedObjectType.Moby:
-                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float) TextureWrapMode.Repeat);
-                    GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float) TextureWrapMode.Repeat);
+                default:
                     break;
             }
         }
@@ -420,7 +396,7 @@ namespace Replanetizer.Utils
                     {
                         GL.BindTexture(TextureTarget.Texture2D, (conf.id > 0) ? textureIds[level.textures[conf.id]] : 0);
                         SetTransparencyMode(conf);
-                        //SetTextureWrapMode(conf.mode);
+                        SetTextureWrapMode(conf);
                         GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
                     }
 

--- a/Replanetizer/Utils/RenderableBuffer.cs
+++ b/Replanetizer/Utils/RenderableBuffer.cs
@@ -25,6 +25,8 @@ namespace Replanetizer.Utils
 
         private int loadedModelID = -1;
 
+        private bool emptyModel = false;
+
         private int ibo = 0;
         private int vbo = 0;
 
@@ -66,11 +68,15 @@ namespace Replanetizer.Utils
             if (iboAllocated)
             {
                 GL.DeleteBuffer(ibo);
+                ibo = 0;
+                iboAllocated = false;
             }
 
             if (vboAllocated)
             {
                 GL.DeleteBuffer(vbo);
+                vbo = 0;
+                vboAllocated = false;
             }
         }
 
@@ -81,6 +87,14 @@ namespace Replanetizer.Utils
         {
             DeleteBuffers();
             loadedModelID = modelObject.modelID;
+
+            if (modelObject.GetIndices().Length == 0)
+            {
+                emptyModel = true;
+                return;
+            }
+
+            emptyModel = false;
 
             BufferUsageHint hint = BufferUsageHint.StaticDraw;
             if (modelObject.IsDynamic())
@@ -296,6 +310,8 @@ namespace Replanetizer.Utils
         /// </summary>
         public void ComputeCulling(Camera camera, bool distanceCulling, bool frustumCulling)
         {
+            if (emptyModel) return;
+
             if (distanceCulling)
             {
                 float dist = (modelObject.position - camera.position).Length;
@@ -370,6 +386,7 @@ namespace Replanetizer.Utils
         public void Render()
         {
             if (SHADER_ID_TABLE == null) return;
+            if (emptyModel) return;
             if (culled) return;
             if (!BindIbo() || !BindVbo()) return;
             if (modelObject.model == null) return;

--- a/Replanetizer/Utils/ShaderIDTable.cs
+++ b/Replanetizer/Utils/ShaderIDTable.cs
@@ -22,10 +22,7 @@ namespace Replanetizer.Utils
         public int uniformSkyWorldToViewMatrix { get; set; }
         public int uniformUseFog { get; set; }
         public int uniformFogColor { get; set; }
-        public int uniformFogFarDist { get; set; }
-        public int uniformFogNearDist { get; set; }
-        public int uniformFogFarIntensity { get; set; }
-        public int uniformFogNearIntensity { get; set; }
+        public int uniformFogParams { get; set; }
         public int uniformObjectBlendDistance { get; set; }
         public int uniformLevelObjectType { get; set; }
         public int uniformLevelObjectNumber { get; set; }

--- a/Replanetizer/Window.cs
+++ b/Replanetizer/Window.cs
@@ -30,7 +30,7 @@ namespace Replanetizer
         public string[] args;
 
         public Window(string[] args) : base(GameWindowSettings.Default,
-            new NativeWindowSettings() { Size = new Vector2i(1600, 900), APIVersion = new Version(3, 3), Flags = ContextFlags.ForwardCompatible, Profile = ContextProfile.Core })
+            new NativeWindowSettings() { Size = new Vector2i(1600, 900), APIVersion = new Version(3, 3), Flags = ContextFlags.ForwardCompatible, Profile = ContextProfile.Core, Vsync = VSyncMode.On })
         {
             this.args = args;
             openFrames = new List<Frame>();


### PR DESCRIPTION
Renderer:
 - Texture wrapping modes based on the texture config are now included.
 - Fixed fog rendering.
 - Fixed light intensity scaling.

Moby spawn flags:
 - Replaced the enum based spawn flags with a bitmask based one
 - Added meaning for each bit (Thanks to Trippy Contrails Connoisseur)

Transformation tools:
 - Translation tool now behaves like in Blender
 - Scaling and rotation tools are now properly clickable.
 - Scaling now works correctly (however local transformation space is always used)

Added the possibility of adding descriptions to fields which are then displayed in a property frame.
Models export include texture wrapping modes now. (However, Blender ignores them)

Closes #55
Closes #61