### PR TITLE
Fix crash when exporting textures

### DIFF
--- a/LibReplanetizer/LibReplanetizer.csproj
+++ b/LibReplanetizer/LibReplanetizer.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="ImGui.NET" Version="1.90.1.1" />
     <PackageReference Include="NLog" Version="5.2.8" />
     <PackageReference Include="OpenTK.Mathematics" Version="4.8.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
     <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
 

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="OpenTK" Version="4.8.2" />
     <PackageReference Include="OpenTK.Mathematics" Version="4.8.2" />
     <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.8.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Replanetizer/Utils/TextureIO.cs
+++ b/Replanetizer/Utils/TextureIO.cs
@@ -97,7 +97,7 @@ namespace Replanetizer.Utils
 
             for (int i = 0; i < level.mobyloadTextures.Count; i++)
             {
-                List<Texture> textures = level.missions[i].textures;
+                List<Texture> textures = level.mobyloadTextures[i];
                 for (int j = 0; j < textures.Count; j++)
                 {
                     ExportTexture(textures[j], Path.Join(path, $"mobyload_{i}_{j}.png"), true);


### PR DESCRIPTION
The mission textures were used when exporting the mobyload textures which could also crash Replanetizer when there were more mobyload textures than missions.