### PR TITLE
RaC1 spaceships

### DIFF
--- a/LibReplanetizer/Headers/SpaceshipHeader.cs
+++ b/LibReplanetizer/Headers/SpaceshipHeader.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (C) 2018-2026, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using System.Collections.Generic;
+using System.IO;
+using static LibReplanetizer.DataFunctions;
+
+namespace LibReplanetizer.Headers
+{
+    public class SpaceshipHeader
+    {
+        private static readonly short[][] SPACESHIP_MODEL_PAIRS = { [530, 534], [531, 535], [532, 536], [533, 537] };
+
+        public int shipModelPointer;
+        public short shipModelID;
+        public int cockpitModelPointer;
+        public short cockpitModelID;
+        public int texturePointer;
+        public int textureCount;
+
+        public SpaceshipHeader(FileStream fs, int spaceshipNum)
+        {
+            short[] modelIDs = SPACESHIP_MODEL_PAIRS[spaceshipNum];
+            shipModelID = modelIDs[0];
+            cockpitModelID = modelIDs[1];
+
+            byte[] pointerBlock = ReadBlock(fs, 0x00, 0x0C);
+            shipModelPointer = ReadInt(pointerBlock, 0x00);
+            cockpitModelPointer = ReadInt(pointerBlock, 0x04);
+            texturePointer = ReadInt(pointerBlock, 0x08);
+
+            textureCount = (int) (fs.Length - texturePointer) / Texture.TEXTUREELEMSIZE;
+        }
+
+        public static List<(int spaceshipNum, string path)> FindSpaceshipFiles(GameType game, string enginePath)
+        {
+            List<(int spaceshipNum, string path)> found = new List<(int, string)>();
+
+            if (game != GameType.RaC1)
+                return found;
+
+            string? folder = Path.GetDirectoryName(Path.GetDirectoryName(enginePath));
+
+            for (int i = 0; i < SPACESHIP_MODEL_PAIRS.Length; i++)
+            {
+                string path = Path.Join(folder, "global", $"spaceship{i}.ps3");
+                if (File.Exists(path))
+                {
+                    found.Add((i, path));
+                }
+            }
+
+            return found;
+        }
+    }
+}

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -34,9 +34,11 @@ namespace LibReplanetizer
         public List<Model> shrubModels;
         public List<Model> gadgetModels;
         public List<Model> armorModels;
+        public List<MobyModel> spaceshipModels;
         public Model collisionEngine;
         public List<Collision> collisionChunks;
         public List<Texture> textures;
+        public List<Texture> spaceshipTextures;
         public List<List<Texture>> armorTextures;
         public List<Texture> gadgetTextures;
         public SkyboxModel skybox;
@@ -166,6 +168,18 @@ namespace LibReplanetizer
                 LOGGER.Debug("Parsing textures...");
                 textures = engineParser.GetTextures();
                 LOGGER.Debug("Added {0} textures", textures.Count);
+
+                var spaceshipData = SpaceshipParser.GetAllSpaceshipData(game, enginePath, textures.Count);
+                spaceshipModels = spaceshipData.models;
+                spaceshipTextures = spaceshipData.textures;
+                LOGGER.Debug("Added {0} spaceship models", spaceshipModels.Count);
+
+                foreach (MobyModel model in spaceshipModels)
+                {
+                    mobyModels.RemoveAll(x => x.id == model.id);
+                }
+
+                mobyModels.AddRange(spaceshipModels);
 
                 LOGGER.Debug("Parsing ties...");
                 ties = engineParser.GetTies(tieModels);
@@ -403,6 +417,8 @@ namespace LibReplanetizer
             {
                 vramParser.GetTextures(textures);
             }
+
+            textures.AddRange(spaceshipTextures);
 
             LOGGER.Info("Level parsing done");
             valid = true;

