### PR TITLE
Deadlocked animation fixes

### DIFF
--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -130,6 +130,7 @@ namespace LibReplanetizer
             path = Path.GetDirectoryName(enginePath);
 
             mobyModels = new List<Model>();
+            MobyModel? ratchet = null;
 
             // Engine elements
             using (EngineParser engineParser = new EngineParser(enginePath))
@@ -183,7 +184,8 @@ namespace LibReplanetizer
                 LOGGER.Debug("Added {0} terrain elements", terrainEngine.fragments.Count);
 
                 LOGGER.Debug("Parsing player animations...");
-                playerAnimations = (mobyModels.Count > 0) ? engineParser.GetPlayerAnimations((MobyModel) mobyModels[0]) : new List<Animation>();
+                ratchet = engineParser.FindRatchetMoby(mobyModels);
+                playerAnimations = ratchet != null ? engineParser.GetPlayerAnimations(ratchet) : new List<Animation>();
                 LOGGER.Debug("Added {0} player animations", playerAnimations.Count);
 
                 uiElements = engineParser.GetUiElements();
@@ -293,7 +295,6 @@ namespace LibReplanetizer
                 LOGGER.Debug("Looking for armor data in {0}", armor);
                 List<Texture> tex;
                 MobyModel? model;
-                MobyModel? ratchet = (MobyModel?) mobyModels[0];
                 using (ArmorParser parser = new ArmorParser(game, armor))
                 {
                     tex = parser.GetTextures();

--- a/LibReplanetizer/Models/Animation/Skeleton.cs
+++ b/LibReplanetizer/Models/Animation/Skeleton.cs
@@ -47,27 +47,14 @@ namespace LibReplanetizer.Models.Animations
 
         public Matrix4 GetRelativeTransformation()
         {
-            // This does not work for Deadlocked yet. Rotation is already inverted in Deadlocked so we will need to invert again here to obtain
-            // the bind matrix as is needed here.
-            Matrix3x4 trans = bone.transformation;
-            Matrix3 rotation = new Matrix3(trans.Row0.Xyz, trans.Row1.Xyz, trans.Row2.Xyz);
+            Matrix4 relativeTransformation = bone.GetInvBindMatrix().Inverted();
 
-            // We need to represent our transformation relative to the parent node
             if (parent != null)
             {
-                Matrix3x4 matP = parent.bone.transformation;
-                Matrix3 matPTrans = new Matrix3(matP.Row0.Xyz, matP.Row1.Xyz, matP.Row2.Xyz);
-                matPTrans.Transpose();
-                rotation = matPTrans * rotation;
+                relativeTransformation = parent.bone.GetInvBindMatrix() * relativeTransformation;
             }
 
-            Matrix4 result = new Matrix4(rotation);
-            result.M14 = trans.M14 / 1024.0f;
-            result.M24 = trans.M24 / 1024.0f;
-            result.M34 = trans.M34 / 1024.0f;
-            result.M44 = 1.0f;
-
-            return result;
+            return relativeTransformation;
         }
     }
 }

--- a/LibReplanetizer/Parsers/EngineParser.cs
+++ b/LibReplanetizer/Parsers/EngineParser.cs
@@ -11,6 +11,7 @@ using LibReplanetizer.Models;
 using LibReplanetizer.Models.Animations;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using static LibReplanetizer.DataFunctions;
 
 namespace LibReplanetizer.Parsers
@@ -79,9 +80,18 @@ namespace LibReplanetizer.Parsers
             return GetUiElements(engineHead.uiElementPointer);
         }
 
+        public MobyModel? FindRatchetMoby(List<Model> models)
+        {
+            if (engineHead.game == GameType.DL)
+                return (MobyModel?) models.FirstOrDefault(x => x.id == 9207);
+
+            return (MobyModel?) models.FirstOrDefault();
+        }
+
         public List<Animation> GetPlayerAnimations(MobyModel ratchet)
         {
-            if (engineHead.game == GameType.DL) return new List<Animation>();
+            if (engineHead.game == GameType.DL)
+                return ratchet.animations;
 
             return GetPlayerAnimations(engineHead.game, engineHead.playerAnimationPointer, ratchet);
         }


### PR DESCRIPTION
- Finds ratchet animation moby `9207` when loading Deadlocked levels so that armor files can be exported with animations.
- Fixes the below when exporting rigged Deadlocked mobys (tested working on RC3 and RC4 ratchet).

Before fix:
<img width="598" height="629" alt="image" src="https://github.com/user-attachments/assets/65506f81-5904-48b6-9ed2-7be2a492808b" />

With fix:
<img width="550" height="440" alt="image" src="https://github.com/user-attachments/assets/d008ebaa-3125-4fcb-a3ed-9914f347911f" />
