### PR TITLE
Fix some memory hook bugs

### DIFF
--- a/LibReplanetizer/Level Objects/Gameplay/Moby.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Moby.cs
@@ -244,9 +244,9 @@ namespace LibReplanetizer.LevelObjects
         public Bitmask mode { get; set; } = 0;
 
         // This should probably get removed, not enough information are available to construct a moby like that
-        public Moby()
+        public Moby(GameType game)
         {
-            this.game = GameType.RaC1;
+            this.game = game;
             this.pVars = new byte[0];
             this.mobyID = MAX_ID++;
         }
@@ -852,6 +852,8 @@ namespace LibReplanetizer.LevelObjects
 
                 oClass = ReadUshort(memory, offset + 0xAA);
 
+                UID = ReadUshort(memory, offset + 0xB2);
+
                 transformation = ReadMatrix3x4(memory, offset + 0xC0);
 
                 float rotX = ReadFloat(memory, offset + 0xF0);
@@ -902,6 +904,7 @@ namespace LibReplanetizer.LevelObjects
             if (memory.IsDead())
             {
                 model = null;
+                modelID = -1;
                 return;
             }
 

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -791,7 +791,7 @@ namespace Replanetizer.Frames
 
             if (interactiveSession && hookLiveUpdate && hook != null)
             {
-                hook.UpdateMobys(level.mobs, level.mobyModels, this);
+                hook.UpdateMobys(level.mobs, level.mobyModels, this, level.game);
                 if (hookUpdateCamera)
                 {
                     hook.UpdateCamera(camera);

--- a/Replanetizer/MemoryHook/MemoryHookHandle.cs
+++ b/Replanetizer/MemoryHook/MemoryHookHandle.cs
@@ -121,7 +121,7 @@ namespace Replanetizer.MemoryHook
 #endif
         }
 
-        public void UpdateMobys(List<Moby> levelMobs, List<Model> models, LevelFrame frame)
+        public void UpdateMobys(List<Moby> levelMobs, List<Model> models, LevelFrame frame, GameType game)
         {
 #if _WINDOWS
             if (!hookWorking) return;
@@ -143,7 +143,7 @@ namespace Replanetizer.MemoryHook
 
             while (levelMobs.Count < numMobs)
             {
-                Moby mob = new Moby();
+                Moby mob = new Moby(game);
                 levelMobs.Add(mob);
                 frame.levelRenderer?.Include(mob);
             }


### PR DESCRIPTION
1. Fix Ratchet disappearing on rac2 and uya when the level is reloaded in-game
2. Mobys that were added by memory hook handle were being set to use rac1's moby struct instead of rac2/rac3's. So stuff like Clank's backpack, weapons etc, would not show up when using the memory hook.