### PR TITLE
Update dependencies and CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           path: /tmp/zips/replanetizer-${{steps.get-version.outputs.release_name}}-linux-x64.zip
 
   build_windows:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     needs: [build_linux]
     steps:
       - uses: actions/checkout@master
@@ -69,7 +69,7 @@ jobs:
             path: /tmp/zips/replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip
 
   build_macos:
-    runs-on: macos-15
+    runs-on: macos-26
     needs: [build_linux]
     steps:
       - uses: actions/checkout@master
@@ -109,46 +109,16 @@ jobs:
           path: ./
 
       - name: Create Release
-        id: create_release
         if: github.ref == 'refs/heads/master'
-        uses: actions/create-release@master
+        uses: softprops/action-gh-release@v2
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
             tag_name: ${{needs.build_linux.outputs.release_name}}
-            release_name: v${{needs.build_linux.outputs.release_name}}
+            name: v${{needs.build_linux.outputs.release_name}}
             draft: false
             prerelease: false
-
-      - name: Upload Release Asset Linux
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-            upload_url: ${{ steps.create_release.outputs.upload_url }}
-            asset_name: replanetizer-${{needs.build_linux.outputs.release_name}}-linux-x64.zip
-            asset_path: replanetizer-${{needs.build_linux.outputs.release_name}}-linux-x64.zip/replanetizer-${{needs.build_linux.outputs.release_name}}-linux-x64.zip
-            asset_content_type: application/zip
-
-      - name: Upload Release Asset Windows
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-            upload_url: ${{ steps.create_release.outputs.upload_url }}
-            asset_name: replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip
-            asset_path: replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip/replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip
-            asset_content_type: application/zip
-
-      - name: Upload Release Asset macOS
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-            upload_url: ${{ steps.create_release.outputs.upload_url }}
-            asset_name: replanetizer-${{needs.build_linux.outputs.release_name}}-osx-x64.zip
-            asset_path: replanetizer-${{needs.build_linux.outputs.release_name}}-osx-x64.zip/replanetizer-${{needs.build_linux.outputs.release_name}}-osx-x64.zip
-            asset_content_type: application/zip
+            files: |
+                replanetizer-${{needs.build_linux.outputs.release_name}}-linux-x64.zip/replanetizer-${{needs.build_linux.outputs.release_name}}-linux-x64.zip
+                replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip/replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip
+                replanetizer-${{needs.build_linux.outputs.release_name}}-osx-x64.zip/replanetizer-${{needs.build_linux.outputs.release_name}}-osx-x64.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       release_name: ${{ steps.get-version.outputs.release_name }}
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -32,7 +32,7 @@ jobs:
       - run: cd /tmp/out-linux/ && zip -r /tmp/zips/replanetizer-${{steps.get-version.outputs.release_name}}-linux-x64.zip replanetizer
         name: Zip up Replanetizer for Linux
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         name: Upload zips to GitHub actions artifact storage
         with:
           name: replanetizer-${{steps.get-version.outputs.release_name}}-linux-x64.zip
@@ -43,7 +43,7 @@ jobs:
     needs: [build_linux]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -62,7 +62,7 @@ jobs:
       - run: Compress-Archive -Path /tmp/out-win/replanetizer -DestinationPath /tmp/zips/replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip
         name: Zip up Replanetizer for Windows
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         name: Upload zips to GitHub actions artifact storage
         with:
             name: replanetizer-${{needs.build_linux.outputs.release_name}}-win-x64.zip
@@ -73,7 +73,7 @@ jobs:
     needs: [build_linux]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -92,7 +92,7 @@ jobs:
       - run: cd /tmp/out-osx/ && zip -r /tmp/zips/replanetizer-${{needs.build_linux.outputs.release_name}}-osx-x64.zip replanetizer
         name: Zip up Replanetizer for Mac
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         name: Upload zips to GitHub actions artifact storage
         with:
             name: replanetizer-${{needs.build_linux.outputs.release_name}}-osx-x64.zip
@@ -104,7 +104,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./
 

--- a/LibReplanetizer.Tests/LibReplanetizer.Tests.csproj
+++ b/LibReplanetizer.Tests/LibReplanetizer.Tests.csproj
@@ -7,13 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LibReplanetizer.Tests/Tests/Integration/FrameFixtureTests.cs
+++ b/LibReplanetizer.Tests/Tests/Integration/FrameFixtureTests.cs
@@ -67,7 +67,6 @@ namespace LibReplanetizer.Tests.Integration
             Skip.If(frame == null, "No animation frames found in this level.");
             // Bone 0 may or may not have a rotation, but should not throw.
             var mat = frame!.GetRotationMatrix(0);
-            Assert.NotNull(mat);
         }
     }
 }

--- a/LibReplanetizer.Tests/Tests/LevelObjects/GameplayObjectTests.cs
+++ b/LibReplanetizer.Tests/Tests/LevelObjects/GameplayObjectTests.cs
@@ -37,7 +37,7 @@ namespace LibReplanetizer.Tests.LevelObjects
             float[] w = { 0.25f, 0.75f };
             byte[] block = BuildSplineBlock(pts, w);
 
