### PR TITLE
Metal shading and other rendering improvements

### DIFF
--- a/LibReplanetizer.SerializationDiffTool/Program.cs
+++ b/LibReplanetizer.SerializationDiffTool/Program.cs
@@ -22,6 +22,8 @@ namespace LibReplanetizer.SerializationDiffTool
 
         public static int Main(string[] args)
         {
+            ReplanetizerFileStream.EnableDebugFileStream();
+
             if (args.Length == 0 || args.Contains("--help") || args.Contains("-h"))
             {
                 PrintUsage();

--- a/LibReplanetizer.Tests/Tests/Integration/CollisionFixtureTests.cs
+++ b/LibReplanetizer.Tests/Tests/Integration/CollisionFixtureTests.cs
@@ -44,15 +44,6 @@ namespace LibReplanetizer.Tests.Integration
         }
 
         [SkippableFact]
-        public void Collision_ColorBuff_NonNull()
-        {
-            Skip.If(EngineFile == null, SkipMsg);
-            using var parser = new EngineParser(EngineFile!);
-            var collision = (Collision) parser.GetCollisionModel();
-            Assert.NotNull(collision.colorBuff);
-        }
-
-        [SkippableFact]
         public void Collision_VertexCount_ConsistentWithBuffer()
         {
             Skip.If(EngineFile == null, SkipMsg);

--- a/LibReplanetizer.Tests/Tests/Integration/TieModelFixtureTests.cs
+++ b/LibReplanetizer.Tests/Tests/Integration/TieModelFixtureTests.cs
@@ -45,15 +45,6 @@ namespace LibReplanetizer.Tests.Integration
         }
 
         [SkippableFact]
-        public void TieModel_SerializeHead_Has64Bytes()
-        {
-            Skip.If(EngineFile == null, SkipMsg);
-            using var parser = new EngineParser(EngineFile!);
-            foreach (var model in parser.GetTieModels().Cast<TieModel>())
-                Assert.Equal(0x40, model.SerializeHead(0).Length);
-        }
-
-        [SkippableFact]
         public void TieModel_IndexBuffer_NonEmpty()
         {
             Skip.If(EngineFile == null, SkipMsg);

--- a/LibReplanetizer/DebugFileStream.cs
+++ b/LibReplanetizer/DebugFileStream.cs
@@ -63,8 +63,7 @@ namespace LibReplanetizer
     /// so the log stays compact even for streaming reads/writes.
     /// </para>
     /// <para>
-    /// All tracking logic is compiled out in Release builds (<c>#if DEBUG</c>), so there is
-    /// zero overhead outside of debug sessions.
+    /// Tracking is enabled whenever a caller explicitly opts into this stream type.
     /// </para>
     /// </summary>
     public class DebugFileStream : FileStream
@@ -148,7 +147,7 @@ namespace LibReplanetizer
             : base(path, mode, access)
         {
             _stackDepth = ReadStackDepth();
-            _trackReads  = access == FileAccess.Read  || access == FileAccess.ReadWrite;
+            _trackReads = access == FileAccess.Read || access == FileAccess.ReadWrite;
             _trackWrites = access == FileAccess.Write || access == FileAccess.ReadWrite;
         }
 
@@ -160,11 +159,9 @@ namespace LibReplanetizer
         /// Records that <paramref name="length"/> bytes were accessed at
         /// <paramref name="offset"/> in the file with the given <paramref name="type"/>.
         /// Adjacent entries that share both type and stack trace are merged.
-        /// Compiled out entirely in Release builds.
         /// </summary>
         private void RecordAccess(long offset, int length, AccessType type)
         {
-#if DEBUG
             if (length <= 0)
                 return;
 
@@ -226,7 +223,7 @@ namespace LibReplanetizer
 
             log.Insert(insertAt, new AccessEntry(offset, end, type, traceString));
 
-            tryMergeSuccessor:
+        tryMergeSuccessor:
             // Try to merge the entry at insertAt with its successor.
             int succIdx = insertAt + 1;
             if (succIdx < log.Count)
@@ -239,7 +236,6 @@ namespace LibReplanetizer
                     log.RemoveAt(succIdx);
                 }
             }
-#endif
         }
 
         // ------------------------------------------------------------------ //
@@ -287,7 +283,6 @@ namespace LibReplanetizer
         /// Writes one access log (reads or writes) to <paramref name="path"/> in a
         /// human-readable format, interleaving "NOT ACCESSED" entries for any gap in the
         /// file larger than <see cref="GAP_THRESHOLD"/> bytes.
-        /// Only meaningful in DEBUG builds.
         /// </summary>
         public void WriteLogToFile(string path, AccessType type, long fileLength)
         {
@@ -333,7 +328,6 @@ namespace LibReplanetizer
 
         protected override void Dispose(bool disposing)
         {
-#if DEBUG
             if (disposing)
             {
                 string? logDir = Environment.GetEnvironmentVariable(LOG_DIR_ENV_VAR);
@@ -354,7 +348,6 @@ namespace LibReplanetizer
                     }
                 }
             }
-#endif
             base.Dispose(disposing);
         }
     }

--- a/LibReplanetizer/Level Objects/Engine/Shrub.cs
+++ b/LibReplanetizer/Level Objects/Engine/Shrub.cs
@@ -20,7 +20,7 @@ namespace LibReplanetizer.LevelObjects
     {
         public const int ELEMENTSIZE = 0x70;
 
-        [Category("Attributes"), DisplayName("Draw Distance"), Description("The distance at which an object will start fading out. After a distance of 8 more units, the object will stop being drawn.")]
+        [Category("Attributes"), DisplayName("Draw Distance"), Description("The distance at which an object will start fading out. After a distance of 8 or more units, the object will stop being drawn.")]
         public float drawDistance { get; set; }
         [Category("Unknowns"), DisplayName("OFF_58: Always 0")]
         public uint off58 { get; set; }

--- a/LibReplanetizer/Level Objects/Gameplay/Moby.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Moby.cs
@@ -139,7 +139,7 @@ namespace LibReplanetizer.LevelObjects
         [Category("Attributes"), DisplayName("Moby ID")]
         public int mobyID { get; set; }
 
-        [Category("Attributes"), DisplayName("Draw Distance"), Description("The distance at which an object will start fading out. After a distance of 8 more units, the object will stop being drawn.")]
+        [Category("Attributes"), DisplayName("Draw Distance"), Description("The distance at which an object will start fading out. After a distance of 32 or more units, the object will stop being drawn.")]
         public int drawDistance { get; set; }
 
         [Category("Attributes"), DisplayName("Update Distance")]

--- a/LibReplanetizer/Level Objects/Gameplay/Moby.cs
+++ b/LibReplanetizer/Level Objects/Gameplay/Moby.cs
@@ -731,6 +731,7 @@ namespace LibReplanetizer.LevelObjects
             public uint unk80 { get; set; }
             public int unk84 { get; set; }
             public int unk88 { get; set; }
+            public uint collCount { get; set; }
             public ushort oClass { get; set; }
             public ushort UID { get; set; }
             public Matrix3x4 transformation { get; set; }
@@ -741,12 +742,13 @@ namespace LibReplanetizer.LevelObjects
 
             public bool IsDead()
             {
-                return (state & 0x80) > 0 || oClass == 0xFFFF || UID == 0xFFFF;
+                // TODO: moby->collCnt <= worldUpdateTime is also a necessary condition for dead mobies!
+                return state > 0xFD;
             }
 
             public void SetDead()
             {
-                state |= 0x80;
+                state = 0xFE;
             }
 
             public void UpdateRC1(byte[] memory, int offset)
@@ -808,6 +810,7 @@ namespace LibReplanetizer.LevelObjects
                 unk84 = ReadInt(memory, offset + 0x84);
                 unk88 = ReadInt(memory, offset + 0x88);
 
+                collCount = ReadUint(memory, offset + 0xA0);
                 oClass = ReadUshort(memory, offset + 0xA6);
 
                 UID = ReadUshort(memory, offset + 0xB2);
@@ -857,6 +860,7 @@ namespace LibReplanetizer.LevelObjects
                 unk58 = ReadFloat(memory, offset + 0x48);
                 frameSpeed = ReadFloat(memory, offset + 0x4C);
 
+                collCount = ReadUint(memory, offset + 0xA0);
                 oClass = ReadUshort(memory, offset + 0xAA);
 
                 UID = ReadUshort(memory, offset + 0xB2);

--- a/LibReplanetizer/Models/Collision.cs
+++ b/LibReplanetizer/Models/Collision.cs
@@ -41,7 +41,6 @@ namespace LibReplanetizer.Models
         // Model
 
         public uint[] indBuff = { };
-        public uint[] colorBuff = { };
 
         // Standard Collision
 
@@ -282,6 +281,7 @@ namespace LibReplanetizer.Models
                     indices[t * 3 + 0] = dataBlock[tOff + 0x00];
                     indices[t * 3 + 1] = dataBlock[tOff + 0x01];
                     indices[t * 3 + 2] = dataBlock[tOff + 0x02];
+                    //type = dataBlock[tOff + 0x02]; ???
                 }
             }
 
@@ -348,6 +348,8 @@ namespace LibReplanetizer.Models
 
         public Collision(FileStream fs, int collisionPointer)
         {
+            vertexStride = 4;
+
             // RaC 1 title screen has no collision
             if (collisionPointer == 0)
                 return;
@@ -488,6 +490,11 @@ namespace LibReplanetizer.Models
             for (int i = 0; i < heroCells.Count; i++)
             {
                 heroCells[i].GetModelData(vertexList, indexList, ref totalVertexCount);
+            }
+
+            for (int i = 0; i < unkCells.Count; i++)
+            {
+                unkCells[i].GetModelData(vertexList, indexList, ref totalVertexCount);
             }
         }
 

--- a/LibReplanetizer/Models/MetalModel.cs
+++ b/LibReplanetizer/Models/MetalModel.cs
@@ -37,7 +37,7 @@ namespace LibReplanetizer.Models
             }
         }
 
-        [Category("Attributes"), DisplayName("Texture Configurations")]
+        [Category("Attributes"), DisplayName("Metal Texture Configurations")]
         public List<TextureConfig> metalTextureConfig { get; set; } = new List<TextureConfig>();
 
         protected int GetMetalFaceCount()

--- a/LibReplanetizer/Parsers/GameplayParser.cs
+++ b/LibReplanetizer/Parsers/GameplayParser.cs
@@ -25,7 +25,7 @@ namespace LibReplanetizer.Parsers
         public GameplayParser(GameType game, string gameplayFilepath)
         {
             this.game = game;
-            fileStream = new ReplanetizerFileStream(gameplayFilepath, FileMode.Open, FileAccess.Read);
+            fileStream = ReplanetizerFileStream.Open(gameplayFilepath, FileMode.Open, FileAccess.Read);
             gameplayHeader = new GameplayHeader(game, fileStream);
         }
 

--- a/LibReplanetizer/Parsers/RatchetFileParser.cs
+++ b/LibReplanetizer/Parsers/RatchetFileParser.cs
@@ -21,7 +21,7 @@ namespace LibReplanetizer.Parsers
 
         protected RatchetFileParser(string filePath)
         {
-            fileStream = new ReplanetizerFileStream(filePath, FileMode.Open, FileAccess.Read);
+            fileStream = ReplanetizerFileStream.Open(filePath, FileMode.Open, FileAccess.Read);
         }
 
         protected List<Model> GetMobyModels(GameType game, int mobyModelPointer)

--- a/LibReplanetizer/ReplanetizerFileStream.cs
+++ b/LibReplanetizer/ReplanetizerFileStream.cs
@@ -1,15 +1,29 @@
-// Copyright (C) 2018-2021, The Replanetizer Contributors.
+// Copyright (C) 2018-2026, The Replanetizer Contributors.
 // Replanetizer is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public
 // License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
 // Please see the LICENSE.md file for more details.
 
-// In DEBUG builds, ReplanetizerFileStream is DebugFileStream, which tracks
-// every read/write with its stack trace and byte range for debugging.
-// In Release builds it is a plain FileStream with zero overhead.
-#if DEBUG
-global using ReplanetizerFileStream = LibReplanetizer.DebugFileStream;
-#else
-global using ReplanetizerFileStream = System.IO.FileStream;
-#endif
+using System.IO;
+
+namespace LibReplanetizer
+{
+    public static class ReplanetizerFileStream
+    {
+        private static bool useDebugFileStream;
+
+        public static void EnableDebugFileStream()
+        {
+            useDebugFileStream = true;
+        }
+
+        public static FileStream Open(string path, FileMode mode, FileAccess access)
+        {
+            if (useDebugFileStream)
+                return new DebugFileStream(path, mode, access);
+
+            return new FileStream(path, mode, access);
+        }
+    }
+}

--- a/LibReplanetizer/Serializers/ChunkSerializer.cs
+++ b/LibReplanetizer/Serializers/ChunkSerializer.cs
@@ -21,7 +21,7 @@ namespace LibReplanetizer.Serializers
 
             directory = Path.Join(directory, "chunk" + chunk + ".ps3");
 
-            ReplanetizerFileStream fs = new ReplanetizerFileStream(directory, FileMode.Create, FileAccess.Write);
+            FileStream fs = ReplanetizerFileStream.Open(directory, FileMode.Create, FileAccess.Write);
 
             // Seek past the header
             fs.Seek(0x10, SeekOrigin.Begin);

--- a/LibReplanetizer/Serializers/EngineSerializer.cs
+++ b/LibReplanetizer/Serializers/EngineSerializer.cs
@@ -24,7 +24,7 @@ namespace LibReplanetizer.Serializers
         public void Save(Level level, string directory)
         {
             enginePath = Path.Join(directory, "engine.ps3");
-            ReplanetizerFileStream fs = new ReplanetizerFileStream(enginePath, FileMode.Create, FileAccess.Write);
+            FileStream fs = ReplanetizerFileStream.Open(enginePath, FileMode.Create, FileAccess.Write);
 
             switch (level.game.num)
             {
@@ -391,7 +391,7 @@ namespace LibReplanetizer.Serializers
                 vramBytes.AddRange(textures[i].data);
             }
 
-            ReplanetizerFileStream fs = new ReplanetizerFileStream(Path.Join(Path.GetDirectoryName(enginePath), "vram.ps3"), FileMode.Create, FileAccess.Write);
+            FileStream fs = ReplanetizerFileStream.Open(Path.Join(Path.GetDirectoryName(enginePath), "vram.ps3"), FileMode.Create, FileAccess.Write);
             fs.Write(vramBytes.ToArray(), 0, vramBytes.Count);
             fs.Close();
 

--- a/LibReplanetizer/Serializers/GameplaySerializer.cs
+++ b/LibReplanetizer/Serializers/GameplaySerializer.cs
@@ -23,7 +23,7 @@ namespace LibReplanetizer.Serializers
         public void Save(Level level, string directory)
         {
             directory = Path.Join(directory, "gameplay_ntsc");
-            ReplanetizerFileStream fs = new ReplanetizerFileStream(directory, FileMode.Create, FileAccess.Write);
+            FileStream fs = ReplanetizerFileStream.Open(directory, FileMode.Create, FileAccess.Write);
 
             switch (level.game.num)
             {

--- a/Replanetizer/Frames/AboutFrame.cs
+++ b/Replanetizer/Frames/AboutFrame.cs
@@ -40,7 +40,7 @@ https://material.io/tools/icons/?style=baseline,
 which is protected under the apache 2.0 license availible at
 https://www.apache.org/licenses/LICENSE-2.0.html
 
-", gitTreeStatus, wnd.openGLString);
+", gitTreeStatus, wnd.backendGraphicsString);
         }
 
         public override void Render(float deltaTime)

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -53,9 +53,8 @@ namespace Replanetizer.Frames
         private readonly string[] selectionPositioningOptions = { PivotPositioning.Mean.HUMAN_NAME, PivotPositioning.IndividualOrigins.HUMAN_NAME };
         private readonly string[] selectionSpaceOptions = { TransformSpace.Global.HUMAN_NAME, TransformSpace.Local.HUMAN_NAME };
 
-        private int antialiasing = 3;
-        private readonly string[] antialiasingOptions = { "Off", "2x MSAA", "4x MSAA", "8x MSAA", "16x MSAA", "32x MSAA", "64x MSAA", "128x MSAA", "256x MSAA", "512x MSAA" };
-        private int maxAntialiasing = 4;
+        private int antialiasing = 1;
+        private readonly string[] antialiasingOptions = { "Off", "2x SSAA", "4x SSAA", "8x SSAA" };
 
         private Vector2 mousePos;
         private Vector3 prevMouseRay;
@@ -99,8 +98,6 @@ namespace Replanetizer.Frames
             string? applicationFolder = System.AppContext.BaseDirectory;
             string shaderFolder = Path.Join(applicationFolder, "Shaders");
             shaderTable = new ShaderTable(shaderFolder);
-
-            maxAntialiasing = (int) Math.Log2((double) GL.GetInteger(GetPName.MaxSamples));
 
             KEYMAP = new Keymap(wnd, Keymap.DEFAULT_KEYMAP);
 
@@ -301,7 +298,7 @@ namespace Replanetizer.Frames
                         InvalidateView();
                     }
                     ImGui.PushItemWidth(90.0f);
-                    if (ImGui.Combo("Antialiasing", ref antialiasing, antialiasingOptions, 1 + maxAntialiasing))
+                    if (ImGui.Combo("Antialiasing", ref antialiasing, antialiasingOptions, antialiasingOptions.Length))
                     {
                         UpdateAaLevel();
                         InvalidateView();
@@ -534,9 +531,9 @@ namespace Replanetizer.Frames
                 {
                     //Setup openGL variables
                     GL.Enable(EnableCap.DepthTest);
-                    GL.Viewport(0, 0, width, height);
+                    GL.Viewport(0, 0, renderer.RenderWidth, renderer.RenderHeight);
                     GL.Enable(EnableCap.ScissorTest);
-                    GL.Scissor(0, 0, width, height);
+                    GL.Scissor(0, 0, renderer.RenderWidth, renderer.RenderHeight);
 
                     OnPaint();
                 });
@@ -982,12 +979,7 @@ namespace Replanetizer.Frames
 
         private void UpdateAaLevel()
         {
-            if (antialiasing == 0)
-                GL.Disable(EnableCap.Multisample);
-            else
-                GL.Enable(EnableCap.Multisample);
-
-            FramebufferRenderer.MSAA_LEVEL = 1 << antialiasing;
+            FramebufferRenderer.SSAA_LEVEL_LOG = antialiasing;
         }
 
         protected void OnResize()
@@ -996,8 +988,8 @@ namespace Replanetizer.Frames
             GL.Viewport(0, 0, width, height);
 
             renderer?.Dispose();
-            renderer = new FramebufferRenderer(width, height);
             UpdateAaLevel();
+            renderer = new FramebufferRenderer(width, height, shaderTable.resolveShader);
         }
 
         public LevelObject? GetObjectAtScreenPosition(Vector2 pos)

--- a/Replanetizer/Frames/LevelFrame.cs
+++ b/Replanetizer/Frames/LevelFrame.cs
@@ -289,6 +289,7 @@ namespace Replanetizer.Frames
                     if (ImGui.Checkbox("Transparency", ref rendererPayload.visibility.enableTransparency)) InvalidateView();
                     if (ImGui.Checkbox("Distance Culling", ref rendererPayload.visibility.enableDistanceCulling)) InvalidateView();
                     if (ImGui.Checkbox("Frustum Culling", ref rendererPayload.visibility.enableFrustumCulling)) InvalidateView();
+                    if (interactiveSession && ImGui.Checkbox("Visible Culling", ref rendererPayload.visibility.enableVisibleCulling)) InvalidateView();
                     if (ImGui.Checkbox("Fog", ref rendererPayload.visibility.enableFog)) InvalidateView();
                     if (ImGui.Checkbox("Lighting", ref rendererPayload.visibility.enableLighting)) InvalidateView();
                     if (ImGui.Checkbox("Meshless Models", ref rendererPayload.visibility.enableMeshlessModels)) InvalidateView();

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -380,7 +380,7 @@ namespace Replanetizer.Frames
                     //Setup openGL variables
                     GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
                     GL.Enable(EnableCap.DepthTest);