--- a/LibReplanetizer/Parsers/SpaceshipParser.cs
+++ b/LibReplanetizer/Parsers/SpaceshipParser.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (C) 2018-2026, The Replanetizer Contributors.
+// Replanetizer is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// Please see the LICENSE.md file for more details.
+
+using LibReplanetizer.Headers;
+using LibReplanetizer.LevelObjects;
+using LibReplanetizer.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+namespace LibReplanetizer.Parsers
+{
+    public class SpaceshipParser : RatchetFileParser, IDisposable
+    {
+        private readonly SpaceshipHeader header;
+        private readonly GameType game;
+        public SpaceshipParser(GameType game, string spaceshipFile, int spaceshipNum) : base(spaceshipFile)
+        {
+            this.game = game;
+            header = new SpaceshipHeader(fileStream, spaceshipNum);
+        }
+
+        public MobyModel GetShipModel() => new MobyModel(fileStream, game, header.shipModelID, header.shipModelPointer);
+        public MobyModel GetCockpitModel() => new MobyModel(fileStream, game, header.cockpitModelID, header.cockpitModelPointer);
+        public List<Texture> GetTextures() => GetTextures(header.texturePointer, header.textureCount);
+
+        public static (List<MobyModel> models, List<Texture> textures) GetAllSpaceshipData(GameType game, string enginePath, int textureIdOffset)
+        {
+            List<MobyModel> models = new List<MobyModel>();
+            List<Texture> textures = new List<Texture>();
+
+            foreach (var (spaceshipNum, path) in SpaceshipHeader.FindSpaceshipFiles(game, enginePath))
+            {
+                using (SpaceshipParser parser = new SpaceshipParser(game, path, spaceshipNum))
+                {
+                    MobyModel shipModel = parser.GetShipModel();
+                    MobyModel cockpitModel = parser.GetCockpitModel();
+
+                    int fileTextureIdOffset = textureIdOffset + textures.Count;
+
+                    foreach (TextureConfig conf in shipModel.textureConfig)
+                        conf.id += fileTextureIdOffset;
+                    foreach (TextureConfig conf in cockpitModel.textureConfig)
+                        conf.id = 1 + fileTextureIdOffset;
+
+                    List<Texture> fileTextures = parser.GetTextures();
+                    string vramPath = Path.ChangeExtension(path, ".vram");
+
+                    using (VramParser vramParser = new VramParser(vramPath))
+                        vramParser.GetTextures(fileTextures);
+
+                    models.Add(shipModel);
+                    models.Add(cockpitModel);
+                    textures.AddRange(fileTextures);
+                }
+            }
+
+            return (models, textures);
+        }
+
+        public void Dispose()
+        {
+            fileStream.Close();
+        }
+    }
+}

--- a/Replanetizer/Frames/TextureFrame.cs
+++ b/Replanetizer/Frames/TextureFrame.cs
@@ -51,7 +51,7 @@ namespace Replanetizer.Frames
                 }
                 ImGui.EndChild();
 
-                if (ImGui.BeginPopupContextItem($"context-menu for {i}"))
+                if (ImGui.BeginPopupContextItem($"context-menu for {prefix}{i}"))
                 {
                     if (ImGui.Button("Export"))
                     {
@@ -101,6 +101,10 @@ namespace Replanetizer.Frames
             if (ImGui.CollapsingHeader("Level textures"))
             {
                 RenderTextureList(level.textures, itemSizeX, levelFrame.textureIds, "levelTextures");
+            }
+            if (ImGui.CollapsingHeader("Spaceship textures"))
+            {
+                RenderTextureList(level.spaceshipTextures, itemSizeX, levelFrame.textureIds, "spaceshipTextures");
             }
             if (ImGui.CollapsingHeader("Gadget textures"))
             {


### PR DESCRIPTION
<img width="1273" height="714" alt="image" src="https://github.com/user-attachments/assets/cc068478-5bf4-4860-8509-ed587a550c1d" />
This PR adds some support for rac1's spaceship files, makes them show up in the model viewer and they now spawn in when you use the memory hook.


As a side note, I noticed there is shipPosition and shipRotation documented in the level variables. Could probably be nice to have them loaded into the level when you open a level in Replanetizer, though I don't know how to deal with the memory hook if this is done? I don't think the ship mobys are instanced in the gameplay file, and are just hardcoded to be loaded into the game separately (same for the ship variation, that also seems hardcoded from what I could see in Ghidra)

Uuuuuuuuuuuuuh yeah! Sorry if the implementation is a bit shaky 