### PR TITLE
Improve handling of splines associated to a GrindPath

### DIFF
--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -974,7 +974,14 @@ namespace Replanetizer.Frames
                 case RenderedObjectType.Moby:
                     return level.mobs.Find(x => x.globalID == hitId);
                 case RenderedObjectType.Spline:
-                    return level.splines.Find(x => x.globalID == hitId);
+                    // Both "Splines" and "GrindPaths" use Spline objects.
+                    // Search for a hit in the Splines first then look
+                    // in the Spline objects of GrindPaths.
+                    Spline? s = level.splines.Find(x => x.globalID == hitId);
+                    if (s != null)
+                        return s;
+
+                    return level.grindPaths.Find(x => x.spline.globalID == hitId);
                 case RenderedObjectType.Cuboid:
                     return level.cuboids.Find(x => x.globalID == hitId);
                 case RenderedObjectType.Sphere:

--- a/Replanetizer/Renderer/GrindPathRenderer.cs
+++ b/Replanetizer/Renderer/GrindPathRenderer.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (C) 2026, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LibReplanetizer.LevelObjects;
+using Replanetizer.Utils;
+
+namespace Replanetizer.Renderer
+{
+    public class GrindPathRenderer : Renderer
+    {
+        private BillboardRenderer grindPathsRenderer;
+        private WireframeRenderer splinesRenderer;
+
+        public GrindPathRenderer(ShaderTable shaderTable)
+        {
+            grindPathsRenderer = new BillboardRenderer(shaderTable);
+            splinesRenderer = new WireframeRenderer(shaderTable);
+        }
+        public override void Include<T>(T obj)
+        {
+            if (obj is GrindPath grindPath)
+            {
+                grindPathsRenderer.Include(grindPath);
+                splinesRenderer.Include(grindPath.spline);
+
+                return;
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public override void Include<T>(List<T> list)
+        {
+            if (list is List<GrindPath> grindPaths)
+            {
+                foreach (GrindPath gp in grindPaths)
+                {
+                    Include(gp);
+                }
+
+                return;
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public override void Render(RendererPayload payload)
+        {
+            // Objects need to be in "payload.selection" to be rendered
+            // using the alternate color. Add the "dummy" Spline object
+            // which correspond to every selected GrindPath to this list
+            // such that both the billboard and the wireframe render in
+            // alternate color (or none if unselected).
+            List<Spline> selectedGPSplines = new List<Spline>();
+
+            foreach (var selected in payload.selection)
+            {
+                if (selected is GrindPath gp)
+                {
+                    selectedGPSplines.Add(gp.spline);
+                }
+            }
+            payload.selection.Add(selectedGPSplines);
+
+            grindPathsRenderer.Render(payload);
+            splinesRenderer.Render(payload);
+
+            // Remove the dummy Spline objects from "payload.selection"
+            // after rendering is done; for every purpose other than
+            // rendering, they are NOT selected.
+            payload.selection.Remove(selectedGPSplines);
+        }
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/Replanetizer/Renderer/LevelRenderer.cs
+++ b/Replanetizer/Renderer/LevelRenderer.cs
@@ -43,8 +43,7 @@ namespace Replanetizer.Renderer
         private BillboardRenderer? pointLightRenderer;
         private BillboardRenderer? envSamplesRenderer;
         private BillboardRenderer? envTransitionRenderer;
-        private BillboardRenderer? grindPathRenderer;
-        private WireframeRenderer? grindPathSplineRenderer;
+        private GrindPathRenderer? grindPathRenderer;
         private ToolRenderer toolRenderer;
         private DirectionalLightsBuffer dirLightsBuffer;
 
@@ -156,14 +155,8 @@ namespace Replanetizer.Renderer
             envTransitionRenderer = new BillboardRenderer(shaderTable);
             envTransitionRenderer.Include(level.envTransitions);
 
-            grindPathRenderer = new BillboardRenderer(shaderTable);
+            grindPathRenderer = new GrindPathRenderer(shaderTable);
             grindPathRenderer.Include(level.grindPaths);
-
-            grindPathSplineRenderer = new WireframeRenderer(shaderTable);
-            foreach (GrindPath path in level.grindPaths)
-            {
-                grindPathSplineRenderer.Include(path.spline);
-            }
         }
 
         private void Add(Shrub shrub)
@@ -367,10 +360,7 @@ namespace Replanetizer.Renderer
                 envTransitionRenderer?.Render(payload);
 
             if (payload.visibility.enableGrindPaths)
-            {
                 grindPathRenderer?.Render(payload);
-                grindPathSplineRenderer?.Render(payload);
-            }
 
             toolRenderer.Render(payload);
         }


### PR DESCRIPTION
Fixes two issues:
- it was not possible to select a GrindPath by clicking on its Spline
- the Spline object of a GrindPath was not rendering as "selected" when the GrindPath itself was selected (this made it difficult, if not impossible, to see where the grind path was in the level)

The first issue is fixed by checking for Spline objects that are associated to a GrindPath when the object hit by the mouse click hittest is a Spline.

The second issue is fixed in a perhaps hacky manner: a new "Renderer" object is introduced for GrindPath objects and wraps the rendering of both the GrindPath (a billboard) and the associated Spline, done by the already existing WireframeRenderer and BillboardRenderer. Using some shenanigans, the renderer manages to make both billboard and spline render as "selected" when the GrindPath is selected.