-                    GL.Viewport(0, 0, width, height);
+                    GL.Viewport(0, 0, renderer.RenderWidth, renderer.RenderHeight);
 
                     OnPaint();
                 });
@@ -903,7 +903,7 @@ namespace Replanetizer.Frames
             camera.aspect = ((float) width) / height;
 
             renderer?.Dispose();
-            renderer = new FramebufferRenderer(width, height);
+            renderer = new FramebufferRenderer(width, height, shaderTable.resolveShader);
         }
 
         private void ExportSelectedModel()

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -101,6 +101,7 @@ namespace Replanetizer.Frames
         private PropertyFrame propertyFrame;
         private bool firstFrame = true;
         private Vector2 startSize;
+        private readonly ModelGPUDataCache gpuDataCache = new ModelGPUDataCache();
 
         public ModelFrame(Window wnd, LevelFrame levelFrame, ShaderTable shaderIDTable, Model? model = null) : base(wnd, levelFrame)
         {
@@ -114,7 +115,7 @@ namespace Replanetizer.Frames
             UpdateZoom(0.0f);
             UpdateCamera();
 
-            meshRenderer = new MeshRenderer(shaderIDTable, levelFrame.level.textures, levelFrame.textureIds, levelFrame.level.playerAnimations);
+            meshRenderer = new MeshRenderer(shaderIDTable, levelFrame.level.textures, levelFrame.textureIds, levelFrame.level.playerAnimations, gpuDataCache);
             rendererPayload = new RendererPayload(camera);
 
             sortedMobyModels = new List<Model>(level.mobyModels);
@@ -971,6 +972,7 @@ namespace Replanetizer.Frames
             base.Dispose();
             renderer?.Dispose();
             meshRenderer?.Dispose();
+            gpuDataCache.Dispose();
         }
     }
 }

--- a/Replanetizer/Frames/ModelFrame.cs
+++ b/Replanetizer/Frames/ModelFrame.cs
@@ -115,7 +115,8 @@ namespace Replanetizer.Frames
             UpdateZoom(0.0f);
             UpdateCamera();
 
-            meshRenderer = new MeshRenderer(shaderIDTable, levelFrame.level.textures, levelFrame.textureIds, levelFrame.level.playerAnimations, gpuDataCache);
+            meshRenderer = new MeshRenderer(shaderIDTable, levelFrame.level.textures, levelFrame.textureIds,
+                levelFrame.textureIds[levelFrame.level.textures[0]], levelFrame.level.playerAnimations, gpuDataCache);
             rendererPayload = new RendererPayload(camera);
 
             sortedMobyModels = new List<Model>(level.mobyModels);

--- a/Replanetizer/Frames/PropertyFrame.cs
+++ b/Replanetizer/Frames/PropertyFrame.cs
@@ -107,13 +107,12 @@ namespace Replanetizer.Frames
                 string category =
                     prop.GetCustomAttribute<CategoryAttribute>()?.Category ?? "Unknowns";
 
-                string displayName =
-                    prop.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? prop.Name;
-
                 if (!properties.ContainsKey(category))
                     properties[category] = new Dictionary<string, PropertyInfo>();
 
-                properties[category][displayName] = prop;
+                // Keep the reflected property name as the identity. Display names are
+                // user-facing and are not guaranteed to be unique.
+                properties[category][prop.Name] = prop;
             }
         }
 
@@ -154,7 +153,9 @@ namespace Replanetizer.Frames
 
             foreach (var (categoryName, categoryItems) in properties)
             {
+                ImGui.PushID(categoryName);
                 RenderCategory(categoryName, categoryItems);
+                ImGui.PopID();
             }
 
             ImGui.PopID();
@@ -171,8 +172,14 @@ namespace Replanetizer.Frames
             }
         }
 
-        private void RenderCategoryItem(string propertyName, PropertyInfo propertyInfo)
+        private void RenderCategoryItem(string propertyIdentifier, PropertyInfo propertyInfo)
         {
+            // Every property gets its own scope. This is important for nested
+            // PropertyFrames and for properties with identical display names.
+            ImGui.PushID(propertyIdentifier);
+
+            string propertyName =
+                propertyInfo.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? propertyInfo.Name;
             object? val = propertyInfo.GetValue(selectedObject);
             Type? type = propertyInfo.GetSetMethod() == null ? null : propertyInfo.PropertyType;
             string? description = propertyInfo.GetCustomAttribute<DescriptionAttribute>()?.Description ?? null;
@@ -492,7 +499,7 @@ namespace Replanetizer.Frames
                                          */
                                         if ((col % 2) == 0 && ((index + 1) < array.Length))
                                         {
-                                            ushort u16val = (ushort)((element << 8) | Convert.ToByte(array.GetValue(index + 1)!));
+                                            ushort u16val = (ushort) ((element << 8) | Convert.ToByte(array.GetValue(index + 1)!));
                                             tooltipText += $"\nDecimal (16 bits): {u16val}";
                                             tooltipText += $"\nHexadecimal (16 bits): 0x" + u16val.ToString("X4");
                                         }
@@ -504,7 +511,7 @@ namespace Replanetizer.Frames
                                             byte n2 = Convert.ToByte(array.GetValue(index + 2)!);
                                             byte n3 = Convert.ToByte(array.GetValue(index + 3)!);
 
-                                            uint u32val = (uint)((element << 24) | (n1 << 16) | (n2 << 8) | n3);
+                                            uint u32val = (uint) ((element << 24) | (n1 << 16) | (n2 << 8) | n3);
                                             tooltipText += $"\nDecimal (32 bits): {u32val}";
                                             tooltipText += $"\nHexadecimal (32 bits): 0x" + u32val.ToString("X8");
 
@@ -673,6 +680,8 @@ namespace Replanetizer.Frames
                     ImGui.EndTooltip();
                 }
             }
+
+            ImGui.PopID();
         }
     }
 }

--- a/Replanetizer/Renderer/AnimationRenderer.cs
+++ b/Replanetizer/Renderer/AnimationRenderer.cs
@@ -35,17 +35,6 @@ namespace Replanetizer.Renderer
 
         private bool emptyModel = false;
 
-        private int ibo = 0;
-        private int vbo = 0;
-        private int vao = 0;
-
-        private List<int> subModelIBOs = new List<int>();
-        private List<int> subModelVBOs = new List<int>();
-        private List<int> subModelVAOs = new List<int>();
-
-        private bool iboAllocated = false;
-        private bool vboAllocated = false;
-        private bool vaoAllocated = false;
 
         private int light { get; set; }
         private Rgb24 ambient { get; set; }
@@ -67,13 +56,16 @@ namespace Replanetizer.Renderer
         private Frame? currentFrame = null;
         private Frame? previousFrame = null;
         private float frameBlend = 0.0f;
+        private readonly ModelGPUDataCache gpuDataCache;
+        private ModelGPUData? gpuData;
 
-        public AnimationRenderer(ShaderTable shaderTable, List<Texture> textures, Dictionary<Texture, GLTexture> textureIds, List<Animation>? ratchetAnimations = null)
+        public AnimationRenderer(ShaderTable shaderTable, List<Texture> textures, Dictionary<Texture, GLTexture> textureIds, List<Animation>? ratchetAnimations = null, ModelGPUDataCache? gpuDataCache = null)
         {
             this.shaderTable = shaderTable;
             this.textureIds = textureIds;
             this.textures = textures;
             this.ratchetAnimations = ratchetAnimations;
+            this.gpuDataCache = gpuDataCache ?? new ModelGPUDataCache();
         }
 
         public void ChangeTextures(List<Texture> textures, Dictionary<Texture, GLTexture>? textureIds = null)
@@ -110,80 +102,17 @@ namespace Replanetizer.Renderer
 
         public override void Include<T>(List<T> list) => throw new NotImplementedException();
 
-        /// <summary>
-        /// Deletes IBO and VBO if they are allocated.
-        /// </summary>
         private void DeleteBuffers()
         {
-            if (iboAllocated)
-            {
-                GL.DeleteBuffer(ibo);
-                ibo = 0;
-                iboAllocated = false;
-            }
-
-            if (vboAllocated)
-            {
-                GL.DeleteBuffer(vbo);
-                vbo = 0;
-                vboAllocated = false;
-            }
-
-            if (vaoAllocated)
-            {
-                GL.DeleteVertexArray(vao);
-                vao = 0;
-                vaoAllocated = false;
-            }
-
+            gpuDataCache.Release(gpuData);
+            gpuData = null;
             loadedModelID = -1;
-
-            foreach (int subModelIBO in subModelIBOs)
-            {
-                if (subModelIBO != -1)
-                {
-                    GL.DeleteBuffer(subModelIBO);
-                }
-            }
-
-            foreach (int subModelVBO in subModelVBOs)
-            {
-                if (subModelVBO != -1)
-                {
-                    GL.DeleteBuffer(subModelVBO);
-                }
-            }
-
-            foreach (int subModelVAO in subModelVAOs)
-            {
-                if (subModelVAO != -1)
-                {
-                    GL.DeleteVertexArray(subModelVAO);
-                }
-            }
-
-            subModelVAOs.Clear();
-            subModelIBOs.Clear();
-            subModelVBOs.Clear();
         }
 
         public bool IsValid()
         {
             UpdateVars();
             return (emptyModel) ? false : true;
-        }
-
-        /// <summary>
-        /// Sets up the vertex attribute pointers according to the type.
-        /// </summary>
-        private void SetupVertexAttribPointers()
-        {
-            GLUtil.ActivateNumberOfVertexAttribArrays(5);
-            GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 40, 0);
-            GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, 40, 12);
-            GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, 40, 24);
-            GL.VertexAttribPointer(3, 4, VertexAttribPointerType.UnsignedByte, false, 40, 32);
-            GL.VertexAttribPointer(4, 4, VertexAttribPointerType.UnsignedByte, true, 40, 36);
         }
 
         /// <summary>
@@ -240,113 +169,7 @@ namespace Replanetizer.Renderer
 
             emptyModel = false;
 
-            GL.GenVertexArrays(1, out vao);
-            GL.BindVertexArray(vao);
-
-            // IBO
-            int iboLength = mobyModel.GetIndices().Length * sizeof(ushort);
-            if (iboLength > 0)
-            {
-                GL.GenBuffers(1, out ibo);
-                GL.BindBuffer(BufferTarget.ElementArrayBuffer, ibo);
-                GL.BufferData(BufferTarget.ElementArrayBuffer, iboLength, IntPtr.Zero, BufferUsageHint.StaticDraw);
-                iboAllocated = true;
-            }
-
-            // VBO
-            int vboLength = mobyModel.GetVertices().Length * sizeof(float);
-            vboLength += mobyModel.vertexBoneIds.Length * sizeof(uint);
-            vboLength += mobyModel.vertexBoneWeights.Length * sizeof(uint);
-            if (vboLength > 0)
-            {
-                GL.GenBuffers(1, out vbo);
-                GL.BindBuffer(BufferTarget.ArrayBuffer, vbo);
-                GL.BufferData(BufferTarget.ArrayBuffer, vboLength, IntPtr.Zero, BufferUsageHint.StaticDraw);
-                vboAllocated = true;
-            }
-
-            UpdateBuffers(mobyModel, vao);
-
-            // Initialize all submodels aswell, we can then dynamically decide to draw them or not during rendering.
-            int subModelCount = mobyModel.GetSubModelCount();
-            for (int i = 0; i < subModelCount; i++)
-            {
-                Model? subModel = mobyModel.GetSubModel(i);
-
-                if (subModel == null)
-                {
-                    subModelVAOs.Add(-1);
-                    subModelIBOs.Add(-1);
-                    subModelVBOs.Add(-1);
-                    continue;
-                }
-
-                int subModelVao;
-                GL.GenVertexArrays(1, out subModelVao);
-                GL.BindVertexArray(subModelVao);
-
-                // IBO
-                int subModelIboLength = subModel.GetIndices().Length * sizeof(ushort);
-                int subModelIbo = -1;
-                if (subModelIboLength > 0)
-                {
-                    GL.GenBuffers(1, out subModelIbo);
-                    GL.BindBuffer(BufferTarget.ElementArrayBuffer, subModelIbo);
-                    GL.BufferData(BufferTarget.ElementArrayBuffer, subModelIboLength, IntPtr.Zero, BufferUsageHint.StaticDraw);
-                }
-
-                // VBO
-                int subModelVboLength = subModel.GetVertices().Length * sizeof(float);
-                subModelVboLength += subModel.vertexBoneIds.Length * sizeof(uint);
-                subModelVboLength += subModel.vertexBoneWeights.Length * sizeof(uint);
-                int subModelVbo = -1;
-                if (subModelVboLength > 0)
-                {
-                    GL.GenBuffers(1, out subModelVbo);
-                    GL.BindBuffer(BufferTarget.ArrayBuffer, subModelVbo);
-                    GL.BufferData(BufferTarget.ArrayBuffer, subModelVboLength, IntPtr.Zero, BufferUsageHint.StaticDraw);
-                }
-
-                subModelVAOs.Add(subModelVao);
-                subModelIBOs.Add(subModelIbo);
-                subModelVBOs.Add(subModelVbo);
-
-                UpdateBuffers(subModel, subModelVao);
-            }
-        }
-
-        /// <summary>
-        /// Updates the buffers. This is not actually needed as long as mesh manipulations are not possible.
-        /// </summary>
-        private void UpdateBuffers(Model model, int modelVAO)
-        {
-            GL.BindVertexArray(modelVAO);
-
-            ushort[] iboData = model.GetIndices();
-            GL.BufferSubData(BufferTarget.ElementArrayBuffer, IntPtr.Zero, iboData.Length * sizeof(ushort), iboData);
-
-            float[] vboData = model.GetVertices();
-            uint[] boneIDs = model.vertexBoneIds;
-            uint[] boneWeights = model.vertexBoneWeights;
-
-            float[] fullData = new float[vboData.Length + boneIDs.Length + boneWeights.Length];
-
-            for (int i = 0; i < vboData.Length / 8; i++)
-            {
-                fullData[10 * i + 0] = vboData[8 * i + 0];
-                fullData[10 * i + 1] = vboData[8 * i + 1];
-                fullData[10 * i + 2] = vboData[8 * i + 2];
-                fullData[10 * i + 3] = vboData[8 * i + 3];
-                fullData[10 * i + 4] = vboData[8 * i + 4];
-                fullData[10 * i + 5] = vboData[8 * i + 5];
-                fullData[10 * i + 6] = vboData[8 * i + 6];
-                fullData[10 * i + 7] = vboData[8 * i + 7];
-                fullData[10 * i + 8] = BitConverter.UInt32BitsToSingle(boneIDs[i]);
-                fullData[10 * i + 9] = BitConverter.UInt32BitsToSingle(boneWeights[i]);
-            }
-            GL.BufferSubData(BufferTarget.ArrayBuffer, IntPtr.Zero, fullData.Length * sizeof(float), fullData);
-
-            SetupVertexAttribPointers();
+            gpuData = gpuDataCache.Acquire(mobyModel, ModelGPULayout.Animated);
         }
 
         /// <summary>
@@ -509,14 +332,11 @@ namespace Replanetizer.Renderer
 
         public override void Render(RendererPayload payload)
         {
-            if (((mob == null || mob.model == null || mob.memory == null) && mobyModelStandalone == null)) return;
+            if ((mob == null || mob.model == null || mob.memory == null) && mobyModelStandalone == null) return;
 
             UpdateVars();
 
-            if (emptyModel)
-            {
-                return;
-            }
+            if (emptyModel || gpuData == null) return;
 
             if (ComputeCulling(payload.camera, payload.visibility.enableDistanceCulling)) return;
 
@@ -664,7 +484,7 @@ namespace Replanetizer.Renderer
 
             shaderTable.animationShader.SetUniformMatrix4(UniformName.bones, mobyModel.boneCount, ref boneMatrices[0].Row0.X);
 
-            RenderModel(mobyModel, vao);
+            RenderModel(mobyModel, gpuData.vao);
 
             int subModelCount = mobyModel.GetSubModelCount();
             for (int i = 0; i < subModelCount; i++)
@@ -672,10 +492,11 @@ namespace Replanetizer.Renderer
                 if ((payload.visibility.subModelsMask & (1u << i)) == 0) continue;
 
                 Model? subModel = mobyModel.GetSubModel(i);
+                ModelGPUData? modelGPUData = gpuData.subModels[i];
 
-                if (subModel == null) continue;
+                if (subModel == null || modelGPUData == null) continue;
 
-                RenderModel(subModel, subModelVAOs[i]);
+                RenderModel(subModel, modelGPUData.vao);
             }
 
             GLUtil.CheckGlError("AnimationRenderer");

--- a/Replanetizer/Renderer/AnimationRenderer.cs
+++ b/Replanetizer/Renderer/AnimationRenderer.cs
@@ -288,11 +288,17 @@ namespace Replanetizer.Renderer
         /// Mobies and shrubs are culled by their drawDistance.
         /// Ties, terrain and shrubs are culled by frustum culling.
         /// </summary>
-        private bool ComputeCulling(Camera camera, bool distanceCulling)
+        private bool ComputeCulling(Camera camera, bool distanceCulling, bool visibleCulling)
         {
             if (emptyModel) return true;
             if (mobyModelStandalone != null) return false;
             if (mob == null) return true;
+
+            if (visibleCulling && mob.memory != null)
+            {
+                if (mob.memory.visible == 0)
+                    return true;
+            }
 
             if (distanceCulling)
             {
@@ -345,7 +351,7 @@ namespace Replanetizer.Renderer
 
             if (emptyModel || gpuData == null) return;
 
-            if (ComputeCulling(payload.camera, payload.visibility.enableDistanceCulling)) return;
+            if (ComputeCulling(payload.camera, payload.visibility.enableDistanceCulling, payload.visibility.enableVisibleCulling)) return;
 
             MobyModel? mobyModel = (MobyModel?) mob?.model ?? mobyModelStandalone;
 

--- a/Replanetizer/Renderer/AnimationRenderer.cs
+++ b/Replanetizer/Renderer/AnimationRenderer.cs
@@ -32,8 +32,10 @@ namespace Replanetizer.Renderer
         private MobyModel? mobyModelStandalone;
 
         private int loadedModelID = -1;
+        private MobyModel? loadedModel;
+        private bool loadedModelHasMeshData = false;
 
-        private bool emptyModel = false;
+        private bool emptyModel = true;
 
 
         private int light { get; set; }
@@ -107,6 +109,14 @@ namespace Replanetizer.Renderer
             gpuDataCache.Release(gpuData);
             gpuData = null;
             loadedModelID = -1;
+            loadedModel = null;
+            loadedModelHasMeshData = false;
+            emptyModel = true;
+        }
+
+        private static bool HasAnimationMeshData(MobyModel? model)
+        {
+            return model != null && model.GetIndices().Length > 0 && model.boneCount > 0;
         }
 
         public bool IsValid()
@@ -141,27 +151,22 @@ namespace Replanetizer.Renderer
 
             if (mobyModel == null)
             {
-                emptyModel = true;
                 return;
             }
 
-            if (mobyModel.GetIndices().Length == 0)
-            {
-                emptyModel = true;
-                return;
-            }
+            loadedModel = mobyModel;
+            loadedModelHasMeshData = HasAnimationMeshData(mobyModel);
 
-            if (mobyModel.boneCount == 0)
-            {
-                emptyModel = true;
+            if (!loadedModelHasMeshData)
                 return;
-            }
 
             // This is a camera object that only exist at runtime and blocks vision in interactive mode.
             // We simply don't draw it.
             if (loadedModelID == 0x3EF)
             {
                 loadedModelID = -1;
+                loadedModel = null;
+                loadedModelHasMeshData = false;
                 emptyModel = true;
                 mob = null;
                 return;
@@ -194,13 +199,15 @@ namespace Replanetizer.Renderer
                 modelID = mobyModelStandalone.id;
             }
 
-            if (modelID != -1)
+            MobyModel? currentModel = (MobyModel?) mob?.model ?? mobyModelStandalone;
+            bool currentModelHasMeshData = HasAnimationMeshData(currentModel);
+
+            if (loadedModelID != modelID
+                || loadedModel != currentModel
+                || loadedModelHasMeshData != currentModelHasMeshData)
             {
-                if (loadedModelID != modelID)
-                {
-                    previousFrame = null;
-                    GenerateBuffers();
-                }
+                previousFrame = null;
+                GenerateBuffers();
             }
         }
 