-            var spline = new Spline(block, 0);
+            var spline = new Spline(block, 0, 0);
 
             Assert.Equal(6, spline.vertexBuffer.Length);
             Assert.Equal(1f, spline.vertexBuffer[0]);
@@ -53,7 +53,7 @@ namespace LibReplanetizer.Tests.LevelObjects
             float[] w = { 0.1f, 0.9f };
             byte[] block = BuildSplineBlock(pts, w);
 
-            var spline = new Spline(block, 0);
+            var spline = new Spline(block, 0, 0);
 
             Assert.Equal(w[0], spline.wVals[0]);
             Assert.Equal(w[1], spline.wVals[1]);
@@ -66,7 +66,7 @@ namespace LibReplanetizer.Tests.LevelObjects
             float[] w = { 0f, 0.5f, 1f };
             byte[] original = BuildSplineBlock(pts, w);
 
-            var spline = new Spline(original, 0);
+            var spline = new Spline(original, 0, 0);
             byte[] serialized = spline.ToByteArray();
 
             Assert.Equal(original, serialized);
@@ -77,7 +77,7 @@ namespace LibReplanetizer.Tests.LevelObjects
         {
             float[][] pts = { new[] { 1f, 2f, 3f }, new[] { 7f, 8f, 9f } };
             float[] w = { 0f, 1f };
-            var spline = new Spline(BuildSplineBlock(pts, w), 0);
+            var spline = new Spline(BuildSplineBlock(pts, w), 0, 0);
 
             var v = spline.GetVertex(1);
 
@@ -89,7 +89,7 @@ namespace LibReplanetizer.Tests.LevelObjects
         {
             float[][] pts = { new[] { 0f, 0f, 0f } };
             float[] w = { 0f };
-            var spline = new Spline(BuildSplineBlock(pts, w), 0);
+            var spline = new Spline(BuildSplineBlock(pts, w), 0, 0);
 
             spline.SetVertex(0, new Vector3(5f, 6f, 7f));
 

--- a/LibReplanetizer.Tests/Tests/LevelObjects/MobyShrubTieTerrainTests.cs
+++ b/LibReplanetizer.Tests/Tests/LevelObjects/MobyShrubTieTerrainTests.cs
@@ -384,7 +384,7 @@ namespace LibReplanetizer.Tests.LevelObjects
         [Fact]
         public void DefaultConstructor_SetsGame_RaC1()
         {
-            var moby = new Moby();
+            var moby = new Moby(GameType.RaC1);
             // We can verify pVars is initialised (not null)
             Assert.NotNull(moby.pVars);
             Assert.Empty(moby.pVars);
@@ -393,7 +393,7 @@ namespace LibReplanetizer.Tests.LevelObjects
         [Fact]
         public void DefaultConstructor_SpawnTypeIsZero()
         {
-            var moby = new Moby();
+            var moby = new Moby(GameType.RaC1);
             Assert.False(moby.spawnBeforeMissionCompletion);
             Assert.False(moby.spawnAfterMissionCompletion);
             Assert.False(moby.isCrate);

--- a/LibReplanetizer.Tests/Tests/LevelObjects/MobyTests.cs
+++ b/LibReplanetizer.Tests/Tests/LevelObjects/MobyTests.cs
@@ -21,7 +21,7 @@ namespace LibReplanetizer.Tests.LevelObjects
             // Use the protected-setter via the public property.
             // Moby cannot be constructed without a byte block and model list, so
             // we rely on the object initialiser with default values.
-            var moby = new Moby();
+            var moby = new Moby(GameType.RaC1);
             moby.spawnType = spawnType;
             return moby;
         }

--- a/LibReplanetizer.Tests/Tests/LevelObjects/ShapeObjectTests.cs
+++ b/LibReplanetizer.Tests/Tests/LevelObjects/ShapeObjectTests.cs
@@ -37,7 +37,7 @@ namespace LibReplanetizer.Tests.LevelObjects
             WriteFloat(splineBlock, 0x14, 0f);
             WriteFloat(splineBlock, 0x18, 0f);
             WriteFloat(splineBlock, 0x1C, 0f);
-            return new Spline(splineBlock, 0);
+            return new Spline(splineBlock, 0, 0);
         }
 
         [Fact]

--- a/LibReplanetizer/LibReplanetizer.csproj
+++ b/LibReplanetizer/LibReplanetizer.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="ImGui.NET" Version="1.91.6.1" />
-    <PackageReference Include="NLog" Version="6.0.4" />
+    <PackageReference Include="NLog" Version="6.1.3" />
     <PackageReference Include="OpenTK.Mathematics" Version="4.9.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageReference Include="System.Resources.Extensions" Version="9.0.9" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -39,13 +39,13 @@
 
   <ItemGroup>
     <PackageReference Include="ImGui.NET" Version="1.91.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NLog" Version="6.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="NLog" Version="6.1.3" />
     <PackageReference Include="OpenTK" Version="4.9.4" />
     <PackageReference Include="OpenTK.Mathematics" Version="4.9.4" />
     <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.9.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageReference Include="System.Resources.Extensions" Version="9.0.9" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We had some deprecation warnings in the CI so I took care of that before our builds start to suddenly fail in a few months. I took the opportunity to also update our dependencies.

ImageSharp requires a license with the newer versions so I couldn't update to those yet. It should be quite easy for us to obtain a license though.