### PR TITLE
Deadlocked missions data files support

### DIFF
--- a/LibReplanetizer/Headers/MissionHeader.cs
+++ b/LibReplanetizer/Headers/MissionHeader.cs
@@ -50,6 +50,21 @@ namespace LibReplanetizer.Headers
 
             return files;
         }
+        public static List<string> FindMissionDataFiles(GameType game, string enginePath)
+        {
+            string? dir = Path.GetDirectoryName(enginePath);
+
+            List<string> files = new List<string>();
+
+            if (dir == null) return files;
+
+            if (game == GameType.DL)
+            {
+                files.AddRange(Directory.GetFiles(dir, "gameplay_mission_data*.dat"));
+            }
+
+            return files;
+        }
 
         public byte[] Serialize()
         {

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -384,7 +384,7 @@ namespace LibReplanetizer
                 if (datPath != null)
                 {
                     using var datParser = new MissionDataParser(datPath, game);
-                    mission.mobies = datParser.GetMobies(mission.models);
+                    mission.mobies = datParser.GetMobies(mission.models, mobyModels);
                 }
 
                 missions.Add(mission);

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using LibReplanetizer.Serializers;
+using System.Linq;
 
 namespace LibReplanetizer
 {
@@ -348,6 +349,7 @@ namespace LibReplanetizer
             }
 
             List<string> missionPaths = MissionHeader.FindMissionFiles(game, enginePath);
+            List<string> missionDataPaths = MissionHeader.FindMissionDataFiles(game, enginePath);
             missions = new List<Mission>();
 
             for (int i = 0; i < missionPaths.Count; i++)
@@ -374,6 +376,15 @@ namespace LibReplanetizer
                 using (VramParser parser = new VramParser(vramPath))
                 {
                     parser.GetTextures(mission.textures);
+                }
+
+                string? datPath = missionDataPaths.FirstOrDefault(p =>
+                    Path.GetFileNameWithoutExtension(p).Contains($"[{i}]"));
+
+                if (datPath != null)
+                {
+                    using var datParser = new MissionDataParser(datPath, game);
+                    mission.mobies = datParser.GetMobies(mission.models);
                 }
 
                 missions.Add(mission);

--- a/LibReplanetizer/Parsers/MissionParser.cs
+++ b/LibReplanetizer/Parsers/MissionParser.cs
@@ -76,7 +76,7 @@ namespace LibReplanetizer.Parsers
             this.fileStream = File.OpenRead(datFilePath);
         }
 
-        public List<Moby> GetMobies(List<Model> missionModels)
+        public List<Moby> GetMobies(List<Model> missionModels, List<Model> levelModels)
         {
             byte[] fileHeader = ReadBlock(fileStream, 0x00, 0x20);
             int mobyInstancesOffset = ReadInt(fileHeader, 0x04);
@@ -90,6 +90,11 @@ namespace LibReplanetizer.Parsers
             int mobyDataStart = mobyInstancesOffset + 0x10;
             byte[] mobyBlock = ReadBlock(fileStream, mobyDataStart, mobyCount * 0x70);
 
+            List<Model> allModels = new List<Model>(missionModels);
+            foreach (var m in levelModels)
+                if (!allModels.Exists(x => x.id == m.id))
+                    allModels.Add(m);
+
             var mobies = new List<Moby>();
             for (int i = 0; i < mobyCount; i++)
             {
@@ -100,8 +105,7 @@ namespace LibReplanetizer.Parsers
                 mobyBlock[offset + 0x51] = 0xFF;
                 mobyBlock[offset + 0x52] = 0xFF;
                 mobyBlock[offset + 0x53] = 0xFF;
-
-                Moby moby = new Moby(GameType.DL, mobyBlock, i, missionModels, new List<byte[]>());
+                Moby moby = new Moby(GameType.DL, mobyBlock, i, allModels, new List<byte[]>());
                 mobies.Add(moby);
             }
 

--- a/LibReplanetizer/Parsers/MissionParser.cs
+++ b/LibReplanetizer/Parsers/MissionParser.cs
@@ -64,4 +64,53 @@ namespace LibReplanetizer.Parsers
             fileStream.Close();
         }
     }
+
+    public class MissionDataParser : IDisposable
+    {
+        private FileStream fileStream;
+        private GameType game;
+
+        public MissionDataParser(string datFilePath, GameType game)
+        {
+            this.game = game;
+            this.fileStream = File.OpenRead(datFilePath);
+        }
+
+        public List<Moby> GetMobies(List<Model> missionModels)
+        {
+            byte[] fileHeader = ReadBlock(fileStream, 0x00, 0x20);
+            int mobyInstancesOffset = ReadInt(fileHeader, 0x04);
+
+            byte[] mobySecHeader = ReadBlock(fileStream, mobyInstancesOffset, 0x10);
+            int mobyCount = ReadInt(mobySecHeader, 0x00);
+
+            if (mobyCount <= 0 || mobyCount > 10000)
+                return new List<Moby>();
+
+            int mobyDataStart = mobyInstancesOffset + 0x10;
+            byte[] mobyBlock = ReadBlock(fileStream, mobyDataStart, mobyCount * 0x70);
+
+            var mobies = new List<Moby>();
+            for (int i = 0; i < mobyCount; i++)
+            {
+                int offset = i * 0x70;
+
+                // Null so the constructor doesnt try to index into an empty pvar list
+                mobyBlock[offset + 0x50] = 0xFF;
+                mobyBlock[offset + 0x51] = 0xFF;
+                mobyBlock[offset + 0x52] = 0xFF;
+                mobyBlock[offset + 0x53] = 0xFF;
+
+                Moby moby = new Moby(GameType.DL, mobyBlock, i, missionModels, new List<byte[]>());
+                mobies.Add(moby);
+            }
+
+            return mobies;
+        }
+
+        public void Dispose()
+        {
+            fileStream?.Close();
+        }
+    }
 }

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -36,6 +36,7 @@ namespace Replanetizer.Frames
         private FramebufferRenderer? renderer;
         public LevelRenderer? levelRenderer;
         private RendererPayload rendererPayload;