--- a/Replanetizer/Renderer/AnimationRenderer.cs
+++ b/Replanetizer/Renderer/AnimationRenderer.cs
@@ -352,6 +352,8 @@ namespace Replanetizer.Renderer
             Matrix4 worldToView = payload.camera.GetWorldViewMatrix();
             shaderTable.animationShader.SetUniformMatrix4(UniformName.modelToWorld, ref modelToWorld);
             shaderTable.animationShader.SetUniformMatrix4(UniformName.worldToView, ref worldToView);
+            shaderTable.animationShader.SetUniform3(UniformName.cameraPosition, payload.camera.position);
+            shaderTable.animationShader.SetUniform1(UniformName.useMetalShading, 0);
             shaderTable.animationShader.SetUniform1(UniformName.mainTexture, 0);
             shaderTable.animationShader.SetUniform1(UniformName.blueNoiseTexture, 1);
             shaderTable.animationShader.SetUniform1(UniformName.levelObjectNumber, (mob != null) ? mob.globalID : 0);

--- a/Replanetizer/Renderer/AnimationRenderer.cs
+++ b/Replanetizer/Renderer/AnimationRenderer.cs
@@ -350,9 +350,10 @@ namespace Replanetizer.Renderer
 
             Matrix4 modelToWorld = (mob != null) ? mob.modelMatrix : Matrix4.Identity;
             Matrix4 worldToView = payload.camera.GetWorldViewMatrix();
+            Matrix4 viewMatrix = payload.camera.GetViewMatrix();
             shaderTable.animationShader.SetUniformMatrix4(UniformName.modelToWorld, ref modelToWorld);
             shaderTable.animationShader.SetUniformMatrix4(UniformName.worldToView, ref worldToView);
-            shaderTable.animationShader.SetUniform3(UniformName.cameraPosition, payload.camera.position);
+            shaderTable.animationShader.SetUniformMatrix4(UniformName.viewMatrix, ref viewMatrix);
             shaderTable.animationShader.SetUniform1(UniformName.useMetalShading, 0);
             shaderTable.animationShader.SetUniform1(UniformName.mainTexture, 0);
             shaderTable.animationShader.SetUniform1(UniformName.blueNoiseTexture, 1);

--- a/Replanetizer/Renderer/AnimationRenderer.cs
+++ b/Replanetizer/Renderer/AnimationRenderer.cs
@@ -48,6 +48,7 @@ namespace Replanetizer.Renderer
 
         private List<Texture> textures;
         private Dictionary<Texture, GLTexture> textureIds;
+        private readonly GLTexture metalTexture;
         private ShaderTable shaderTable;
 
         // The Ratchet moby does not contain its own animations.
@@ -61,11 +62,12 @@ namespace Replanetizer.Renderer
         private readonly ModelGPUDataCache gpuDataCache;
         private ModelGPUData? gpuData;
 
-        public AnimationRenderer(ShaderTable shaderTable, List<Texture> textures, Dictionary<Texture, GLTexture> textureIds, List<Animation>? ratchetAnimations = null, ModelGPUDataCache? gpuDataCache = null)
+        public AnimationRenderer(ShaderTable shaderTable, List<Texture> textures, Dictionary<Texture, GLTexture> textureIds, GLTexture metalTexture, List<Animation>? ratchetAnimations = null, ModelGPUDataCache? gpuDataCache = null)
         {
             this.shaderTable = shaderTable;
             this.textureIds = textureIds;
             this.textures = textures;
+            this.metalTexture = metalTexture;
             this.ratchetAnimations = ratchetAnimations;
             this.gpuDataCache = gpuDataCache ?? new ModelGPUDataCache();
         }
@@ -321,9 +323,11 @@ namespace Replanetizer.Renderer
             return false;
         }
 
-        private void RenderModel(Model model, int modelVAO)
+        private void RenderModel(Model model, ModelGPUData modelGPUData)
         {
-            GL.BindVertexArray(modelVAO);
+            GL.BindVertexArray(modelGPUData.vao);
+
+            shaderTable.animationShader.SetUniform1(UniformName.useMetalShading, 0);
 
             //Bind textures one by one, applying it to the relevant vertices based on the index array
             foreach (TextureConfig conf in model.textureConfig)
@@ -342,6 +346,27 @@ namespace Replanetizer.Renderer
                 SetTransparencyMode(conf);
                 SetTextureMode(conf);
                 GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
+            }
+
+            if (model is MetalModel metalModel && modelGPUData.metalVao != 0 && modelGPUData.metalIndexCount > 0)
+            {
+                GL.BindVertexArray(modelGPUData.metalVao);
+                shaderTable.animationShader.SetUniform1(UniformName.useMetalShading, 1);
+
+                GL.Enable(EnableCap.PolygonOffsetFill);
+                GL.PolygonOffset(-1.0f, -1.0f);
+
+                foreach (TextureConfig conf in metalModel.metalTextureConfig)
+                {
+                    metalTexture.Bind();
+                    SetTextureWrapMode(conf, metalTexture);
+
+                    SetTransparencyMode(conf);
+                    SetTextureMode(conf);
+                    GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, (conf.start - model.faceCount * 3) * sizeof(ushort));
+                }
+
+                GL.Disable(EnableCap.PolygonOffsetFill);
             }
         }
 
@@ -503,7 +528,7 @@ namespace Replanetizer.Renderer
 
             shaderTable.animationShader.SetUniformMatrix4(UniformName.bones, mobyModel.boneCount, ref boneMatrices[0].Row0.X);
 
-            RenderModel(mobyModel, gpuData.vao);
+            RenderModel(mobyModel, gpuData);
 
             int subModelCount = mobyModel.GetSubModelCount();
             for (int i = 0; i < subModelCount; i++)
@@ -515,7 +540,7 @@ namespace Replanetizer.Renderer
 
                 if (subModel == null || modelGPUData == null) continue;
 
-                RenderModel(subModel, modelGPUData.vao);
+                RenderModel(subModel, modelGPUData);
             }
 
             GLUtil.CheckGlError("AnimationRenderer");

--- a/Replanetizer/Renderer/AnimationRenderer.cs
+++ b/Replanetizer/Renderer/AnimationRenderer.cs
@@ -189,7 +189,7 @@ namespace Replanetizer.Renderer
             {
                 light = Math.Max(0, Math.Min(ALLOCATED_LIGHTS, mob.light)); ;
                 ambient = mob.color;
-                renderDistance = mob.drawDistance;
+                renderDistance = (mob.drawDistance > 0.0f) ? mob.drawDistance : float.MaxValue;
                 modelID = mob.modelID;
             }
             else if (mobyModelStandalone != null)
@@ -304,9 +304,11 @@ namespace Replanetizer.Renderer
             {
                 float dist = (mob.position - camera.position).Length;
 
-                blendDistance = MathF.Max(0.125f * (dist - renderDistance), 0.0f);
+                float blendScale = 32.0f;
 
-                if (dist > renderDistance + 8.0f)
+                blendDistance = MathF.Max((dist - renderDistance) / blendScale, 0.0f);
+
+                if (dist > renderDistance + blendScale)
                 {
                     return true;
                 }

--- a/Replanetizer/Renderer/AnimationRenderer.cs
+++ b/Replanetizer/Renderer/AnimationRenderer.cs
@@ -356,6 +356,7 @@ namespace Replanetizer.Renderer
             shaderTable.animationShader.SetUniform1(UniformName.useMetalShading, 0);
             shaderTable.animationShader.SetUniform1(UniformName.mainTexture, 0);
             shaderTable.animationShader.SetUniform1(UniformName.blueNoiseTexture, 1);
+            shaderTable.animationShader.SetUniform1(UniformName.ssaaLevelLog, FramebufferRenderer.SSAA_LEVEL_LOG);
             shaderTable.animationShader.SetUniform1(UniformName.levelObjectNumber, (mob != null) ? mob.globalID : 0);
             if (selected)
             {

--- a/Replanetizer/Renderer/BillboardRenderer.cs
+++ b/Replanetizer/Renderer/BillboardRenderer.cs
@@ -64,7 +64,7 @@ namespace Replanetizer.Renderer
             // Only a single placeholder texture currently.
 
             using Image<Rgba32> image = Image.Load<Rgba32>(Path.Join(iconsFolder, "Placeholder.png"));
-            GLTexture placeholderTex = new GLTexture("BillboardTexture", image, true, true);
+            GLTexture placeholderTex = new GLTexture("BillboardTexture", image, false, true);
 
             billboardTextures = new Dictionary<RenderedObjectType, GLTexture>();
             billboardTextures.Add(RenderedObjectType.Null, placeholderTex);

--- a/Replanetizer/Renderer/CollisionRenderer.cs
+++ b/Replanetizer/Renderer/CollisionRenderer.cs
@@ -90,14 +90,11 @@ namespace Replanetizer.Renderer
         {
             Matrix4 worldToView = payload.camera.GetWorldViewMatrix();
 
-            // Calculate camera position from the view matrix
-            var cameraPos = worldToView.ExtractTranslation();
-
             shaderTable.collisionShader.UseShader();
             shaderTable.collisionShader.SetUniformMatrix4(UniformName.worldToView, ref worldToView);
 
             // Send the camera position to the shader
-            shaderTable.collisionShader.SetUniform3(UniformName.cameraPosition, cameraPos);
+            shaderTable.collisionShader.SetUniform3(UniformName.cameraPosition, payload.camera.position);
 
             for (int i = 0; i < numCollisions; i++)
             {

--- a/Replanetizer/Renderer/GLTexture.cs
+++ b/Replanetizer/Renderer/GLTexture.cs
@@ -82,24 +82,25 @@ namespace Replanetizer.Renderer
             GLUtil.CheckGlError("Clear");
 
             GLUtil.CreateTexture(TextureTarget.Texture2D, this.name, out textureID);
-            GL.TextureStorage2D(textureID, mipmapLevels, internalFormat, width, height);
+            GL.BindTexture(TextureTarget.Texture2D, textureID);
+            GL.TexImage2D(TextureTarget.Texture2D, 0, (PixelInternalFormat) internalFormat, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, IntPtr.Zero);
             GLUtil.CheckGlError("Storage2d");
 
             byte[] imageBytes = new byte[image.Width * image.Height * 4];
             image.CopyPixelDataTo(imageBytes);
 
-            GL.TextureSubImage2D(textureID, 0, 0, 0, width, height, PixelFormat.Rgba, PixelType.UnsignedByte, imageBytes);
+            GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, width, height, PixelFormat.Rgba, PixelType.UnsignedByte, imageBytes);
             GLUtil.CheckGlError("SubImage");
 
-            if (generateMipmaps) GL.GenerateTextureMipmap(textureID);
+            if (generateMipmaps) GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
 
             SetWrapModes(TextureWrapMode.Repeat, TextureWrapMode.Repeat);
 
-            GL.TextureParameter(textureID, TextureParameterName.TextureMinFilter, (int) (generateMipmaps ? TextureMinFilter.Linear : TextureMinFilter.LinearMipmapLinear));
-            GL.TextureParameter(textureID, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Linear);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) (generateMipmaps ? TextureMinFilter.LinearMipmapLinear : TextureMinFilter.Linear));
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Linear);
             GLUtil.CheckGlError("Filtering");
 
-            GL.TextureParameter(textureID, TextureParameterName.TextureMaxLevel, mipmapLevels - 1);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, mipmapLevels - 1);
         }
 
         public GLTexture(string name, Image<L8> image)
@@ -113,22 +114,23 @@ namespace Replanetizer.Renderer
             GLUtil.CheckGlError("Clear");
 
             GLUtil.CreateTexture(TextureTarget.Texture2D, this.name, out textureID);
-            GL.TextureStorage2D(textureID, mipmapLevels, internalFormat, width, height);
+            GL.BindTexture(TextureTarget.Texture2D, textureID);
+            GL.TexImage2D(TextureTarget.Texture2D, 0, (PixelInternalFormat) internalFormat, width, height, 0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
             GLUtil.CheckGlError("Storage2d");
 
             byte[] imageBytes = new byte[image.Width * image.Height];
             image.CopyPixelDataTo(imageBytes);
 
-            GL.TextureSubImage2D(textureID, 0, 0, 0, width, height, PixelFormat.Red, PixelType.UnsignedByte, imageBytes);
+            GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, width, height, PixelFormat.Red, PixelType.UnsignedByte, imageBytes);
             GLUtil.CheckGlError("SubImage");
 
             SetWrapModes(TextureWrapMode.Repeat, TextureWrapMode.Repeat);
 
-            GL.TextureParameter(textureID, TextureParameterName.TextureMinFilter, (int) TextureMinFilter.Nearest);
-            GL.TextureParameter(textureID, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) TextureMinFilter.Nearest);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);
             GLUtil.CheckGlError("Filtering");
 
-            GL.TextureParameter(textureID, TextureParameterName.TextureMaxLevel, mipmapLevels - 1);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, mipmapLevels - 1);
         }
 
         public GLTexture(string name, int width, int height, IntPtr data, bool generateMipmaps = false, bool srgb = false)
@@ -140,15 +142,16 @@ namespace Replanetizer.Renderer
             mipmapLevels = generateMipmaps == false ? 1 : (int) Math.Floor(Math.Log(Math.Max(this.width, this.height), 2));
 
             GLUtil.CreateTexture(TextureTarget.Texture2D, this.name, out textureID);
-            GL.TextureStorage2D(textureID, mipmapLevels, internalFormat, this.width, this.height);
+            GL.BindTexture(TextureTarget.Texture2D, textureID);
+            GL.TexImage2D(TextureTarget.Texture2D, 0, (PixelInternalFormat) internalFormat, this.width, this.height, 0, PixelFormat.Bgra, PixelType.UnsignedByte, IntPtr.Zero);
 
-            GL.TextureSubImage2D(textureID, 0, 0, 0, this.width, this.height, PixelFormat.Bgra, PixelType.UnsignedByte, data);
+            GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, this.width, this.height, PixelFormat.Bgra, PixelType.UnsignedByte, data);
 
-            if (generateMipmaps) GL.GenerateTextureMipmap(textureID);
+            if (generateMipmaps) GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
 
             SetWrapModes(TextureWrapMode.Repeat, TextureWrapMode.Repeat);
 
-            GL.TextureParameter(textureID, TextureParameterName.TextureMaxLevel, mipmapLevels - 1);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, mipmapLevels - 1);
         }
 
         public GLTexture(Texture t)
@@ -237,40 +240,51 @@ namespace Replanetizer.Renderer
 
         public void SetMinFilter(TextureMinFilter filter)
         {
-            GL.TextureParameter(textureID, TextureParameterName.TextureMinFilter, (int) filter);
+            BindForEdit();
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) filter);
         }
 
         public void SetMagFilter(TextureMagFilter filter)
         {
-            GL.TextureParameter(textureID, TextureParameterName.TextureMagFilter, (int) filter);
+            BindForEdit();
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) filter);
         }
 
         public void SetAnisotropy(float level)
         {
             const TextureParameterName TEXTURE_MAX_ANISOTROPY = (TextureParameterName) 0x84FE;
-            GL.TextureParameter(textureID, TEXTURE_MAX_ANISOTROPY, GLUtil.Clamp(level, 1, MAX_ANISO));
+            BindForEdit();
+            GL.TexParameter(TextureTarget.Texture2D, TEXTURE_MAX_ANISOTROPY, GLUtil.Clamp(level, 1, MAX_ANISO));
         }
 
         public void SetLod(int @base, int min, int max)
         {
-            GL.TextureParameter(textureID, TextureParameterName.TextureLodBias, @base);
-            GL.TextureParameter(textureID, TextureParameterName.TextureMinLod, min);
-            GL.TextureParameter(textureID, TextureParameterName.TextureMaxLod, max);
+            BindForEdit();
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureLodBias, @base);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinLod, min);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLod, max);
         }
 
         public void SetWrapModes(TextureWrapMode modeS, TextureWrapMode modeT)
         {
+            BindForEdit();
+
             if (wrapS != modeS)
             {
-                GL.TextureParameter(textureID, TextureParameterName.TextureWrapS, (int) modeS);
+                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) modeS);
                 wrapS = modeS;
             }
 
             if (wrapT != modeT)
             {
-                GL.TextureParameter(textureID, TextureParameterName.TextureWrapT, (int) modeT);
+                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) modeT);
                 wrapT = modeT;
             }
+        }
+
+        private void BindForEdit()
+        {
+            GL.BindTexture(TextureTarget.Texture2D, textureID);
         }
 
         public void Dispose()

--- a/Replanetizer/Renderer/GLUniform.cs
+++ b/Replanetizer/Renderer/GLUniform.cs
@@ -62,6 +62,12 @@ namespace Replanetizer.Renderer
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Set1(int count, uint[] value)
+        {
+            GL.Uniform1(location, count, value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Set1(int value)
         {
             if (intValue != value)

--- a/Replanetizer/Renderer/GLUtil.cs
+++ b/Replanetizer/Renderer/GLUtil.cs
@@ -35,13 +35,12 @@ namespace Replanetizer.Renderer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LabelObject(ObjectLabelIdentifier objLabelIdent, int glObject, string name)
         {
-            GL.ObjectLabel(objLabelIdent, glObject, name.Length, name);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CreateTexture(TextureTarget target, string name, out int texture)
         {
-            GL.CreateTextures(target, 1, out texture);
+            GL.GenTextures(1, out texture);
             LabelObject(ObjectLabelIdentifier.Texture, texture, $"Texture: {name}");
         }
 
@@ -62,7 +61,7 @@ namespace Replanetizer.Renderer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CreateBuffer(string name, out int buffer)
         {
-            GL.CreateBuffers(1, out buffer);
+            GL.GenBuffers(1, out buffer);
             LabelObject(ObjectLabelIdentifier.Buffer, buffer, $"Buffer: {name}");
         }
 
@@ -75,7 +74,7 @@ namespace Replanetizer.Renderer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CreateVertexArray(string name, out int vao)
         {
-            GL.CreateVertexArrays(1, out vao);
+            GL.GenVertexArrays(1, out vao);
             LabelObject(ObjectLabelIdentifier.VertexArray, vao, $"VAO: {name}");
         }
 

--- a/Replanetizer/Renderer/LevelRenderer.cs
+++ b/Replanetizer/Renderer/LevelRenderer.cs
@@ -79,21 +79,21 @@ namespace Replanetizer.Renderer
 
             foreach (Moby mob in level.mobs)
             {
-                MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
+                MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textures, textureIDs, textureIDs[level.textures[0]], null, gpuDataCache);
                 mobRenderer.Include(mob);
                 mobyRenderers.Add(mobRenderer);
             }
 
             foreach (Shrub shrub in level.shrubs)
             {
-                MeshRenderer shrubRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
+                MeshRenderer shrubRenderer = new MeshRenderer(shaderTable, textures, textureIDs, textureIDs[level.textures[0]], null, gpuDataCache);
                 shrubRenderer.Include(shrub);
                 shrubRenderers.Add(shrubRenderer);
             }
 
             foreach (Tie tie in level.ties)
             {
-                MeshRenderer tieRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
+                MeshRenderer tieRenderer = new MeshRenderer(shaderTable, textures, textureIDs, textureIDs[level.textures[0]], null, gpuDataCache);
                 tieRenderer.Include(tie);
                 tieRenderers.Add(tieRenderer);
             }
@@ -105,7 +105,7 @@ namespace Replanetizer.Renderer
                     List<MeshRenderer> terrainRenderer = new List<MeshRenderer>();
                     foreach (TerrainFragment fragment in terrainChunk.fragments)
                     {
-                        MeshRenderer fragmentRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
+                        MeshRenderer fragmentRenderer = new MeshRenderer(shaderTable, textures, textureIDs, textureIDs[level.textures[0]], null, gpuDataCache);
                         fragmentRenderer.Include(fragment);
                         terrainRenderer.Add(fragmentRenderer);
                     }
@@ -117,7 +117,7 @@ namespace Replanetizer.Renderer
                 List<MeshRenderer> terrainRenderer = new List<MeshRenderer>();
                 foreach (TerrainFragment fragment in level.terrainEngine.fragments)
                 {
-                    MeshRenderer fragmentRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
+                    MeshRenderer fragmentRenderer = new MeshRenderer(shaderTable, textures, textureIDs, textureIDs[level.textures[0]], null, gpuDataCache);
                     fragmentRenderer.Include(fragment);
                     terrainRenderer.Add(fragmentRenderer);
                 }
@@ -168,7 +168,7 @@ namespace Replanetizer.Renderer
                 throw new NullReferenceException();
             }
 
-            MeshRenderer shrubRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
+            MeshRenderer shrubRenderer = new MeshRenderer(shaderTable, textures, textureIDs, textureIDs[textures[0]], null, gpuDataCache);
             shrubRenderer.Include(shrub);
             shrubRenderers.Add(shrubRenderer);
         }
@@ -180,7 +180,7 @@ namespace Replanetizer.Renderer
                 throw new NullReferenceException();
             }
 
