### PR TITLE
Return empty string on pressing "cancel" on windows file dialog

### DIFF
--- a/Replanetizer/Utils/CrossFileDialog.cs
+++ b/Replanetizer/Utils/CrossFileDialog.cs
@@ -262,8 +262,14 @@ namespace Replanetizer.Utils
                 var dialog = new System.Windows.Forms.OpenFileDialog();
                 dialog.Title = title;
                 dialog.Filter = BuildFilterList(filter);
-                dialog.ShowDialog();
-                return dialog.FileName;
+                if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                {
+                    return dialog.FileName;
+                }
+                else
+                {
+                    return string.Empty;
+                }
 #else
                 throw new NoImplementationException();
 #endif
@@ -284,8 +290,14 @@ namespace Replanetizer.Utils
                 var dialog = new System.Windows.Forms.SaveFileDialog();
                 dialog.Title = title;
                 dialog.Filter = BuildFilterList(filter);
-                dialog.ShowDialog();
-                return dialog.FileName;
+                if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                {
+                    return dialog.FileName;
+                }
+                else
+                {
+                    return string.Empty;
+                }
 #else
                 throw new NoImplementationException();
 #endif
@@ -297,8 +309,14 @@ namespace Replanetizer.Utils
                 var dialog = new System.Windows.Forms.FolderBrowserDialog();
                 dialog.Description = title;
                 dialog.UseDescriptionForTitle = true;
-                dialog.ShowDialog();
-                return dialog.SelectedPath;
+                if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                {
+                    return dialog.SelectedPath;
+                }
+                else
+                {
+                    return string.Empty;
+                }
 #else
                 throw new NoImplementationException();
 #endif


### PR DESCRIPTION
I noticed the windows implementation of `CrossFileDialog` was returning the currently entered string even when pressing cancel, gone ahead and made it return an empty string in that case. I've not tested the `KDialog` or `Zenity` implementation as I currently don't have an Linux install.

I've also noticed that whenever CrossFileDialog is used, it checks to make sure the string isn't empty so i assume that's the desired behaviour here.