+        private HashSet<Mission> selectedMissions = new HashSet<Mission>();
         public Level level { get; set; }
         private bool enableCameraInfo = true;
         public ShaderTable shaderTable;
@@ -334,6 +335,24 @@ namespace Replanetizer.Frames
                     ImGui.EndMenu();
                 }
 
+                if (level.game == GameType.DL && level.missions.Count > 0 && ImGui.BeginMenu("Missions"))
+                {
+                    foreach (var mission in level.missions)
+                    {
+                        bool selected = selectedMissions.Contains(mission);
+                        if (ImGui.Checkbox($"Mission {mission.missionID}", ref selected))
+                        {
+                            if (selected)
+                                selectedMissions.Add(mission);
+                            else
+                                selectedMissions.Remove(mission);
+
+                            RefreshMissionMobies();
+                        }
+                    }
+                    ImGui.EndMenu();
+                }
+
                 ImGui.Separator();
 
                 if (interactiveSession)
@@ -601,7 +620,7 @@ namespace Replanetizer.Frames
                 camera.SetRotation(0, 0);
             }
             selectedObjects.Clear();
-
+            activeMobies = level.mobs.ToList();
             InvalidateView();
         }
 
@@ -1002,8 +1021,17 @@ namespace Replanetizer.Frames
                     return level.shrubs.Find(x => x.globalID == hitId);
                 case RenderedObjectType.Tie:
                     return level.ties.Find(x => x.globalID == hitId);
+
                 case RenderedObjectType.Moby:
-                    return level.mobs.Find(x => x.globalID == hitId);
+                    Moby? foundMoby = level.mobs.Find(x => x.globalID == hitId);
+                    if (foundMoby != null) return foundMoby;
+                    foreach (var mission in selectedMissions)
+                    {
+                        Moby? missionMoby = mission.mobies.Find(x => x.globalID == hitId);
+                        if (missionMoby != null) return missionMoby;
+                    }
+                    return null;
+
                 case RenderedObjectType.Spline:
                     // Both "Splines" and "GrindPaths" use Spline objects.
                     // Search for a hit in the Splines first then look
@@ -1092,6 +1120,36 @@ namespace Replanetizer.Frames
                     sw.WriteLine(item);
                 }
             }
+        }
+
+        private List<Moby> activeMobies = new List<Moby>();
+        private void RefreshMissionMobies()
+        {
+            if (levelRenderer == null) return;
+
+            foreach (var moby in activeMobies.ToList())
+                levelRenderer.Remove(moby, level);
+
+            var mobies = new List<Moby>(level.mobs);
+            foreach (var mission in selectedMissions)
+                mobies.AddRange(mission.mobies);
+
+            foreach (var moby in mobies)
+            {
+                Mission? sourceMission = selectedMissions.FirstOrDefault(m => m.mobies.Contains(moby));
+                if (sourceMission != null)
+                {
+                    bool isMissionModel = sourceMission.models.Exists(m => m.id == moby.modelID);
+                    levelRenderer.Include(moby, isMissionModel ? sourceMission.textures : level.textures);
+                }
+                else
+                {
+                    levelRenderer.Include(moby);
+                }
+            }
+
+            activeMobies = mobies;
+            InvalidateView();
         }
 
         protected void OnPaint()

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -695,6 +695,18 @@ namespace Replanetizer.Frames
 
         private void SelectModel(Model? model)
         {
+            if (model == null)
+                return;
+
+            foreach (var mission in level.missions)
+            {
+                if (mission.models.Contains(model))
+                {
+                    SelectModel(model, mission.textures);
+                    return;
+                }
+            }
+
             SelectModel(model, level.textures);
         }
 

--- a/Replanetizer/Renderer/LevelRenderer.cs
+++ b/Replanetizer/Renderer/LevelRenderer.cs
@@ -183,14 +183,14 @@ namespace Replanetizer.Renderer
             tieRenderers.Add(tieRenderer);
         }
 
-        private void Add(Moby mob)
+        private void Add(Moby mob, List<Texture>? textureOverride = null)
         {
             if (textures == null)
             {
                 throw new NullReferenceException();
             }
 
-            MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textures, textureIDs);
+            MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textureOverride ?? textures, textureIDs);
             mobRenderer.Include(mob);
             mobyRenderers.Add(mobRenderer);
         }
@@ -214,6 +214,10 @@ namespace Replanetizer.Renderer
             }
 
             throw new NotImplementedException();
+        }
+        public void Include(Moby mob, List<Texture>? textureOverride = null)
+        {
+            Add(mob, textureOverride);
         }
         public override void Include<T>(List<T> list) => throw new NotImplementedException();
 


### PR DESCRIPTION
<img width="1599" height="929" alt="image" src="https://github.com/user-attachments/assets/7043e94f-d0bc-4646-bd77-48933ecb6429" />
Adds support for deadlocked's mission data files so that moby instances from missions can be shown.