-            MeshRenderer tieRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
+            MeshRenderer tieRenderer = new MeshRenderer(shaderTable, textures, textureIDs, textureIDs[textures[0]], null, gpuDataCache);
             tieRenderer.Include(tie);
             tieRenderers.Add(tieRenderer);
         }
@@ -192,7 +192,7 @@ namespace Replanetizer.Renderer
                 throw new NullReferenceException();
             }
 
-            MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textureOverride ?? textures, textureIDs, null, gpuDataCache);
+            MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textureOverride ?? textures, textureIDs, textureIDs[textures[0]], null, gpuDataCache);
             mobRenderer.Include(mob);
             mobyRenderers.Add(mobRenderer);
         }

--- a/Replanetizer/Renderer/LevelRenderer.cs
+++ b/Replanetizer/Renderer/LevelRenderer.cs
@@ -22,6 +22,7 @@ namespace Replanetizer.Renderer
         private static readonly Rgb24 CLEAR_COLOR = Color.FromRgb(0x9d, 0xab, 0xc7).ToPixel<Rgb24>();
         private readonly ShaderTable shaderTable;
         private Dictionary<Texture, GLTexture> textureIDs;
+        private readonly ModelGPUDataCache gpuDataCache;
 
         private LevelVariables? levelVariables;
         private List<Light>? lights;
@@ -51,6 +52,7 @@ namespace Replanetizer.Renderer
         {
             this.shaderTable = shaderTable;
             this.textureIDs = textureIDs;
+            this.gpuDataCache = new ModelGPUDataCache();
 
             this.toolRenderer = new ToolRenderer(shaderTable);
             this.dirLightsBuffer = new DirectionalLightsBuffer(shaderTable);
@@ -77,21 +79,21 @@ namespace Replanetizer.Renderer
 
             foreach (Moby mob in level.mobs)
             {
-                MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textures, textureIDs);
+                MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
                 mobRenderer.Include(mob);
                 mobyRenderers.Add(mobRenderer);
             }
 
             foreach (Shrub shrub in level.shrubs)
             {
-                MeshRenderer shrubRenderer = new MeshRenderer(shaderTable, textures, textureIDs);
+                MeshRenderer shrubRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
                 shrubRenderer.Include(shrub);
                 shrubRenderers.Add(shrubRenderer);
             }
 
             foreach (Tie tie in level.ties)
             {
-                MeshRenderer tieRenderer = new MeshRenderer(shaderTable, textures, textureIDs);
+                MeshRenderer tieRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
                 tieRenderer.Include(tie);
                 tieRenderers.Add(tieRenderer);
             }
@@ -103,7 +105,7 @@ namespace Replanetizer.Renderer
                     List<MeshRenderer> terrainRenderer = new List<MeshRenderer>();
                     foreach (TerrainFragment fragment in terrainChunk.fragments)
                     {
-                        MeshRenderer fragmentRenderer = new MeshRenderer(shaderTable, textures, textureIDs);
+                        MeshRenderer fragmentRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
                         fragmentRenderer.Include(fragment);
                         terrainRenderer.Add(fragmentRenderer);
                     }
@@ -115,7 +117,7 @@ namespace Replanetizer.Renderer
                 List<MeshRenderer> terrainRenderer = new List<MeshRenderer>();
                 foreach (TerrainFragment fragment in level.terrainEngine.fragments)
                 {
-                    MeshRenderer fragmentRenderer = new MeshRenderer(shaderTable, textures, textureIDs);
+                    MeshRenderer fragmentRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
                     fragmentRenderer.Include(fragment);
                     terrainRenderer.Add(fragmentRenderer);
                 }
@@ -166,7 +168,7 @@ namespace Replanetizer.Renderer
                 throw new NullReferenceException();
             }
 
-            MeshRenderer shrubRenderer = new MeshRenderer(shaderTable, textures, textureIDs);
+            MeshRenderer shrubRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
             shrubRenderer.Include(shrub);
             shrubRenderers.Add(shrubRenderer);
         }
@@ -178,7 +180,7 @@ namespace Replanetizer.Renderer
                 throw new NullReferenceException();
             }
 
-            MeshRenderer tieRenderer = new MeshRenderer(shaderTable, textures, textureIDs);
+            MeshRenderer tieRenderer = new MeshRenderer(shaderTable, textures, textureIDs, null, gpuDataCache);
             tieRenderer.Include(tie);
             tieRenderers.Add(tieRenderer);
         }
@@ -190,7 +192,7 @@ namespace Replanetizer.Renderer
                 throw new NullReferenceException();
             }
 
-            MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textureOverride ?? textures, textureIDs);
+            MeshRenderer mobRenderer = new MeshRenderer(shaderTable, textureOverride ?? textures, textureIDs, null, gpuDataCache);
             mobRenderer.Include(mob);
             mobyRenderers.Add(mobRenderer);
         }
@@ -450,6 +452,7 @@ namespace Replanetizer.Renderer
 
             dirLightsBuffer.Dispose();
             toolRenderer?.Dispose();
+            gpuDataCache.Dispose();
         }
     }
 }

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -34,18 +34,6 @@ namespace Replanetizer.Renderer
 
         private int loadedModelID = -1;
 
-        private int ibo = 0;
-        private int vbo = 0;
-        private int vao = 0;
-
-        private List<int> subModelIBOs = new List<int>();
-        private List<int> subModelVBOs = new List<int>();
-        private List<int> subModelVAOs = new List<int>();
-
-        private bool iboAllocated = false;
-        private bool vboAllocated = false;
-        private bool vaoAllocated = false;
-
         private RenderedObjectType type { get; set; }
         private int objectID = 0;
         private int light { get; set; }
@@ -70,13 +58,16 @@ namespace Replanetizer.Renderer
         private ShaderTable shaderTable;
         private BillboardRenderer fallback;
         private AnimationRenderer? animationRenderer = null;
+        private readonly ModelGPUDataCache gpuDataCache;
+        private ModelGPUData? gpuData;
 
-        public MeshRenderer(ShaderTable shaderTable, List<Texture> textures, Dictionary<Texture, GLTexture> textureIds, List<Animation>? ratchetAnimations = null)
+        public MeshRenderer(ShaderTable shaderTable, List<Texture> textures, Dictionary<Texture, GLTexture> textureIds, List<Animation>? ratchetAnimations = null, ModelGPUDataCache? gpuDataCache = null)
         {
             this.shaderTable = shaderTable;
             this.textureIds = textureIds;
             this.textures = textures;
             this.ratchetAnimations = ratchetAnimations;
+            this.gpuDataCache = gpuDataCache ?? new ModelGPUDataCache();
             this.fallback = new BillboardRenderer(shaderTable);
         }
 
@@ -127,106 +118,13 @@ namespace Replanetizer.Renderer
 
         public override void Include<T>(List<T> list) => throw new NotImplementedException();
 
-        /// <summary>
-        /// Deletes IBO and VBO if they are allocated.
-        /// </summary>
         private void DeleteBuffers()
         {
-            if (iboAllocated)
-            {
-                GL.DeleteBuffer(ibo);
-                ibo = 0;
-                iboAllocated = false;
-            }
-
-            if (vboAllocated)
-            {
-                GL.DeleteBuffer(vbo);
-                vbo = 0;
-                vboAllocated = false;
-            }
-
-            if (vaoAllocated)
-            {
-                GL.DeleteVertexArray(vao);
-                vao = 0;
-                vaoAllocated = false;
-            }
-
+            gpuDataCache.Release(gpuData);
+            gpuData = null;
             loadedModelID = -1;
             modelRender = null;
             renderPrepared = false;
-
-            foreach (int subModelIBO in subModelIBOs)
-            {
-                if (subModelIBO != -1)
-                {
-                    GL.DeleteBuffer(subModelIBO);
-                }
-            }
-
-            foreach (int subModelVBO in subModelVBOs)
-            {
-                if (subModelVBO != -1)
-                {
-                    GL.DeleteBuffer(subModelVBO);
-                }
-            }
-
-            foreach (int subModelVAO in subModelVAOs)
-            {
-                if (subModelVAO != -1)
-                {
-                    GL.DeleteVertexArray(subModelVAO);
-                }
-            }
-
-            subModelVAOs.Clear();
-            subModelIBOs.Clear();
-            subModelVBOs.Clear();
-        }
-
-        /// <summary>
-        /// Sets up the vertex attribute pointers according to the type.
-        /// </summary>
-        private void SetupVertexAttribPointers()
-        {
-            if (modelObject != null)
-            {
-                switch (type)
-                {
-                    case RenderedObjectType.Terrain:
-                        GLUtil.ActivateNumberOfVertexAttribArrays(5);
-                        GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, sizeof(float) * 10, 0);
-                        GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, sizeof(float) * 10, sizeof(float) * 3);
-                        GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, sizeof(float) * 10, sizeof(float) * 6);
-                        GL.VertexAttribPointer(3, 4, VertexAttribPointerType.UnsignedByte, true, sizeof(float) * 10, sizeof(float) * 8);
-                        GL.VertexAttribPointer(4, 1, VertexAttribPointerType.Float, false, sizeof(float) * 10, sizeof(float) * 9);
-                        break;
-                    case RenderedObjectType.Tie:
-                        GLUtil.ActivateNumberOfVertexAttribArrays(4);
-                        GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, sizeof(float) * 9, 0);
-                        GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, sizeof(float) * 9, sizeof(float) * 3);
-                        GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, sizeof(float) * 9, sizeof(float) * 6);
-                        GL.VertexAttribPointer(3, 4, VertexAttribPointerType.UnsignedByte, true, sizeof(float) * 9, sizeof(float) * 8);
-                        break;
-                    case RenderedObjectType.Shrub:
-                    case RenderedObjectType.Moby:
-                        GLUtil.ActivateNumberOfVertexAttribArrays(3);
-                        GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, sizeof(float) * 8, 0);
-                        GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, sizeof(float) * 8, sizeof(float) * 3);
-                        GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, sizeof(float) * 8, sizeof(float) * 6);
-                        break;
-                }
-            }
-            else
-            {
-                GLUtil.ActivateNumberOfVertexAttribArrays(3);
-                GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, sizeof(float) * 8, 0);
-                GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, sizeof(float) * 8, sizeof(float) * 3);
-                GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, sizeof(float) * 8, sizeof(float) * 6);
-            }
-
         }
 
         /// <summary>
@@ -244,7 +142,7 @@ namespace Replanetizer.Renderer
 
                 if (modelObject is Moby mob)
                 {
-                    animationRenderer = new AnimationRenderer(shaderTable, textures, textureIds, ratchetAnimations);
+                    animationRenderer = new AnimationRenderer(shaderTable, textures, textureIds, ratchetAnimations, gpuDataCache);
                     animationRenderer.Include(mob);
                 }
             }
@@ -254,7 +152,7 @@ namespace Replanetizer.Renderer
 
                 if (modelStandalone is MobyModel mobyModel)
                 {
-                    animationRenderer = new AnimationRenderer(shaderTable, textures, textureIds, ratchetAnimations);
+                    animationRenderer = new AnimationRenderer(shaderTable, textures, textureIds, ratchetAnimations, gpuDataCache);
                     animationRenderer.Include(mobyModel);
                 }
             }
@@ -275,159 +173,20 @@ namespace Replanetizer.Renderer
                 return;
             }
 
-            GL.GenVertexArrays(1, out vao);
-            GL.BindVertexArray(vao);
-            vaoAllocated = true;
-
-            // IBO
-            int iboLength = modelRender.GetIndices().Length * sizeof(ushort);
-            if (iboLength > 0)
+            ModelGPULayout layout = type switch
             {
-                GL.GenBuffers(1, out ibo);
-                GL.BindBuffer(BufferTarget.ElementArrayBuffer, ibo);
-                GL.BufferData(BufferTarget.ElementArrayBuffer, iboLength, IntPtr.Zero, BufferUsageHint.StaticDraw);
-                iboAllocated = true;
-            }
+                RenderedObjectType.Terrain => ModelGPULayout.Terrain,
+                RenderedObjectType.Tie => ModelGPULayout.Tie,
+                _ => ModelGPULayout.Static
+            };
+            byte[]? ambientRgbas = modelObject is Tie || modelObject is TerrainFragment
+                ? modelObject.GetAmbientRgbas() : null;
+            List<int>? terrainLights = (modelRender as TerrainModel)?.lights;
+            string instanceKey = (ambientRgbas == null ? "" : Convert.ToBase64String(ambientRgbas)) + ":"
+                + (terrainLights == null ? "" : string.Join(",", terrainLights));
 
-            // VBO
-            int vboLength = modelRender.GetVertices().Length * sizeof(float);
-            if (modelObject != null)
-            {
-                switch (type)
-                {
-                    case RenderedObjectType.Terrain:
-                        TerrainModel? terrainModel = (TerrainModel?) modelRender;
-                        if (terrainModel == null) break;
-                        vboLength += modelObject.GetAmbientRgbas().Length * sizeof(Byte) + terrainModel.lights.Count * sizeof(int);
-                        break;
-                    case RenderedObjectType.Tie:
-                        vboLength += modelObject.GetAmbientRgbas().Length * sizeof(Byte);
-                        break;
-                }
-            }
-
-            if (vboLength > 0)
-            {
-                GL.GenBuffers(1, out vbo);
-                GL.BindBuffer(BufferTarget.ArrayBuffer, vbo);
-                GL.BufferData(BufferTarget.ArrayBuffer, vboLength, IntPtr.Zero, BufferUsageHint.StaticDraw);
-                vboAllocated = true;
-            }
-
-            UpdateBuffers(modelRender, vao);
-
-            // Initialize all submodels aswell, we can then dynamically decide to draw them or not during rendering.
-            int subModelCount = modelRender.GetSubModelCount();
-            for (int i = 0; i < subModelCount; i++)
-            {
-                Model? subModel = modelRender.GetSubModel(i);
-
-                if (subModel == null)
-                {
-                    subModelVAOs.Add(-1);
-                    subModelIBOs.Add(-1);
-                    subModelVBOs.Add(-1);
-                    continue;
-                }
-
-                int subModelVao;
-                GL.GenVertexArrays(1, out subModelVao);
-                GL.BindVertexArray(subModelVao);
-
-                // IBO
-                int subModelIboLength = subModel.GetIndices().Length * sizeof(ushort);
-                int subModelIbo = -1;
-                if (subModelIboLength > 0)
-                {
-                    GL.GenBuffers(1, out subModelIbo);
-                    GL.BindBuffer(BufferTarget.ElementArrayBuffer, subModelIbo);
-                    GL.BufferData(BufferTarget.ElementArrayBuffer, subModelIboLength, IntPtr.Zero, BufferUsageHint.StaticDraw);
-                }
-
-                // VBO
-                int subModelVboLength = subModel.GetVertices().Length * sizeof(float);
-                subModelVboLength += subModel.vertexBoneIds.Length * sizeof(uint);
-                subModelVboLength += subModel.vertexBoneWeights.Length * sizeof(uint);
-                int subModelVbo = -1;
-                if (subModelVboLength > 0)
-                {
-                    GL.GenBuffers(1, out subModelVbo);
-                    GL.BindBuffer(BufferTarget.ArrayBuffer, subModelVbo);
-                    GL.BufferData(BufferTarget.ArrayBuffer, subModelVboLength, IntPtr.Zero, BufferUsageHint.StaticDraw);
-                }
-
-                subModelVAOs.Add(subModelVao);
-                subModelIBOs.Add(subModelIbo);
-                subModelVBOs.Add(subModelVbo);
-
-                UpdateBuffers(subModel, subModelVao);
-            }
+            gpuData = gpuDataCache.Acquire(modelRender, layout, instanceKey, ambientRgbas, terrainLights);
         }
-
-        /// <summary>
-        /// Updates the buffers. This is not actually needed as long as mesh manipulations are not possible.
-        /// </summary>
-        private void UpdateBuffers(Model model, int modelVAO)
-        {
-            GL.BindVertexArray(modelVAO);
-
-            ushort[] iboData = model.GetIndices();
-            GL.BufferSubData(BufferTarget.ElementArrayBuffer, IntPtr.Zero, iboData.Length * sizeof(ushort), iboData);
-
-            float[] vboData = model.GetVertices();
-            if (modelObject != null)
-            {
-                switch (type)
-                {
-                    case RenderedObjectType.Terrain:
-                        {
-                            byte[] rgbas = modelObject.GetAmbientRgbas();
-                            TerrainModel? terrainModel = (TerrainModel?) model;
-                            if (terrainModel == null) break;
-                            int[] lights = terrainModel.lights.ToArray();
-                            float[] fullData = new float[vboData.Length + rgbas.Length / 4 + lights.Length];
-                            for (int i = 0; i < vboData.Length / 8; i++)
-                            {
-                                fullData[10 * i + 0] = vboData[8 * i + 0];
-                                fullData[10 * i + 1] = vboData[8 * i + 1];
-                                fullData[10 * i + 2] = vboData[8 * i + 2];
-                                fullData[10 * i + 3] = vboData[8 * i + 3];
-                                fullData[10 * i + 4] = vboData[8 * i + 4];
-                                fullData[10 * i + 5] = vboData[8 * i + 5];
-                                fullData[10 * i + 6] = vboData[8 * i + 6];
-                                fullData[10 * i + 7] = vboData[8 * i + 7];
-                                fullData[10 * i + 8] = (i * 4 < rgbas.Length) ? BitConverter.ToSingle(rgbas, i * 4) : 0f;
-                                fullData[10 * i + 9] = (i < lights.Length) ? (float) lights[i] : 0f;
-                            }
-                            vboData = fullData;
-                            break;
-                        }
-                    case RenderedObjectType.Tie:
-                        {
-                            byte[] rgbas = modelObject.GetAmbientRgbas();
-                            float[] fullData = new float[vboData.Length + rgbas.Length / 4];
-                            for (int i = 0; i < vboData.Length / 8; i++)
-                            {
-                                fullData[9 * i + 0] = vboData[8 * i + 0];
-                                fullData[9 * i + 1] = vboData[8 * i + 1];
-                                fullData[9 * i + 2] = vboData[8 * i + 2];
-                                fullData[9 * i + 3] = vboData[8 * i + 3];
-                                fullData[9 * i + 4] = vboData[8 * i + 4];
-                                fullData[9 * i + 5] = vboData[8 * i + 5];
-                                fullData[9 * i + 6] = vboData[8 * i + 6];
-                                fullData[9 * i + 7] = vboData[8 * i + 7];
-                                fullData[9 * i + 8] = (i * 4 < rgbas.Length) ? BitConverter.ToSingle(rgbas, i * 4) : 0f;
-                            }
-                            vboData = fullData;
-                            break;
-                        }
-                }
-            }
-            GL.BufferSubData(BufferTarget.ArrayBuffer, IntPtr.Zero, vboData.Length * sizeof(float), vboData);
-
-            SetupVertexAttribPointers();
-        }
-
         /// <summary>
         /// Updates the light and ambient variables which can then be used to update the shader. Check if the modelID
         /// has changed and update the buffers if necessary.
@@ -761,7 +520,7 @@ namespace Replanetizer.Renderer
                 }
             }
 
-            if (modelRender == null) return;
+            if (modelRender == null || gpuData == null) return;
 
             // Setup shaders
             shaderTable.meshShader.UseShader();
