### PR TITLE
Assign proper ID to Splines when parsing a level

### DIFF
--- a/LibReplanetizer/Level Objects/Gameplay/Spline.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Spline.cs
@@ -21,8 +21,6 @@ namespace LibReplanetizer.LevelObjects
         [Category("Attributes"), DisplayName("offset")]
         public long offset { get; set; }
 
-        static int CNT = 0;
-
         /*public override Vector3 position
         {
             get { return _position; }
@@ -57,20 +55,20 @@ namespace LibReplanetizer.LevelObjects
             }
         }
 
-        public Spline(byte[] splineBlock, int offset)
+        public Spline(byte[] splineBlock, int offset, int id)
         {
+            this.id = id;
             this.offset = offset;
             LoadFromByteArray(splineBlock, offset);
         }
 
-        public static LevelObject CreateFromByteArray(byte[] splineBlock, int offset)
+        public static LevelObject CreateFromByteArray(byte[] splineBlock, int offset, int id)
         {
-            return new Spline(splineBlock, offset);
+            return new Spline(splineBlock, offset, id);
         }
 
         public void LoadFromByteArray(byte[] splineBlock, int offset)
         {
-            id = CNT;
             int count = ReadInt(splineBlock, offset);
             vertexBuffer = new float[count * 3];
             wVals = new float[count];
@@ -86,8 +84,6 @@ namespace LibReplanetizer.LevelObjects
             {
                 //_position = new Vector3(vertexBuffer[0], vertexBuffer[1], vertexBuffer[2]);
             }
-
-            CNT++;
         }
 
         public override byte[] ToByteArray()

--- a/LibReplanetizer/Parsers/GameplayParser.cs
+++ b/LibReplanetizer/Parsers/GameplayParser.cs
@@ -43,7 +43,7 @@ namespace LibReplanetizer.Parsers
             for (int i = 0; i < splineCount; i++)
             {
                 int offset = ReadInt(splineHeadBlock, (i * 4));
-                splines.Add(new Spline(splineBlock, offset));
+                splines.Add(new Spline(splineBlock, offset, i));
             }
             return splines;
         }
@@ -332,8 +332,12 @@ namespace LibReplanetizer.Parsers
 
             for (int i = 0; i < count; i++)
             {
+                /*
+                 * Use ID -1 for the Spline objects created here
+                 * as they are used only for rendering.
+                 */
                 int offset = ReadInt(splineHeadBlock, i * 0x04);
-                splines.Add(new Spline(splineBlock, offset));
+                splines.Add(new Spline(splineBlock, offset, -1));
             }
 
             for (int i = 0; i < count; i++)


### PR DESCRIPTION
Unlike objects such as Cuboids, which use their index inside the level's <object type> table as "id", a static incrementing counter was used to assign an ID to each Spline. This appears to work fine but the current implementation actually contains a fatal bug: the counter is never reset when loading a new level! As a result, if more than one level is loaded without restarting Replanetizer, all Spline IDs will be wrong.

The solution is fairly simple: follow the same logic as other objects types and explicitly assign the proper ID to each Spline object.
