### PR TITLE
Fixes DL animations ignoring additional bone scalings after the first

### DIFF
--- a/LibReplanetizer/Models/Animation/Animation.cs
+++ b/LibReplanetizer/Models/Animation/Animation.cs
@@ -137,7 +137,7 @@ namespace LibReplanetizer.Models.Animations
             }
 
             // speed is not stored in anim header
-            speed = 1;
+            speed = 0.5f;
         }
 
         public byte[] Serialize(int baseOffset = 0, int fileOffset = 0)

--- a/LibReplanetizer/Models/Animation/Frame.cs
+++ b/LibReplanetizer/Models/Animation/Frame.cs
@@ -107,7 +107,9 @@ namespace LibReplanetizer.Models.Animations
 
             if (exists)
             {
-                return scalings.First(s => s.bone == bone).scale;
+                // dl can have multiple scalings per bone
+                // doesn't seem to break the other rac games
+                return scalings.Where(s => s.bone == bone).Select(x => x.scale).Aggregate((a, b) => a + b);
             }
 
             return null;


### PR DESCRIPTION
Seems to fix the last remaining issue with DL animations. Uses the same principal as translations to sum all scalings applied to a bone in an animation frame.

I also changed the default animation speed to 0.5 to more closely match in game. Not sure yet if there is a speed parameter somewhere in the data.