@@ -789,7 +548,7 @@ namespace Replanetizer.Renderer
                 shaderTable.colorShader.SetUniform4(UniformName.incolor, 1.0f, 1.0f, 1.0f, 1.0f);
             }
 
-            RenderModel(modelRender, vao);
+            RenderModel(modelRender, gpuData.vao);
 
             int subModelCount = modelRender.GetSubModelCount();
             for (int i = 0; i < subModelCount; i++)
@@ -797,10 +556,11 @@ namespace Replanetizer.Renderer
                 if ((payload.visibility.subModelsMask & (1u << i)) == 0) continue;
 
                 Model? subModel = modelRender.GetSubModel(i);
+                ModelGPUData? modelGPUData = gpuData.subModels[i];
 
-                if (subModel == null) continue;
+                if (subModel == null || modelGPUData == null) continue;
 
-                RenderModel(subModel, subModelVAOs[i]);
+                RenderModel(subModel, modelGPUData.vao);
             }
 
             GLUtil.CheckGlError("MeshRenderer");

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -573,6 +573,7 @@ namespace Replanetizer.Renderer
 
             shaderTable.meshShader.SetUniform1(UniformName.mainTexture, 0);
             shaderTable.meshShader.SetUniform1(UniformName.blueNoiseTexture, 1);
+            shaderTable.meshShader.SetUniform1(UniformName.ssaaLevelLog, FramebufferRenderer.SSAA_LEVEL_LOG);
             shaderTable.meshShader.SetUniformMatrix4(UniformName.modelToWorld, ref modelToWorld);
             shaderTable.meshShader.SetUniformMatrix4(UniformName.worldToView, ref worldToView);
             shaderTable.meshShader.SetUniform3(UniformName.cameraPosition, payload.camera.position);

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -517,11 +517,9 @@ namespace Replanetizer.Renderer
                 GL.BindVertexArray(modelGPUData.vao);
                 shaderTable.colorShader.UseShader();
 
-                GL.Enable(EnableCap.LineSmooth);
                 GL.PolygonMode(TriangleFace.FrontAndBack, PolygonMode.Line);
                 GL.DrawElements(PrimitiveType.Triangles, model.indexBuffer.Length, DrawElementsType.UnsignedShort, 0);
                 GL.PolygonMode(TriangleFace.FrontAndBack, PolygonMode.Fill);
-                GL.Disable(EnableCap.LineSmooth);
             }
         }
 

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -337,11 +337,17 @@ namespace Replanetizer.Renderer
         /// Mobies and shrubs are culled by their drawDistance.
         /// Ties, terrain and shrubs are culled by frustum culling.
         /// </summary>
-        private bool ComputeCulling(Camera camera, bool distanceCulling, bool frustumCulling)
+        private bool ComputeCulling(Camera camera, bool distanceCulling, bool frustumCulling, bool visibleCulling)
         {
             if (modelRender == null) return false;
             if (modelStandalone != null) return false;
             if (modelObject == null) return true;
+
+            if (visibleCulling && modelObject is Moby mob && mob.memory != null)
+            {
+                if (mob.memory.visible == 0)
+                    return true;
+            }
 
             if (distanceCulling)
             {
@@ -439,7 +445,7 @@ namespace Replanetizer.Renderer
 
             modelRender = modelObject?.model ?? modelStandalone;
 
-            if (ComputeCulling(payload.camera, payload.visibility.enableDistanceCulling, payload.visibility.enableFrustumCulling))
+            if (ComputeCulling(payload.camera, payload.visibility.enableDistanceCulling, payload.visibility.enableFrustumCulling, payload.visibility.enableVisibleCulling))
             {
                 renderPrepared = true;
                 renderPerform = false;

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -576,7 +576,8 @@ namespace Replanetizer.Renderer
             shaderTable.meshShader.SetUniform1(UniformName.ssaaLevelLog, FramebufferRenderer.SSAA_LEVEL_LOG);
             shaderTable.meshShader.SetUniformMatrix4(UniformName.modelToWorld, ref modelToWorld);
             shaderTable.meshShader.SetUniformMatrix4(UniformName.worldToView, ref worldToView);
-            shaderTable.meshShader.SetUniform3(UniformName.cameraPosition, payload.camera.position);
+            Matrix4 viewMatrix = payload.camera.GetViewMatrix();
+            shaderTable.meshShader.SetUniformMatrix4(UniformName.viewMatrix, ref viewMatrix);
             shaderTable.meshShader.SetUniform1(UniformName.levelObjectNumber, objectID);
             shaderTable.meshShader.SetUniform1(UniformName.levelObjectType, (int) type);
             shaderTable.meshShader.SetUniform4(UniformName.staticColor, ambient);

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -220,7 +220,7 @@ namespace Replanetizer.Renderer
                         Moby mob = (Moby) modelObject;
                         light = Math.Max(0, Math.Min(ALLOCATED_LIGHTS, mob.light));
                         mob.color.ToRgba32(ref ambient);
-                        renderDistance = mob.drawDistance;
+                        renderDistance = (mob.drawDistance > 0.0f) ? mob.drawDistance : float.MaxValue;
                         break;
                     case RenderedObjectType.Tie:
                         Tie tie = (Tie) modelObject;
@@ -353,9 +353,13 @@ namespace Replanetizer.Renderer
             {
                 float dist = (modelObject.position - camera.position).Length;
 
-                blendDistance = MathF.Max(0.125f * (dist - renderDistance), 0.0f);
+                float blendScale = 8.0f;
+                if (type == RenderedObjectType.Moby)
+                    blendScale = 32.0f;
 
-                if (dist > renderDistance + 8.0f)
+                blendDistance = MathF.Max((dist - renderDistance) / blendScale, 0.0f);
+
+                if (dist > renderDistance + blendScale)
                 {
                     return true;
                 }

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -127,6 +127,16 @@ namespace Replanetizer.Renderer
             renderPrepared = false;
         }
 
+        private static bool HasMeshData(Model model)
+        {
+            if (model.GetIndices().Length > 0)
+            {
+                return true;
+            }
+
+            return model is MetalModel metalModel && metalModel.metalIndexBuffer.Length > 0;
+        }
+
         /// <summary>
         /// Generates IBO and VBO.
         /// </summary>
@@ -160,7 +170,7 @@ namespace Replanetizer.Renderer
             if (modelRender == null)
                 return;
 
-            if (modelRender.GetIndices().Length == 0)
+            if (!HasMeshData(modelRender))
                 return;
 
             // This is a camera object that only exist at runtime and blocks vision in interactive mode.
@@ -428,7 +438,7 @@ namespace Replanetizer.Renderer
             renderPrepared = true;
             renderPerform = true;
 
-            if (modelRender == null || modelRender.GetIndices().Length == 0)
+            if (modelRender == null || !HasMeshData(modelRender))
             {
                 renderPerformBillboardOnly = true;
                 return;

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -258,9 +258,9 @@ namespace Replanetizer.Renderer
             shaderTable.meshShader.SetUniform1(UniformName.useTransparency, (config.IgnoresTransparency()) ? 0 : 1);
         }
 
-        private void SetTextureMode(TextureConfig config)
+        private void SetTextureMode(TextureConfig config, bool bIsMetalTexture)
         {
-            shaderTable.meshShader.SetUniform1(UniformName.useTexture, (config.id >= 0) ? 1 : 0);
+            shaderTable.meshShader.SetUniform1(UniformName.useTexture, (config.id >= 0 || bIsMetalTexture) ? 1 : 0);
         }
 
         /// <summary>
@@ -455,6 +455,7 @@ namespace Replanetizer.Renderer
             GL.BindVertexArray(modelGPUData.vao);
 
             shaderTable.meshShader.UseShader();
+            shaderTable.meshShader.SetUniform1(UniformName.useMetalShading, 0);
 
             //Bind textures one by one, applying it to the relevant vertices based on the index array
             foreach (TextureConfig conf in model.textureConfig)
@@ -471,7 +472,7 @@ namespace Replanetizer.Renderer
                 }
 
                 SetTransparencyMode(conf);
-                SetTextureMode(conf);
+                SetTextureMode(conf, false);
                 GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
             }
 
@@ -480,9 +481,14 @@ namespace Replanetizer.Renderer
                 && modelGPUData.metalIndexCount > 0)
             {
                 GL.BindVertexArray(modelGPUData.metalVao);
+                shaderTable.meshShader.SetUniform1(UniformName.useMetalShading, 1);
+
+                GL.Enable(EnableCap.PolygonOffsetFill);
+                GL.PolygonOffset(-1.0f, -1.0f);
 
                 foreach (TextureConfig conf in metalModel.metalTextureConfig)
                 {
+#if false
                     if (conf.id >= 0 && conf.id < textures.Count)
                     {
                         GLTexture tex = textureIds[textures[conf.id]];
@@ -493,11 +499,17 @@ namespace Replanetizer.Renderer
                     {
                         GLTexture.BindNull();
                     }
+#endif
+                    GLTexture tex = textureIds[textures[0]];
+                    tex.Bind();
+                    SetTextureWrapMode(conf, tex);
 
                     SetTransparencyMode(conf);
-                    SetTextureMode(conf);
-                    GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
+                    SetTextureMode(conf, true);
+                    GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, (conf.start - model.faceCount * 3) * sizeof(ushort));
                 }
+
+                GL.Disable(EnableCap.PolygonOffsetFill);
             }
 
             if (selected)
@@ -565,6 +577,7 @@ namespace Replanetizer.Renderer
             shaderTable.meshShader.SetUniform1(UniformName.blueNoiseTexture, 1);
             shaderTable.meshShader.SetUniformMatrix4(UniformName.modelToWorld, ref modelToWorld);
             shaderTable.meshShader.SetUniformMatrix4(UniformName.worldToView, ref worldToView);
+            shaderTable.meshShader.SetUniform3(UniformName.cameraPosition, payload.camera.position);
             shaderTable.meshShader.SetUniform1(UniformName.levelObjectNumber, objectID);
             shaderTable.meshShader.SetUniform1(UniformName.levelObjectType, (int) type);
             shaderTable.meshShader.SetUniform4(UniformName.staticColor, ambient);

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -440,9 +440,9 @@ namespace Replanetizer.Renderer
             renderPerformBillboardOnly = false;
         }
 
-        private void RenderModel(Model model, int modelVAO)
+        private void RenderModel(Model model, ModelGPUData modelGPUData)
         {
-            GL.BindVertexArray(modelVAO);
+            GL.BindVertexArray(modelGPUData.vao);
 
             shaderTable.meshShader.UseShader();
 
@@ -465,8 +465,34 @@ namespace Replanetizer.Renderer
                 GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
             }
 
+            if (model is MetalModel metalModel
+                && modelGPUData.metalVao != 0
+                && modelGPUData.metalIndexCount > 0)
+            {
+                GL.BindVertexArray(modelGPUData.metalVao);
+
+                foreach (TextureConfig conf in metalModel.metalTextureConfig)
+                {
+                    if (conf.id >= 0 && conf.id < textures.Count)
+                    {
+                        GLTexture tex = textureIds[textures[conf.id]];
+                        tex.Bind();
+                        SetTextureWrapMode(conf, tex);
+                    }
+                    else
+                    {
+                        GLTexture.BindNull();
+                    }
+
+                    SetTransparencyMode(conf);
+                    SetTextureMode(conf);
+                    GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
+                }
+            }
+
             if (selected)
             {
+                GL.BindVertexArray(modelGPUData.vao);
                 shaderTable.colorShader.UseShader();
 
                 GL.Enable(EnableCap.LineSmooth);
@@ -548,7 +574,7 @@ namespace Replanetizer.Renderer
                 shaderTable.colorShader.SetUniform4(UniformName.incolor, 1.0f, 1.0f, 1.0f, 1.0f);
             }
 
-            RenderModel(modelRender, gpuData.vao);
+            RenderModel(modelRender, gpuData);
 
             int subModelCount = modelRender.GetSubModelCount();
             for (int i = 0; i < subModelCount; i++)
@@ -560,7 +586,7 @@ namespace Replanetizer.Renderer
 
                 if (subModel == null || modelGPUData == null) continue;
 
-                RenderModel(subModel, modelGPUData.vao);
+                RenderModel(subModel, modelGPUData);
             }
 
             GLUtil.CheckGlError("MeshRenderer");

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -33,6 +33,7 @@ namespace Replanetizer.Renderer
         private Model? modelStandalone;
 
         private int loadedModelID = -1;
+        private bool modelHasMeshData = false;
 
         private RenderedObjectType type { get; set; }
         private int objectID = 0;
@@ -123,6 +124,7 @@ namespace Replanetizer.Renderer
             gpuDataCache.Release(gpuData);
             gpuData = null;
             loadedModelID = -1;
+            modelHasMeshData = false;
             modelRender = null;
             renderPrepared = false;
         }
@@ -178,10 +180,13 @@ namespace Replanetizer.Renderer
             if (renderCameraMesh == false && loadedModelID == 0x3EF && modelObject != null)
             {
                 loadedModelID = -1;
+                modelHasMeshData = false;
                 modelObject = null;
                 modelRender = null;
                 return;
             }
+
+            modelHasMeshData = true;
 
             ModelGPULayout layout = type switch
             {
@@ -233,7 +238,10 @@ namespace Replanetizer.Renderer
                 modelToWorld = modelObject.modelMatrix;
                 objectID = modelObject.globalID;
 
-                if (modelRender != modelObject.model)
+                bool currentModelHasMeshData = modelObject.model != null && HasMeshData(modelObject.model);
+                if (modelRender != modelObject.model
+                    || loadedModelID != modelObject.modelID
+                    || modelHasMeshData != currentModelHasMeshData)
                 {
                     GenerateBuffers();
                 }
@@ -243,7 +251,10 @@ namespace Replanetizer.Renderer
                 modelToWorld = Matrix4.Identity;
                 objectID = 0;
 
-                if (loadedModelID != modelStandalone.id)
+                bool currentModelHasMeshData = HasMeshData(modelStandalone);
+                if (modelRender != modelStandalone
+                    || loadedModelID != modelStandalone.id
+                    || modelHasMeshData != currentModelHasMeshData)
                 {
                     GenerateBuffers();
                 }
@@ -437,6 +448,7 @@ namespace Replanetizer.Renderer
 
             renderPrepared = true;
             renderPerform = true;
+            renderPerformBillboardOnly = false;
 
             if (modelRender == null || !HasMeshData(modelRender))
             {

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -56,17 +56,19 @@ namespace Replanetizer.Renderer
 
         private List<Texture> textures;
         private Dictionary<Texture, GLTexture> textureIds;
+        private readonly GLTexture metalTexture;
         private ShaderTable shaderTable;
         private BillboardRenderer fallback;
         private AnimationRenderer? animationRenderer = null;
         private readonly ModelGPUDataCache gpuDataCache;
         private ModelGPUData? gpuData;
 
-        public MeshRenderer(ShaderTable shaderTable, List<Texture> textures, Dictionary<Texture, GLTexture> textureIds, List<Animation>? ratchetAnimations = null, ModelGPUDataCache? gpuDataCache = null)
+        public MeshRenderer(ShaderTable shaderTable, List<Texture> textures, Dictionary<Texture, GLTexture> textureIds, GLTexture metalTexture, List<Animation>? ratchetAnimations = null, ModelGPUDataCache? gpuDataCache = null)
         {
             this.shaderTable = shaderTable;
             this.textureIds = textureIds;
             this.textures = textures;
+            this.metalTexture = metalTexture;
             this.ratchetAnimations = ratchetAnimations;
             this.gpuDataCache = gpuDataCache ?? new ModelGPUDataCache();
             this.fallback = new BillboardRenderer(shaderTable);
@@ -154,7 +156,7 @@ namespace Replanetizer.Renderer
 
                 if (modelObject is Moby mob)
                 {
-                    animationRenderer = new AnimationRenderer(shaderTable, textures, textureIds, ratchetAnimations, gpuDataCache);
+                    animationRenderer = new AnimationRenderer(shaderTable, textures, textureIds, metalTexture, ratchetAnimations, gpuDataCache);
                     animationRenderer.Include(mob);
                 }
             }
@@ -164,7 +166,7 @@ namespace Replanetizer.Renderer
 
                 if (modelStandalone is MobyModel mobyModel)
                 {
-                    animationRenderer = new AnimationRenderer(shaderTable, textures, textureIds, ratchetAnimations, gpuDataCache);
+                    animationRenderer = new AnimationRenderer(shaderTable, textures, textureIds, metalTexture, ratchetAnimations, gpuDataCache);
                     animationRenderer.Include(mobyModel);
                 }
             }
@@ -269,9 +271,9 @@ namespace Replanetizer.Renderer
             shaderTable.meshShader.SetUniform1(UniformName.useTransparency, (config.IgnoresTransparency()) ? 0 : 1);
         }
 
-        private void SetTextureMode(TextureConfig config, bool bIsMetalTexture)
+        private void SetTextureMode(TextureConfig config)
         {
-            shaderTable.meshShader.SetUniform1(UniformName.useTexture, (config.id >= 0 || bIsMetalTexture) ? 1 : 0);
+            shaderTable.meshShader.SetUniform1(UniformName.useTexture, (config.id >= 0) ? 1 : 0);
         }
 
         /// <summary>
@@ -494,13 +496,11 @@ namespace Replanetizer.Renderer
                 }
 
                 SetTransparencyMode(conf);
-                SetTextureMode(conf, false);
+                SetTextureMode(conf);
                 GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, conf.start * sizeof(ushort));
             }
 
-            if (model is MetalModel metalModel
-                && modelGPUData.metalVao != 0
-                && modelGPUData.metalIndexCount > 0)
+            if (model is MetalModel metalModel && modelGPUData.metalVao != 0 && modelGPUData.metalIndexCount > 0)
             {
                 GL.BindVertexArray(modelGPUData.metalVao);
                 shaderTable.meshShader.SetUniform1(UniformName.useMetalShading, 1);
@@ -510,24 +510,11 @@ namespace Replanetizer.Renderer
 
                 foreach (TextureConfig conf in metalModel.metalTextureConfig)
                 {
-#if false
-                    if (conf.id >= 0 && conf.id < textures.Count)
-                    {
-                        GLTexture tex = textureIds[textures[conf.id]];
-                        tex.Bind();
-                        SetTextureWrapMode(conf, tex);
-                    }
-                    else
-                    {
-                        GLTexture.BindNull();
-                    }
-#endif
-                    GLTexture tex = textureIds[textures[0]];
-                    tex.Bind();
-                    SetTextureWrapMode(conf, tex);
+                    metalTexture.Bind();
+                    SetTextureWrapMode(conf, metalTexture);
 
                     SetTransparencyMode(conf);
-                    SetTextureMode(conf, true);
+                    SetTextureMode(conf);
                     GL.DrawElements(PrimitiveType.Triangles, conf.size, DrawElementsType.UnsignedShort, (conf.start - model.faceCount * 3) * sizeof(ushort));
                 }
 

--- a/Replanetizer/Renderer/ModelGpuDataCache.cs
+++ b/Replanetizer/Renderer/ModelGpuDataCache.cs
@@ -105,8 +105,14 @@ namespace Replanetizer.Renderer
 
             GL.GenBuffers(1, out ibo);
             GL.BindBuffer(BufferTarget.ElementArrayBuffer, ibo);
+            int regularVertexCount = model.GetVertices().Length / 8;
+            ushort[] metalIndices = new ushort[metalModel.metalIndexBuffer.Length];
+            for (int i = 0; i < metalIndices.Length; i++)
+            {
+                metalIndices[i] = (ushort) (metalModel.metalIndexBuffer[i] - regularVertexCount);
+            }
             GL.BufferData(BufferTarget.ElementArrayBuffer,
-                metalModel.metalIndexBuffer.Length * sizeof(ushort), metalModel.metalIndexBuffer, BufferUsageHint.StaticDraw);
+                metalIndices.Length * sizeof(ushort), metalIndices, BufferUsageHint.StaticDraw);
 
             float[] vertices = BuildMetalVertexData(metalModel, layout);
             GL.GenBuffers(1, out vbo);

