### PR TITLE
Make the instance buttons in Model Viewer truly unique

### DIFF
--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -286,10 +286,10 @@ namespace Replanetizer.Frames
             {
                 foreach (ModelObject obj in selectedObjectInstances)
                 {
-                    string objName = "Instance";
+                    string objName = $"Instance##{obj.globalID}";
                     if (obj is Moby mob)
                     {
-                        objName = $"Instance [" + GetStringFromID(mob.mobyID) + "]";
+                        objName = $"Instance [{GetStringFromID(mob.mobyID)}]##{mob.globalID}";
                     }
 
                     if (ImGui.Button(objName))


### PR DESCRIPTION
When hooked to RPCS3, it's possible for mobys to have the same mobyID. Since that's what was used to create the button's label, there were multiple buttons with the same label, which made ImGui unhappy and caused only one instance to be selectable.

Fix by including the guaranteed unique globalID of elements as hidden text in the button label, which makes them unique to ImGui while still showing the same text as before.

While at it, also actually make use of string interpolation in one place that wanted to but did not.