--- a/Replanetizer/Renderer/ModelGpuDataCache.cs
+++ b/Replanetizer/Renderer/ModelGpuDataCache.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using LibReplanetizer.Models;
+using OpenTK.Graphics.OpenGL;
+
+namespace Replanetizer.Renderer
+{
+    internal enum ModelGPULayout
+    {
+        Static,
+        Terrain,
+        Tie,
+        Animated
+    }
+
+    internal sealed class ModelGPUData
+    {
+        internal readonly Model model;
+        internal readonly int vao;
+        internal readonly int vbo;
+        internal readonly int ibo;
+        internal readonly List<ModelGPUData?> subModels;
+        internal int References { get; set; }
+
+        private ModelGPUData(Model model, int vao, int vbo, int ibo, List<ModelGPUData?> subModels)
+        {
+            this.model = model;
+            this.vao = vao;
+            this.vbo = vbo;
+            this.ibo = ibo;
+            this.subModels = subModels;
+        }
+
+        internal static ModelGPUData Create(Model model, ModelGPULayout layout, byte[]? ambientRgbas = null, List<int>? terrainLights = null)
+        {
+            int vao;
+            int vbo = 0;
+            int ibo = 0;
+
+            GL.GenVertexArrays(1, out vao);
+            GL.BindVertexArray(vao);
+
+            ushort[] indices = model.GetIndices();
+            if (indices.Length > 0)
+            {
+                GL.GenBuffers(1, out ibo);
+                GL.BindBuffer(BufferTarget.ElementArrayBuffer, ibo);
+                GL.BufferData(BufferTarget.ElementArrayBuffer, indices.Length * sizeof(ushort), indices, BufferUsageHint.StaticDraw);
+            }
+
+            float[] vertices = BuildVertexData(model, layout, ambientRgbas, terrainLights);
+            if (vertices.Length > 0)
+            {
+                GL.GenBuffers(1, out vbo);
+                GL.BindBuffer(BufferTarget.ArrayBuffer, vbo);
+                GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * sizeof(float), vertices, BufferUsageHint.StaticDraw);
+            }
+
+            SetupVertexAttribPointers(layout);
+
+            List<ModelGPUData?> subModels = new List<ModelGPUData?>();
+            for (int i = 0; i < model.GetSubModelCount(); i++)
+            {
+                Model? subModel = model.GetSubModel(i);
+                subModels.Add(subModel == null ? null : Create(subModel, layout));
+            }
+
+            return new ModelGPUData(model, vao, vbo, ibo, subModels);
+        }
+
+        private static float[] BuildVertexData(Model model, ModelGPULayout layout, byte[]? ambientRgbas, List<int>? terrainLights)
+        {
+            float[] source = model.GetVertices();
+            if (layout == ModelGPULayout.Static || layout == ModelGPULayout.Animated)
+            {
+                if (layout == ModelGPULayout.Static) return source;
+
+                uint[] boneIds = model.vertexBoneIds;
+                uint[] boneWeights = model.vertexBoneWeights;
+                float[] result = new float[source.Length + boneIds.Length + boneWeights.Length];
+                for (int i = 0; i < source.Length / 8; i++)
+                {
+                    CopyVertex(source, result, i, 10);
+                    result[10 * i + 8] = BitConverter.UInt32BitsToSingle(boneIds[i]);
+                    result[10 * i + 9] = BitConverter.UInt32BitsToSingle(boneWeights[i]);
+                }
+                return result;
+            }
+
+            int stride = layout == ModelGPULayout.Terrain ? 10 : 9;
+            float[] fullData = new float[source.Length / 8 * stride];
+            for (int i = 0; i < source.Length / 8; i++)
+            {
+                CopyVertex(source, fullData, i, stride);
+                if (layout == ModelGPULayout.Terrain)
+                {
+                    fullData[stride * i + 8] = ambientRgbas != null && i * 4 < ambientRgbas.Length
+                        ? BitConverter.ToSingle(ambientRgbas, i * 4) : 0.0f;
+                    fullData[stride * i + 9] = terrainLights != null && i < terrainLights.Count
+                        ? terrainLights[i] : 0.0f;
+                }
+                else
+                {
+                    fullData[stride * i + 8] = ambientRgbas != null && i * 4 < ambientRgbas.Length
+                        ? BitConverter.ToSingle(ambientRgbas, i * 4) : 0.0f;
+                }
+            }
+            return fullData;
+        }
+
+        private static void CopyVertex(float[] source, float[] destination, int index, int stride)
+        {
+            for (int j = 0; j < 8; j++) destination[stride * index + j] = source[8 * index + j];
+        }
+
+        private static void SetupVertexAttribPointers(ModelGPULayout layout)
+        {
+            switch (layout)
+            {
+                case ModelGPULayout.Terrain:
+                    GLUtil.ActivateNumberOfVertexAttribArrays(5);
+                    GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 40, 0);
+                    GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, 40, 12);
+                    GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, 40, 24);
+                    GL.VertexAttribPointer(3, 4, VertexAttribPointerType.UnsignedByte, true, 40, 32);
+                    GL.VertexAttribPointer(4, 1, VertexAttribPointerType.Float, false, 40, 36);
+                    break;
+                case ModelGPULayout.Tie:
+                    GLUtil.ActivateNumberOfVertexAttribArrays(4);
+                    GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 36, 0);
+                    GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, 36, 12);
+                    GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, 36, 24);
+                    GL.VertexAttribPointer(3, 4, VertexAttribPointerType.UnsignedByte, true, 36, 32);
+                    break;
+                case ModelGPULayout.Animated:
+                    GLUtil.ActivateNumberOfVertexAttribArrays(5);
+                    GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 40, 0);
+                    GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, 40, 12);
+                    GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, 40, 24);
+                    GL.VertexAttribPointer(3, 4, VertexAttribPointerType.UnsignedByte, false, 40, 32);
+                    GL.VertexAttribPointer(4, 4, VertexAttribPointerType.UnsignedByte, true, 40, 36);
+                    break;
+                default:
+                    GLUtil.ActivateNumberOfVertexAttribArrays(3);
+                    GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 32, 0);
+                    GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, 32, 12);
+                    GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, 32, 24);
+                    break;
+            }
+        }
+
+        internal void Dispose()
+        {
+            foreach (ModelGPUData? subModel in subModels) subModel?.Dispose();
+            if (ibo != 0) GL.DeleteBuffer(ibo);
+            if (vbo != 0) GL.DeleteBuffer(vbo);
+            GL.DeleteVertexArray(vao);
+        }
+    }
+
+    public sealed class ModelGPUDataCache : IDisposable
+    {
+        private readonly Dictionary<CacheKey, ModelGPUData> data = new Dictionary<CacheKey, ModelGPUData>();
+
+        internal ModelGPUData Acquire(Model model, ModelGPULayout layout, string instanceKey = "", byte[]? ambientRgbas = null, List<int>? terrainLights = null)
+        {
+            CacheKey key = new CacheKey(model, layout, instanceKey);
+            if (!data.TryGetValue(key, out ModelGPUData? gpuData))
+            {
+                gpuData = ModelGPUData.Create(model, layout, ambientRgbas, terrainLights);
+                data.Add(key, gpuData);
+            }
+            gpuData.References++;
+            return gpuData;
+        }
+
+        internal void Release(ModelGPUData? gpuData)
+        {
+            if (gpuData == null) return;
+            CacheKey? key = null;
+            foreach (KeyValuePair<CacheKey, ModelGPUData> pair in data)
+            {
+                if (ReferenceEquals(pair.Value, gpuData)) { key = pair.Key; break; }
+            }
+            if (key == null) return;
+            gpuData.References--;
+            if (gpuData.References <= 0)
+            {
+                gpuData.Dispose();
+                data.Remove(key.Value);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (ModelGPUData gpuData in data.Values) gpuData.Dispose();
+            data.Clear();
+        }
+
+        private readonly struct CacheKey : IEquatable<CacheKey>
+        {
+            private readonly Model model;
+            private readonly ModelGPULayout layout;
+            private readonly string instanceKey;
+
+            internal CacheKey(Model model, ModelGPULayout layout, string instanceKey)
+            {
+                this.model = model;
+                this.layout = layout;
+                this.instanceKey = instanceKey;
+            }
+
+            public bool Equals(CacheKey other) => ReferenceEquals(model, other.model) && layout == other.layout && instanceKey == other.instanceKey;
+            public override bool Equals(object? obj) => obj is CacheKey other && Equals(other);
+            public override int GetHashCode() => HashCode.Combine(RuntimeHelpers.GetHashCode(model), layout, instanceKey);
+        }
+    }
+}

--- a/Replanetizer/Renderer/ModelGpuDataCache.cs
+++ b/Replanetizer/Renderer/ModelGpuDataCache.cs
@@ -21,15 +21,24 @@ namespace Replanetizer.Renderer
         internal readonly int vbo;
         internal readonly int ibo;
         internal readonly List<ModelGPUData?> subModels;
+        internal readonly int metalVao;
+        internal readonly int metalVbo;
+        internal readonly int metalIbo;
+        internal readonly int metalIndexCount;
         internal int References { get; set; }
 
-        private ModelGPUData(Model model, int vao, int vbo, int ibo, List<ModelGPUData?> subModels)
+        private ModelGPUData(Model model, int vao, int vbo, int ibo, List<ModelGPUData?> subModels,
+            int metalVao, int metalVbo, int metalIbo, int metalIndexCount)
         {
             this.model = model;
             this.vao = vao;
             this.vbo = vbo;
             this.ibo = ibo;
             this.subModels = subModels;
+            this.metalVao = metalVao;
+            this.metalVbo = metalVbo;
+            this.metalIbo = metalIbo;
+            this.metalIndexCount = metalIndexCount;
         }
 
         internal static ModelGPUData Create(Model model, ModelGPULayout layout, byte[]? ambientRgbas = null, List<int>? terrainLights = null)
@@ -66,7 +75,86 @@ namespace Replanetizer.Renderer
                 subModels.Add(subModel == null ? null : Create(subModel, layout));
             }
 
-            return new ModelGPUData(model, vao, vbo, ibo, subModels);
+            int metalVao = 0;
+            int metalVbo = 0;
+            int metalIbo = 0;
+            int metalIndexCount = 0;
+            if (model is MetalModel metalModel && metalModel.metalIndexBuffer.Length > 0
+                && metalModel.metalVertexBuffer.Length > 0
+                && (layout != ModelGPULayout.Animated
+                    || (metalModel.metalVertexBoneIds.Length >= metalModel.metalVertexCount
+                        && metalModel.metalVertexBoneWeights.Length >= metalModel.metalVertexCount)))
+            {
+                CreateMetalBuffers(metalModel, layout, out metalVao, out metalVbo, out metalIbo, out metalIndexCount);
+            }
+
+            return new ModelGPUData(model, vao, vbo, ibo, subModels,
+                metalVao, metalVbo, metalIbo, metalIndexCount);
+        }
+
+        private static void CreateMetalBuffers(Model model, ModelGPULayout layout, out int vao, out int vbo, out int ibo, out int indexCount)
+        {
+            MetalModel metalModel = (MetalModel) model;
+            vao = 0;
+            vbo = 0;
+            ibo = 0;
+            indexCount = metalModel.metalIndexBuffer.Length;
+
+            GL.GenVertexArrays(1, out vao);
+            GL.BindVertexArray(vao);
+
+            GL.GenBuffers(1, out ibo);
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, ibo);
+            GL.BufferData(BufferTarget.ElementArrayBuffer,
+                metalModel.metalIndexBuffer.Length * sizeof(ushort), metalModel.metalIndexBuffer, BufferUsageHint.StaticDraw);
+
+            float[] vertices = BuildMetalVertexData(metalModel, layout);
+            GL.GenBuffers(1, out vbo);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, vbo);
+            GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * sizeof(float), vertices, BufferUsageHint.StaticDraw);
+
+            SetupMetalVertexAttribPointers(layout);
+        }
+
+        private static float[] BuildMetalVertexData(MetalModel model, ModelGPULayout layout)
+        {
+            int vertexCount = model.metalVertexBuffer.Length / 8;
+            bool animated = layout == ModelGPULayout.Animated;
+            int stride = animated ? 10 : 8;
+            float[] result = new float[vertexCount * stride];
+            for (int i = 0; i < vertexCount; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    result[i * stride + j] = model.metalVertexBuffer[i * 8 + j];
+                }
+
+                if (animated)
+                {
+                    result[i * stride + 8] = BitConverter.UInt32BitsToSingle(model.metalVertexBoneIds[i]);
+                    result[i * stride + 9] = BitConverter.UInt32BitsToSingle(model.metalVertexBoneWeights[i]);
+                }
+            }
+            return result;
+        }
+
+        private static void SetupMetalVertexAttribPointers(ModelGPULayout layout)
+        {
+            if (layout == ModelGPULayout.Animated)
+            {
+                GLUtil.ActivateNumberOfVertexAttribArrays(5);
+                GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 40, 0);
+                GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, 40, 12);
+                GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, 40, 24);
+                GL.VertexAttribPointer(3, 4, VertexAttribPointerType.UnsignedByte, false, 40, 32);
+                GL.VertexAttribPointer(4, 4, VertexAttribPointerType.UnsignedByte, true, 40, 36);
+                return;
+            }
+
+            GLUtil.ActivateNumberOfVertexAttribArrays(3);
+            GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 32, 0);
+            GL.VertexAttribPointer(1, 3, VertexAttribPointerType.Float, false, 32, 12);
+            GL.VertexAttribPointer(2, 2, VertexAttribPointerType.Float, false, 32, 24);
         }
 
         private static float[] BuildVertexData(Model model, ModelGPULayout layout, byte[]? ambientRgbas, List<int>? terrainLights)
@@ -156,6 +244,9 @@ namespace Replanetizer.Renderer
             if (ibo != 0) GL.DeleteBuffer(ibo);
             if (vbo != 0) GL.DeleteBuffer(vbo);
             GL.DeleteVertexArray(vao);
+            if (metalIbo != 0) GL.DeleteBuffer(metalIbo);
+            if (metalVbo != 0) GL.DeleteBuffer(metalVbo);
+            if (metalVao != 0) GL.DeleteVertexArray(metalVao);
         }
     }
 

--- a/Replanetizer/Renderer/RendererPayload.cs
+++ b/Replanetizer/Renderer/RendererPayload.cs
@@ -23,7 +23,8 @@ namespace Replanetizer.Renderer
             enableSkybox = true, enableTerrain = true, enableCollision = false, enableTransparency = true,
             enableDistanceCulling = true, enableFrustumCulling = true, enableFog = true, enableGameCameras = false,
             enablePointLights = false, enableEnvSamples = false, enableEnvTransitions = false, enableSoundInstances = false,
-            enableGrindPaths = false, enableMeshlessModels = false, enableAnimations = false, enableLighting = true;
+            enableGrindPaths = false, enableMeshlessModels = false, enableAnimations = false, enableLighting = true,
+            enableVisibleCulling = true;
 
             // Misc
             public bool hideCameraMoby = false;

--- a/Replanetizer/Renderer/Shader.cs
+++ b/Replanetizer/Renderer/Shader.cs
@@ -221,6 +221,18 @@ namespace Replanetizer.Renderer
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetUniform1Array(UniformName uniformName, uint[] values)
+        {
+            GLUniform? uniform = GetUniformLocation(uniformName);
+
+            if (uniform != null)
+            {
+                UseShader();
+                uniform.Set1(values.Length, values);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetUniform1(UniformName uniformName, float v)
         {
             GLUniform? uniform = GetUniformLocation(uniformName);

--- a/Replanetizer/Renderer/ShaderTable.cs
+++ b/Replanetizer/Renderer/ShaderTable.cs
@@ -19,6 +19,7 @@ namespace Replanetizer.Renderer
         public Shader animationShader;
         public Shader wireframeShader;
         public Shader splineShader;
+        public Shader resolveShader;
 
         public ShaderTable(string directory)
         {
@@ -30,6 +31,7 @@ namespace Replanetizer.Renderer
             animationShader = Shader.GetShaderFromFiles("animationShader", Path.Join(directory, "animationvs.glsl"), Path.Join(directory, "animationfs.glsl"));
             wireframeShader = Shader.GetShaderFromFiles("wireframeShader", Path.Join(directory, "wireframevs.glsl"), Path.Join(directory, "wireframefs.glsl"), Path.Join(directory, "wireframegs.glsl"));
             splineShader = Shader.GetShaderFromFiles("splineShader", Path.Join(directory, "splinevs.glsl"), Path.Join(directory, "splinefs.glsl"), Path.Join(directory, "splinegs.glsl"));
+            resolveShader = Shader.GetShaderFromFiles("resolveShader", Path.Join(directory, "resolvevs.glsl"), Path.Join(directory, "resolvefs.glsl"));
         }
 
         public void Dispose()
@@ -42,6 +44,7 @@ namespace Replanetizer.Renderer
             animationShader?.Dispose();
             wireframeShader?.Dispose();
             splineShader?.Dispose();
+            resolveShader?.Dispose();
         }
     }
 }

--- a/Replanetizer/Renderer/UniformName.cs
+++ b/Replanetizer/Renderer/UniformName.cs
@@ -44,7 +44,8 @@ namespace Replanetizer.Renderer
         resolution,
         useTexture,
         useLighting,
-        cameraPosition
+        cameraPosition,
+        useMetalShading
     }
 
 }

--- a/Replanetizer/Renderer/UniformName.cs
+++ b/Replanetizer/Renderer/UniformName.cs
@@ -45,7 +45,10 @@ namespace Replanetizer.Renderer
         useTexture,
         useLighting,
         cameraPosition,
-        useMetalShading
+        useMetalShading,
+        ssaaLevelLog,
+        resolveTexture,
+        resolveSsaaLevel
     }
 
 }

--- a/Replanetizer/Renderer/UniformName.cs
+++ b/Replanetizer/Renderer/UniformName.cs
@@ -23,6 +23,7 @@ namespace Replanetizer.Renderer
         mainTexture,
         blueNoiseTexture,
         worldToView,
+        viewMatrix,
         modelToWorld,
         levelObjectType,
         levelObjectNumber,

--- a/Replanetizer/Renderer/WireframeRenderer.cs
+++ b/Replanetizer/Renderer/WireframeRenderer.cs
@@ -37,8 +37,8 @@ namespace Replanetizer.Renderer
             }
         }
 
-        private static readonly Vector4 DEFAULT_COLOR = new Vector4(1.0f, 1.0f, 1.0f, 1.0f);
-        private static readonly Vector4 SELECTED_COLOR = new Vector4(1.0f, 0.0f, 1.0f, 1.0f);
+        private static readonly Vector4 DEFAULT_COLOR = new Vector4(1.0f, 1.0f, 1.0f, 0.0f);
+        private static readonly Vector4 SELECTED_COLOR = new Vector4(1.0f, 0.0f, 1.0f, 0.20f);
 
 
         private readonly ShaderTable shaderTable;
@@ -126,6 +126,9 @@ namespace Replanetizer.Renderer
 
         public override void Render(RendererPayload payload)
         {
+            GL.Enable(EnableCap.Blend);
+            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+
             foreach (WireframeCollection wireframe in wireframes)
             {
                 wireframe.Bind();
@@ -164,6 +167,8 @@ namespace Replanetizer.Renderer
                 }
 
             }
+
+            GL.Disable(EnableCap.Blend);
 
             GLUtil.CheckGlError("WireframeRenderer");
         }

--- a/Replanetizer/Replanetizer.csproj
+++ b/Replanetizer/Replanetizer.csproj
@@ -116,6 +116,12 @@
     <None Update="Shaders\fs.glsl">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Shaders\resolvefs.glsl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Shaders\resolvevs.glsl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Shaders\skyfs.glsl">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Replanetizer/Shaders/animationfs.glsl
+++ b/Replanetizer/Shaders/animationfs.glsl
@@ -1,8 +1,5 @@
 ﻿#version 330 core
 
-// MacOS seems to support this: https://www.geeks3d.com/20130611/apple-adds-opengl-4-support-in-os-x-10-9-mavericks/
-#extension GL_ARB_sample_shading : require
-
 // Interpolated values from the vertex shaders
 in vec2 UV;
 in vec3 lightColor;
@@ -20,25 +17,35 @@ uniform vec4 fogColor;
 uniform float objectBlendDistance;
 uniform int useTransparency;
 uniform int useTexture;
+uniform int ssaaLevelLog;
 
-#define BLUE_NOISE_TEXTURE_SIZE (128.0f)
 #define ONE_OVER_GOLDEN_RATIO (2654435769u) /* 0.61803398875f */
 
 bool computeDitheringDiscard(float alpha)
 {
+    if (alpha <= 0.0f)
+        return true;
+
     if (alpha >= 1.0f)
         return false;
 
-    vec2 pixel = vec2(gl_FragCoord.x, gl_FragCoord.y);
-    vec2 blueNoiseIndex = pixel / BLUE_NOISE_TEXTURE_SIZE;
-    float alphaThreshold = texture(blueNoiseTexture, blueNoiseIndex).x;
+    ivec2 internalPixel = ivec2(gl_FragCoord.xy);
+    ivec2 noiseSize = textureSize(blueNoiseTexture, 0);
+    ivec2 pixel = internalPixel.xy >> ssaaLevelLog;
+    ivec2 noisePixel = pixel % noiseSize;
+    float alphaThreshold = texelFetch(blueNoiseTexture, noisePixel, 0).x;
 
-    uint offsetIndex = uint(1 + gl_SampleID + levelObjectNumber * gl_NumSamples);
+    uint offsetIndex = uint(1 + levelObjectNumber);
 
-    float objectDitherOffset = offsetIndex * ONE_OVER_GOLDEN_RATIO;
+    float objectDitherOffset = float(offsetIndex * ONE_OVER_GOLDEN_RATIO);
     objectDitherOffset = objectDitherOffset / 0xFFFFFFFFu;
 
-    alphaThreshold = mod(alphaThreshold + objectDitherOffset, 1.0f);
+    ivec2 subpixel = internalPixel.xy & ((1 << ssaaLevelLog) - 1);
+
+    uint subpixelID = uint(subpixel.x + (1 << ssaaLevelLog) * subpixel.y);
+    float subpixelOffset = subpixelID * (1.0f / ((1 << ssaaLevelLog) * (1 << ssaaLevelLog)));
+
+    alphaThreshold = fract(alphaThreshold + objectDitherOffset + subpixelOffset);
 
     return (alphaThreshold > alpha);
 }
@@ -67,7 +74,7 @@ void main() {
     if (computeDitheringDiscard(alpha)) discard;
 
 	color.xyz = 1.5f * textureColor.xyz * lightColor * 2.0f;
-	color.w = textureColor.w;
+	color.w = 1.0f;
 
 	color.xyz = (fogColor.xyz - color.xyz) * fogBlend + color.xyz;
 

--- a/Replanetizer/Shaders/animationfs.glsl
+++ b/Replanetizer/Shaders/animationfs.glsl
@@ -17,6 +17,7 @@ uniform vec4 fogColor;
 uniform float objectBlendDistance;
 uniform int useTransparency;
 uniform int useTexture;
+uniform int useMetalShading;
 uniform int ssaaLevelLog;
 
 #define ONE_OVER_GOLDEN_RATIO (2654435769u) /* 0.61803398875f */
@@ -53,7 +54,7 @@ bool computeDitheringDiscard(float alpha)
 void main() {
 	//color of the texture at the specified UV
     vec4 textureColor;
-    if (useTexture == 1) {
+    if (useTexture != 0 || useMetalShading != 0) {
         textureColor = texture(mainTexture, UV);
     }
     else {

--- a/Replanetizer/Shaders/animationvs.glsl
+++ b/Replanetizer/Shaders/animationvs.glsl
@@ -48,6 +48,12 @@ void main() {
         normal += (bones[index] * baseNormal) * vertexBoneWeight[i];
     }
 
+    float weightSum = dot(vertexBoneWeight, vec4(1.0f));
+    if (weightSum > 0.0f) {
+        position /= weightSum;
+        normal /= weightSum;
+    }
+
 	// Output position of the vertex, in clip space : MVP * position
     vec3 worldPosition = (modelToWorld * position).xyz;
     gl_Position = worldToView * vec4(worldPosition, 1.0f);

--- a/Replanetizer/Shaders/animationvs.glsl
+++ b/Replanetizer/Shaders/animationvs.glsl
@@ -27,6 +27,7 @@ out float fogBlend;
 
 // Values that stay constant for the whole mesh.
 uniform mat4 worldToView;
+uniform mat4 viewMatrix;
 uniform mat4 modelToWorld;
 uniform mat4 bones[128];
 uniform int lightIndex;
@@ -35,31 +36,6 @@ uniform vec4 fogParams;
 uniform vec4 staticColor;
 uniform int useLighting;
 uniform int useMetalShading;
-uniform vec3 cameraPosition;
-
-vec2 computeReflectionUV(vec3 reflectionDirection)
-{
-    // Project the unit sphere onto a centered disk using an azimuthal
-    // equidistant projection. The disk radius is 0.5 in UV space.
-    float directionLength = length(reflectionDirection);
-    if (directionLength < 0.0001f)
-        return vec2(0.5f, 0.5f);
-
-    reflectionDirection /= directionLength;
-
-    float z = clamp(reflectionDirection.z, -1.0f, 1.0f);
-    float xyLength = length(reflectionDirection.xy);
-    if (xyLength < 0.0001f)
-    {
-        // The front pole is the disk center. The opposite pole has no
-        // azimuth, so place it at a stable point on the disk boundary.
-        return z >= 0.0f ? vec2(0.5f, 0.5f) : vec2(0.5f, 0.0f);
-    }
-
-    float radius = acos(z) / 3.14159265359f;
-    vec2 diskDirection = reflectionDirection.xy / xyLength;
-    return vec2(0.5f, 0.5f) + 0.5f * radius * diskDirection;
-}
 
 void main() {
     vec4 position = vec4(0.0f);
@@ -80,9 +56,8 @@ void main() {
 
 	// UV of the vertex. No special space for this one.
     if (useMetalShading != 0) {
-        vec3 viewDirection = normalize(worldPosition - cameraPosition);
-        vec3 reflectionDirection = reflect(viewDirection, normal.xyz);
-        UV = computeReflectionUV(reflectionDirection);
+        vec3 viewNormal = normalize((viewMatrix * normal).xyz);
+        UV = vec2(0.5f) + vec2(-0.5f,0.5f) * viewNormal.xy;
     }
     else {
         UV = vertexUV;

--- a/Replanetizer/Shaders/animationvs.glsl
+++ b/Replanetizer/Shaders/animationvs.glsl
@@ -34,6 +34,32 @@ uniform int useFog;
 uniform vec4 fogParams;
 uniform vec4 staticColor;
 uniform int useLighting;
+uniform int useMetalShading;
+uniform vec3 cameraPosition;
+
+vec2 computeReflectionUV(vec3 reflectionDirection)
+{
+    // Project the unit sphere onto a centered disk using an azimuthal
+    // equidistant projection. The disk radius is 0.5 in UV space.
+    float directionLength = length(reflectionDirection);
+    if (directionLength < 0.0001f)
+        return vec2(0.5f, 0.5f);
+
+    reflectionDirection /= directionLength;
+
+    float z = clamp(reflectionDirection.z, -1.0f, 1.0f);
+    float xyLength = length(reflectionDirection.xy);
+    if (xyLength < 0.0001f)
+    {
+        // The front pole is the disk center. The opposite pole has no
+        // azimuth, so place it at a stable point on the disk boundary.
+        return z >= 0.0f ? vec2(0.5f, 0.5f) : vec2(0.5f, 0.0f);
+    }
+
+    float radius = acos(z) / 3.14159265359f;
+    vec2 diskDirection = reflectionDirection.xy / xyLength;
+    return vec2(0.5f, 0.5f) + 0.5f * radius * diskDirection;
+}
 
 void main() {
     vec4 position = vec4(0.0f);
@@ -47,12 +73,20 @@ void main() {
     }
 
 	// Output position of the vertex, in clip space : MVP * position
-	gl_Position = worldToView * (modelToWorld * position);
+    vec3 worldPosition = (modelToWorld * position).xyz;
+    gl_Position = worldToView * vec4(worldPosition, 1.0f);
 
 	normal = normalize(modelToWorld * normal);
 
 	// UV of the vertex. No special space for this one.
-	UV = vertexUV;
+    if (useMetalShading != 0) {
+        vec3 viewDirection = normalize(worldPosition - cameraPosition);
+        vec3 reflectionDirection = reflect(viewDirection, normal.xyz);
+        UV = computeReflectionUV(reflectionDirection);
+    }
+    else {
+        UV = vertexUV;
+    }
 
     // Light color is precomputed on PS3 but we do it here instead.
     if (useLighting == 1) {

--- a/Replanetizer/Shaders/collisionshaderfs.glsl
+++ b/Replanetizer/Shaders/collisionshaderfs.glsl
@@ -15,17 +15,17 @@ void main() {
     vec3 N = normalize(cross(dFdy(v_worldPos), dFdx(v_worldPos)));
     vec3 lightDir = normalize(v_cameraPos - v_worldPos);
 
-    float ambient = 0.4; 
+    float ambient = 0.4;
     float diffuse = max(abs(dot(N, lightDir)), 0.0);
-    
+
     float brightness = ambient + (diffuse * 0.5);
 
     // Gray on the back sides, otherwise use material color
-    if(!gl_FrontFacing) {
-        color = vec4(0.5 * brightness, 0.5 * brightness, 0.5 * brightness, 0.7);
+    if (gl_FrontFacing) {
+        color = vec4(normalizedColor.rgb * brightness, 1.0);
     }
     else {
-        color = vec4(normalizedColor.rgb * brightness, 1.0);
+        color = vec4(vec3(0.5 * brightness), 0.7);
     }
 
     color = vec4(clamp(color.rgb, 0.0, 1.0), 1.0);

--- a/Replanetizer/Shaders/collisionshadervs.glsl
+++ b/Replanetizer/Shaders/collisionshadervs.glsl
@@ -8,13 +8,13 @@ layout(location = 1) in vec4 vertexColors;
 flat out vec4 diffuseColors;
 out float fogBlend;
 out vec3 v_worldPos;
-out vec3 v_cameraPos; 
+out vec3 v_cameraPos;
 
 // Values that stay constant for the whole mesh.
 uniform mat4 worldToView;
 uniform int useFog;
 uniform vec4 fogParams;
-uniform vec3 cameraPosition_worldspace;
+uniform vec3 cameraPosition;
 
 void main() {
     // Output position of the vertex, in clip space
@@ -23,7 +23,7 @@ void main() {
     diffuseColors = vertexColors;
 
     v_worldPos = vertexPosition_modelspace;
-    v_cameraPos = cameraPosition_worldspace;
+    v_cameraPos = cameraPosition;
 
     fogBlend = 0.0f;
 

--- a/Replanetizer/Shaders/fs.glsl
+++ b/Replanetizer/Shaders/fs.glsl
@@ -1,8 +1,5 @@
 ﻿#version 330 core
 
-// MacOS seems to support this: https://www.geeks3d.com/20130611/apple-adds-opengl-4-support-in-os-x-10-9-mavericks/
-#extension GL_ARB_sample_shading : require
-
 // Interpolated values from the vertex shaders
 in vec2 UV;
 in vec3 lightColor;
@@ -21,25 +18,35 @@ uniform vec4 fogColor;
 uniform float objectBlendDistance;
 uniform int useTransparency;
 uniform int useTexture;
+uniform int ssaaLevelLog;
 
-#define BLUE_NOISE_TEXTURE_SIZE (128.0f)
 #define ONE_OVER_GOLDEN_RATIO (2654435769u) /* 0.61803398875f */
 
 bool computeDitheringDiscard(float alpha)
 {
+    if (alpha <= 0.0f)
+        return true;
+
     if (alpha >= 1.0f)
         return false;
 
-    vec2 pixel = vec2(gl_FragCoord.x, gl_FragCoord.y);
-    vec2 blueNoiseIndex = pixel / BLUE_NOISE_TEXTURE_SIZE;
-    float alphaThreshold = texture(blueNoiseTexture, blueNoiseIndex).x;
+    ivec2 internalPixel = ivec2(gl_FragCoord.xy);
+    ivec2 noiseSize = textureSize(blueNoiseTexture, 0);
+    ivec2 pixel = internalPixel.xy >> ssaaLevelLog;
+    ivec2 noisePixel = pixel % noiseSize;
+    float alphaThreshold = texelFetch(blueNoiseTexture, noisePixel, 0).x;
 
-    uint offsetIndex = uint(1 + gl_SampleID + levelObjectNumber * gl_NumSamples);
+    uint offsetIndex = uint(1 + levelObjectNumber);
 
-    float objectDitherOffset = offsetIndex * ONE_OVER_GOLDEN_RATIO;
+    float objectDitherOffset = float(offsetIndex * ONE_OVER_GOLDEN_RATIO);
     objectDitherOffset = objectDitherOffset / 0xFFFFFFFFu;
 
-    alphaThreshold = mod(alphaThreshold + objectDitherOffset, 1.0f);
+    ivec2 subpixel = internalPixel.xy & ((1 << ssaaLevelLog) - 1);
+
+    uint subpixelID = uint(subpixel.x + (1 << ssaaLevelLog) * subpixel.y);
+    float subpixelOffset = subpixelID * (1.0f / ((1 << ssaaLevelLog) * (1 << ssaaLevelLog)));
+
+    alphaThreshold = fract(alphaThreshold + objectDitherOffset + subpixelOffset);
 
     return (alphaThreshold > alpha);
 }
@@ -83,7 +90,7 @@ void main() {
     if (computeDitheringDiscard(alpha)) discard;
 
 	color.xyz = 1.5f * textureColor.xyz * lightColor * 2.0f;
-	color.w = textureColor.w;
+	color.w = 1.0f;
 
 	color.xyz = (fogColor.xyz - color.xyz) * fogBlend + color.xyz;
 

--- a/Replanetizer/Shaders/fs.glsl
+++ b/Replanetizer/Shaders/fs.glsl
@@ -18,6 +18,7 @@ uniform vec4 fogColor;
 uniform float objectBlendDistance;
 uniform int useTransparency;
 uniform int useTexture;
+uniform int useMetalShading;
 uniform int ssaaLevelLog;
 
 #define ONE_OVER_GOLDEN_RATIO (2654435769u) /* 0.61803398875f */
@@ -69,7 +70,7 @@ bool computeDitheringDiscard(float alpha)
 void main() {
 	//color of the texture at the specified UV
     vec4 textureColor;
-    if (useTexture == 1) {
+    if (useTexture != 0 || useMetalShading != 0) {
         textureColor = texture(mainTexture, UV);
     }
     else {

--- a/Replanetizer/Shaders/resolvefs.glsl
+++ b/Replanetizer/Shaders/resolvefs.glsl
@@ -1,0 +1,24 @@
+#version 330 core
+
+uniform sampler2D resolveTexture;
+uniform int resolveSsaaLevel;
+
+layout(location = 0) out vec4 color;
+
+void main()
+{
+    ivec2 outputPixel = ivec2(gl_FragCoord.xy);
+    ivec2 sourceBase = outputPixel * resolveSsaaLevel;
+    vec3 colorSum = vec3(0.0f);
+
+    for (int y = 0; y < resolveSsaaLevel; y++)
+    {
+        for (int x = 0; x < resolveSsaaLevel; x++)
+        {
+            colorSum += texelFetch(resolveTexture, sourceBase + ivec2(x, y), 0).rgb;
+        }
+    }
+
+    float sampleCount = float(resolveSsaaLevel * resolveSsaaLevel);
+    color = vec4(colorSum / sampleCount, 1.0f);
+}

--- a/Replanetizer/Shaders/resolvevs.glsl
+++ b/Replanetizer/Shaders/resolvevs.glsl
@@ -1,0 +1,12 @@
+#version 330 core
+
+void main()
+{
+    const vec2 positions[3] = vec2[](
+        vec2(-1.0f, -1.0f),
+        vec2(3.0f, -1.0f),
+        vec2(-1.0f, 3.0f)
+    );
+
+    gl_Position = vec4(positions[gl_VertexID], 0.0f, 1.0f);
+}

--- a/Replanetizer/Shaders/vs.glsl
+++ b/Replanetizer/Shaders/vs.glsl
@@ -34,15 +34,49 @@ uniform int useFog;
 uniform vec4 fogParams;
 uniform vec4 staticColor;
 uniform int useLighting;
+uniform int useMetalShading;
+uniform vec3 cameraPosition;
+
+vec2 computeReflectionUV(vec3 reflectionDirection)
+{
+    // Project the unit sphere onto a centered disk using an azimuthal
+    // equidistant projection. The disk radius is 0.5 in UV space.
+    float directionLength = length(reflectionDirection);
+    if (directionLength < 0.0001f)
+        return vec2(0.5f, 0.5f);
+
+    reflectionDirection /= directionLength;
+
+    float z = clamp(reflectionDirection.z, -1.0f, 1.0f);
+    float xyLength = length(reflectionDirection.xy);
+    if (xyLength < 0.0001f)
+    {
+        // The front pole is the disk center. The opposite pole has no
+        // azimuth, so place it at a stable point on the disk boundary.
+        return z >= 0.0f ? vec2(0.5f, 0.5f) : vec2(0.5f, 0.0f);
+    }
+
+    float radius = acos(z) / 3.14159265359f;
+    vec2 diskDirection = reflectionDirection.xy / xyLength;
+    return vec2(0.5f, 0.5f) + 0.5f * radius * diskDirection;
+}
 
 void main() {
 	// Output position of the vertex, in clip space : MVP * position
-	gl_Position = worldToView * (modelToWorld * vec4(vertexPosition_modelspace, 1.0f));
+    vec3 worldPosition = (modelToWorld * vec4(vertexPosition_modelspace, 1.0f)).xyz;
+    gl_Position = worldToView * vec4(worldPosition, 1.0f);
 
 	vec3 normal = normalize((modelToWorld * vec4(vertexNormal, 0.0f)).xyz);
 
 	// UV of the vertex. No special space for this one.
-	UV = vertexUV;
+    if (useMetalShading != 0) {
+        vec3 viewDirection = normalize(worldPosition - cameraPosition);
+        vec3 reflectionDirection = reflect(viewDirection, normal);
+        UV = computeReflectionUV(reflectionDirection);
+    }
+    else {
+        UV = vertexUV;
+    }
 
     // Light color is precomputed on PS3 but we do it here instead.
     if (useLighting == 1) {

--- a/Replanetizer/Shaders/vs.glsl
+++ b/Replanetizer/Shaders/vs.glsl
@@ -27,6 +27,7 @@ out float fogBlend;
 
 // Values that stay constant for the whole mesh.
 uniform mat4 worldToView;
+uniform mat4 viewMatrix;
 uniform mat4 modelToWorld;
 uniform int levelObjectType;
 uniform int lightIndex;
@@ -35,31 +36,6 @@ uniform vec4 fogParams;
 uniform vec4 staticColor;
 uniform int useLighting;
 uniform int useMetalShading;
-uniform vec3 cameraPosition;
-
-vec2 computeReflectionUV(vec3 reflectionDirection)
-{
-    // Project the unit sphere onto a centered disk using an azimuthal
-    // equidistant projection. The disk radius is 0.5 in UV space.
-    float directionLength = length(reflectionDirection);
-    if (directionLength < 0.0001f)
-        return vec2(0.5f, 0.5f);
-
-    reflectionDirection /= directionLength;
-
-    float z = clamp(reflectionDirection.z, -1.0f, 1.0f);
-    float xyLength = length(reflectionDirection.xy);
-    if (xyLength < 0.0001f)
-    {
-        // The front pole is the disk center. The opposite pole has no
-        // azimuth, so place it at a stable point on the disk boundary.
-        return z >= 0.0f ? vec2(0.5f, 0.5f) : vec2(0.5f, 0.0f);
-    }
-
-    float radius = acos(z) / 3.14159265359f;
-    vec2 diskDirection = reflectionDirection.xy / xyLength;
-    return vec2(0.5f, 0.5f) + 0.5f * radius * diskDirection;
-}
 
 void main() {
 	// Output position of the vertex, in clip space : MVP * position
@@ -70,9 +46,8 @@ void main() {
 
 	// UV of the vertex. No special space for this one.
     if (useMetalShading != 0) {
-        vec3 viewDirection = normalize(worldPosition - cameraPosition);
-        vec3 reflectionDirection = reflect(viewDirection, normal);
-        UV = computeReflectionUV(reflectionDirection);
+        vec3 viewNormal = normalize((viewMatrix * vec4(normal, 0.0f)).xyz);
+        UV = vec2(0.5f) + vec2(-0.5f,0.5f) * viewNormal.xy;
     }
     else {
         UV = vertexUV;

--- a/Replanetizer/Shaders/wireframefs.glsl
+++ b/Replanetizer/Shaders/wireframefs.glsl
@@ -17,9 +17,14 @@ void main() {
     float edge_intensity = min(min(dist.x,dist.y),dist.z);
 
     if (edge_intensity > 0.01f) {
-        discard;
+        if (incolor.a == 0.0f) {
+            discard;
+        }
+
+        color = vec4(incolor.rgb, incolor.a);
+    } else {
+        color = vec4(incolor.rgb, 1.0f);
     }
 
-	color = vec4(incolor.rgb, 1.0f);
 	id = (levelObjectType << 24) | levelObjectNumber;
 }

--- a/Replanetizer/Utils/FramebufferRenderer.cs
+++ b/Replanetizer/Utils/FramebufferRenderer.cs
@@ -44,13 +44,6 @@ namespace Replanetizer.Utils
             int maxTextureSize = GL.GetInteger(GetPName.MaxTextureSize);
             if (RenderWidth > maxTextureSize || RenderHeight > maxTextureSize)
             {
-#if DEBUG
-                FramebufferErrorCode status = GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
-                if (status != FramebufferErrorCode.FramebufferComplete)
-                {
-                    LOGGER.Debug($"SSAA render size {RenderWidth}x{RenderHeight} exceeds the maximum texture size of {maxTextureSize}.");
-                }
-#endif
                 if (SSAA_LEVEL_LOG > 0)
                 {
                     SSAA_LEVEL_LOG--;
@@ -83,7 +76,6 @@ namespace Replanetizer.Utils
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, targetTexture, 0);
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2D, typeTexture, 0);
             GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, RenderbufferTarget.Renderbuffer, renderbufferID);
-            CheckFramebufferComplete(framebufferID);
 
             outputTexture = GL.GenTexture();
             GL.BindTexture(TextureTarget.Texture2D, outputTexture);
@@ -101,19 +93,7 @@ namespace Replanetizer.Utils
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, outputFramebufferID);
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, outputTexture, 0);
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2D, outputTypeTexture, 0);
-            CheckFramebufferComplete(outputFramebufferID);
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
-        }
-
-        private static void CheckFramebufferComplete(int framebuffer)
-        {
-#if DEBUG
-            FramebufferErrorCode status = GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
-            if (status != FramebufferErrorCode.FramebufferComplete)
-            {
-                LOGGER.Debug($"Framebuffer {framebuffer} is incomplete: {status}.");
-            }
-#endif
         }
 
         public FramebufferRenderer(int width, int height, Shader resolveShader)

--- a/Replanetizer/Utils/FramebufferRenderer.cs
+++ b/Replanetizer/Utils/FramebufferRenderer.cs
@@ -6,14 +6,19 @@
 // Please see the LICENSE.md file for more details.
 
 using System;
+using Microsoft.VisualBasic.Logging;
 using OpenTK.Graphics.OpenGL;
+using Replanetizer.Renderer;
 
 namespace Replanetizer.Utils
 {
     public class FramebufferRenderer : IDisposable
     {
-        public static int MSAA_LEVEL = 8;
-        private int internalAllocatedMsaaLevel;
+        private static readonly NLog.Logger LOGGER = NLog.LogManager.GetCurrentClassLogger();
+
+        public static int SSAA_LEVEL_LOG = 1;
+        public static int SSAA_LEVEL { get { return 1 << SSAA_LEVEL_LOG; } }
+        private int internalAllocatedSsaaLevel;
 
         private bool disposed = false;
 
@@ -26,28 +31,59 @@ namespace Replanetizer.Utils
         private int outputFramebufferID;
 
         private int width, height;
+        private readonly Shader resolveShader;
+        public int RenderWidth { get; private set; }
+        public int RenderHeight { get; private set; }
 
         private void AllocateAllResources()
         {
-            internalAllocatedMsaaLevel = MSAA_LEVEL;
+            internalAllocatedSsaaLevel = SSAA_LEVEL;
+            RenderWidth = checked(width * SSAA_LEVEL);
+            RenderHeight = checked(height * SSAA_LEVEL);
+
+            int maxTextureSize = GL.GetInteger(GetPName.MaxTextureSize);
+            if (RenderWidth > maxTextureSize || RenderHeight > maxTextureSize)
+            {
+#if DEBUG
+                FramebufferErrorCode status = GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
+                if (status != FramebufferErrorCode.FramebufferComplete)
+                {
+                    LOGGER.Debug($"SSAA render size {RenderWidth}x{RenderHeight} exceeds the maximum texture size of {maxTextureSize}.");
+                }
+#endif
+                if (SSAA_LEVEL_LOG > 0)
+                {
+                    SSAA_LEVEL_LOG--;
+
+                    AllocateAllResources();
+                    return;
+                }
+
+                // If we couldn't reduce the SSAA level, just try it anyway and see what happens, there is nothing we can do at this point.
+            }
 
             targetTexture = GL.GenTexture();
-            GL.BindTexture(TextureTarget.Texture2DMultisample, targetTexture);
-            GL.TexImage2DMultisample(TextureTargetMultisample.Texture2DMultisample, MSAA_LEVEL, PixelInternalFormat.Rgb, width, height, true);
+            GL.BindTexture(TextureTarget.Texture2D, targetTexture);
+            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgb8, RenderWidth, RenderHeight, 0, PixelFormat.Rgb, PixelType.UnsignedByte, (IntPtr) 0);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Linear);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) TextureMinFilter.Linear);
 
             renderbufferID = GL.GenRenderbuffer();
             GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, renderbufferID);
-            GL.RenderbufferStorageMultisample(RenderbufferTarget.Renderbuffer, MSAA_LEVEL, RenderbufferStorage.DepthComponent, width, height);
+            GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, RenderbufferStorage.DepthComponent24, RenderWidth, RenderHeight);
 
             typeTexture = GL.GenTexture();
-            GL.BindTexture(TextureTarget.Texture2DMultisample, typeTexture);
-            GL.TexImage2DMultisample(TextureTargetMultisample.Texture2DMultisample, MSAA_LEVEL, PixelInternalFormat.R32i, width, height, true);
+            GL.BindTexture(TextureTarget.Texture2D, typeTexture);
+            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.R32i, RenderWidth, RenderHeight, 0, PixelFormat.RedInteger, PixelType.Int, (IntPtr) 0);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) TextureMagFilter.Nearest);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) TextureMinFilter.Nearest);
 
             framebufferID = GL.GenFramebuffer();
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferID);
-            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2DMultisample, targetTexture, 0);
-            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2DMultisample, typeTexture, 0);
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, targetTexture, 0);
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2D, typeTexture, 0);
             GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, RenderbufferTarget.Renderbuffer, renderbufferID);
+            CheckFramebufferComplete(framebufferID);
 
             outputTexture = GL.GenTexture();
             GL.BindTexture(TextureTarget.Texture2D, outputTexture);
@@ -65,26 +101,40 @@ namespace Replanetizer.Utils
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, outputFramebufferID);
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, outputTexture, 0);
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment1, TextureTarget.Texture2D, outputTypeTexture, 0);
+            CheckFramebufferComplete(outputFramebufferID);
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
         }
 
-        public FramebufferRenderer(int width, int height)
+        private static void CheckFramebufferComplete(int framebuffer)
+        {
+#if DEBUG
+            FramebufferErrorCode status = GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
+            if (status != FramebufferErrorCode.FramebufferComplete)
+            {
+                LOGGER.Debug($"Framebuffer {framebuffer} is incomplete: {status}.");
+            }
+#endif
+        }
+
+        public FramebufferRenderer(int width, int height, Shader resolveShader)
         {
             this.width = width;
             this.height = height;
+            this.resolveShader = resolveShader;
 
             AllocateAllResources();
         }
 
         public void RenderToTexture(Action renderFunction)
         {
-            if (internalAllocatedMsaaLevel != MSAA_LEVEL)
+            if (internalAllocatedSsaaLevel != SSAA_LEVEL)
             {
                 DeleteAllResources();
                 AllocateAllResources();
             }
 
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferID);
-            GL.Viewport(0, 0, width, height);
+            GL.Viewport(0, 0, RenderWidth, RenderHeight);
 
             DrawBuffersEnum[] buffers = { DrawBuffersEnum.ColorAttachment0, DrawBuffersEnum.ColorAttachment1 };
             GL.DrawBuffers(2, buffers);
@@ -97,14 +147,25 @@ namespace Replanetizer.Utils
 
             renderFunction();
 
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, outputFramebufferID);
+            GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
+            GL.Viewport(0, 0, width, height);
+            GL.Disable(EnableCap.DepthTest);
+            GL.Disable(EnableCap.ScissorTest);
+            GL.Disable(EnableCap.Blend);
+
+            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.BindTexture(TextureTarget.Texture2D, targetTexture);
+            resolveShader.UseShader();
+            resolveShader.SetUniform1(UniformName.resolveTexture, 0);
+            resolveShader.SetUniform1(UniformName.resolveSsaaLevel, SSAA_LEVEL);
+            GL.DrawArrays(PrimitiveType.Triangles, 0, 3);
+
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, framebufferID);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, outputFramebufferID);
-            GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
-            GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
-            GL.BlitFramebuffer(0, 0, width, height, 0, 0, width, height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Linear);
             GL.ReadBuffer(ReadBufferMode.ColorAttachment1);
             GL.DrawBuffer(DrawBufferMode.ColorAttachment1);
-            GL.BlitFramebuffer(0, 0, width, height, 0, 0, width, height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
+            GL.BlitFramebuffer(0, 0, RenderWidth, RenderHeight, 0, 0, width, height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
 
             GL.DeleteVertexArray(vao);

--- a/Replanetizer/Utils/FramebufferRenderer.cs
+++ b/Replanetizer/Utils/FramebufferRenderer.cs
@@ -6,7 +6,6 @@
 // Please see the LICENSE.md file for more details.
 
 using System;
-using Microsoft.VisualBasic.Logging;
 using OpenTK.Graphics.OpenGL;
 using Replanetizer.Renderer;
 
@@ -14,8 +13,6 @@ namespace Replanetizer.Utils
 {
     public class FramebufferRenderer : IDisposable
     {
-        private static readonly NLog.Logger LOGGER = NLog.LogManager.GetCurrentClassLogger();
-
         public static int SSAA_LEVEL_LOG = 1;
         public static int SSAA_LEVEL { get { return 1 << SSAA_LEVEL_LOG; } }
         private int internalAllocatedSsaaLevel;

--- a/Replanetizer/Utils/ImGuiController.cs
+++ b/Replanetizer/Utils/ImGuiController.cs
@@ -86,8 +86,10 @@ namespace Replanetizer.Utils
 
             GLUtil.CreateVertexBuffer("ImGui", out vertexBuffer);
             GLUtil.CreateElementBuffer("ImGui", out indexBuffer);
-            GL.NamedBufferData(vertexBuffer, vertexBufferSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
-            GL.NamedBufferData(indexBuffer, indexBufferSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, vertexBuffer);
+            GL.BufferData(BufferTarget.ArrayBuffer, vertexBufferSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, indexBuffer);
+            GL.BufferData(BufferTarget.ElementArrayBuffer, indexBufferSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
 
             RecreateFontDeviceTexture();
 
@@ -123,20 +125,18 @@ void main()
 }";
             shader = new Shader("ImGui", vertexSource, fragmentSource);
 
-            GL.VertexArrayVertexBuffer(vertexArray, 0, vertexBuffer, IntPtr.Zero, Unsafe.SizeOf<ImDrawVert>());
-            GL.VertexArrayElementBuffer(vertexArray, indexBuffer);
+            GL.BindVertexArray(vertexArray);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, vertexBuffer);
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, indexBuffer);
 
-            GL.EnableVertexArrayAttrib(vertexArray, 0);
-            GL.VertexArrayAttribBinding(vertexArray, 0, 0);
-            GL.VertexArrayAttribFormat(vertexArray, 0, 2, VertexAttribType.Float, false, 0);
+            GL.EnableVertexAttribArray(0);
+            GL.VertexAttribPointer(0, 2, VertexAttribPointerType.Float, false, Unsafe.SizeOf<ImDrawVert>(), 0);
 
-            GL.EnableVertexArrayAttrib(vertexArray, 1);
-            GL.VertexArrayAttribBinding(vertexArray, 1, 0);
-            GL.VertexArrayAttribFormat(vertexArray, 1, 2, VertexAttribType.Float, false, 8);
+            GL.EnableVertexAttribArray(1);
+            GL.VertexAttribPointer(1, 2, VertexAttribPointerType.Float, false, Unsafe.SizeOf<ImDrawVert>(), 8);
 
-            GL.EnableVertexArrayAttrib(vertexArray, 2);
-            GL.VertexArrayAttribBinding(vertexArray, 2, 0);
-            GL.VertexArrayAttribFormat(vertexArray, 2, 4, VertexAttribType.UnsignedByte, true, 16);
+            GL.EnableVertexAttribArray(2);
+            GL.VertexAttribPointer(2, 4, VertexAttribPointerType.UnsignedByte, true, Unsafe.SizeOf<ImDrawVert>(), 16);
 
             GLUtil.CheckGlError("End of ImGui setup");
         }
@@ -169,20 +169,18 @@ void main()
             {
                 frameBegun = false;
 
-                GL.VertexArrayVertexBuffer(vertexArray, 0, vertexBuffer, IntPtr.Zero, Unsafe.SizeOf<ImDrawVert>());
-                GL.VertexArrayElementBuffer(vertexArray, indexBuffer);
+                GL.BindVertexArray(vertexArray);
+                GL.BindBuffer(BufferTarget.ArrayBuffer, vertexBuffer);
+                GL.BindBuffer(BufferTarget.ElementArrayBuffer, indexBuffer);
 
-                GL.EnableVertexArrayAttrib(vertexArray, 0);
-                GL.VertexArrayAttribBinding(vertexArray, 0, 0);
-                GL.VertexArrayAttribFormat(vertexArray, 0, 2, VertexAttribType.Float, false, 0);
+                GL.EnableVertexAttribArray(0);
+                GL.VertexAttribPointer(0, 2, VertexAttribPointerType.Float, false, Unsafe.SizeOf<ImDrawVert>(), 0);
 
-                GL.EnableVertexArrayAttrib(vertexArray, 1);
-                GL.VertexArrayAttribBinding(vertexArray, 1, 0);
-                GL.VertexArrayAttribFormat(vertexArray, 1, 2, VertexAttribType.Float, false, 8);
+                GL.EnableVertexAttribArray(1);
+                GL.VertexAttribPointer(1, 2, VertexAttribPointerType.Float, false, Unsafe.SizeOf<ImDrawVert>(), 8);
 
-                GL.EnableVertexArrayAttrib(vertexArray, 2);
-                GL.VertexArrayAttribBinding(vertexArray, 2, 0);
-                GL.VertexArrayAttribFormat(vertexArray, 2, 4, VertexAttribType.UnsignedByte, true, 16);
+                GL.EnableVertexAttribArray(2);
+                GL.VertexAttribPointer(2, 4, VertexAttribPointerType.UnsignedByte, true, Unsafe.SizeOf<ImDrawVert>(), 16);
 
                 ImGui.Render();
                 RenderImDrawData(ImGui.GetDrawData());
@@ -345,7 +343,8 @@ void main()
                 if (vertexSize > vertexBufferSize)
                 {
                     int newSize = (int) Math.Max(vertexBufferSize * 1.5f, vertexSize);
-                    GL.NamedBufferData(vertexBuffer, newSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
+                    GL.BindBuffer(BufferTarget.ArrayBuffer, vertexBuffer);
+                    GL.BufferData(BufferTarget.ArrayBuffer, newSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
                     vertexBufferSize = newSize;
 
                     LOGGER.Info("Resized dear imgui vertex buffer to new size {0}", vertexBufferSize);
@@ -355,7 +354,8 @@ void main()
                 if (indexSize > indexBufferSize)
                 {
                     int newSize = (int) Math.Max(indexBufferSize * 1.5f, indexSize);
-                    GL.NamedBufferData(indexBuffer, newSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
+                    GL.BindBuffer(BufferTarget.ElementArrayBuffer, indexBuffer);
+                    GL.BufferData(BufferTarget.ElementArrayBuffer, newSize, IntPtr.Zero, BufferUsageHint.DynamicDraw);
                     indexBufferSize = newSize;
 
                     LOGGER.Info("Resized dear imgui index buffer to new size {0}", indexBufferSize);
@@ -394,10 +394,12 @@ void main()
             {
                 ImDrawListPtr cmdList = drawData.CmdLists[n];
 
-                GL.NamedBufferSubData(vertexBuffer, IntPtr.Zero, cmdList.VtxBuffer.Size * Unsafe.SizeOf<ImDrawVert>(), cmdList.VtxBuffer.Data);
+                GL.BindBuffer(BufferTarget.ArrayBuffer, vertexBuffer);
+                GL.BufferSubData(BufferTarget.ArrayBuffer, IntPtr.Zero, cmdList.VtxBuffer.Size * Unsafe.SizeOf<ImDrawVert>(), cmdList.VtxBuffer.Data);
                 GLUtil.CheckGlError($"Data Vert {n}");
 
-                GL.NamedBufferSubData(indexBuffer, IntPtr.Zero, cmdList.IdxBuffer.Size * sizeof(ushort), cmdList.IdxBuffer.Data);
+                GL.BindBuffer(BufferTarget.ElementArrayBuffer, indexBuffer);
+                GL.BufferSubData(BufferTarget.ElementArrayBuffer, IntPtr.Zero, cmdList.IdxBuffer.Size * sizeof(ushort), cmdList.IdxBuffer.Data);
                 GLUtil.CheckGlError($"Data Idx {n}");
 
                 int vtxOffset = 0;

--- a/Replanetizer/Window.cs
+++ b/Replanetizer/Window.cs
@@ -25,7 +25,10 @@ namespace Replanetizer
     public class Window : GameWindow
     {
         private static readonly NLog.Logger LOGGER = NLog.LogManager.GetCurrentClassLogger();
-        public string openGLString = "Unknown OpenGL Version";
+        public string glVendorString = "Unknown Vendor";
+        public string glRendererString = "Unknown Renderer";
+        public string glVersionString = "Unknown Version";
+        public string backendGraphicsString = "Unknown Backend";
 
         private ImGuiController? controller;
         private List<Frame> openFrames;
@@ -54,8 +57,11 @@ namespace Replanetizer
         {
             base.OnLoad();
 
-            openGLString = "OpenGL " + GL.GetString(StringName.Version);
-            Title = String.Format("Replanetizer ({0})", openGLString);
+            glVendorString = GL.GetString(StringName.Vendor);
+            glRendererString = GL.GetString(StringName.Renderer);
+            glVersionString = GL.GetString(StringName.Version);
+            backendGraphicsString = string.Format("OpenGL {0} | {1} | {2}", glVersionString, glVendorString, glRendererString);
+            Title = string.Format("Replanetizer (OpenGL {0})", glVersionString);
 
             controller = new ImGuiController(ClientSize.X, ClientSize.Y);
 


### PR DESCRIPTION
This PR introduces the rendering of metal texture configurations. The reflection behaves similarly to how it behaves in the game, however, it does not align. The metal texture configurations are also not included in the model exports as I don't yet know how to include them in a way that is useful to people.

I also replaced the MSAA implementation which relied on hardware support that was not guaranteed to be present. We now use simple SSAA. I also improved the transparency dithering which looks quite clean at 4x. 

Some parts of Replanetizer used OpenGL features that are only present through OpenGL 4.5 or extensions, I replaced these parts with OpenGL 3.3 compliant API calls.

There has also been a long standing issue with draw distances, especially noticeable with gadgets when using the RPCS3 hook. Turns out that my distance implementation was entirely based on how shrubs behave. I now incorporated proper handling of mobies which fixes all the issues that I am aware of.