### PR TITLE
Apply alpha to moby models when memory hooking

### DIFF
--- a/Replanetizer/Renderer/AnimationRenderer.cs
+++ b/Replanetizer/Renderer/AnimationRenderer.cs
@@ -45,6 +45,7 @@ namespace Replanetizer.Renderer
 
         private bool selected;
         private float blendDistance = 0.0f;
+        private float mobyAlpha = 1.0f;
 
         private List<Texture> textures;
         private Dictionary<Texture, GLTexture> textureIds;
@@ -715,6 +716,12 @@ namespace Replanetizer.Renderer
 
             UpdateVars();
 
+            mobyAlpha = 1.0f;
+            if (mob != null && mob.memory != null)
+            {
+                mobyAlpha = mob.memory.alpha / 128.0f;
+            }
+
             if (emptyModel || gpuData == null) return;
 
             if (ComputeCulling(payload.camera, payload.visibility.enableDistanceCulling, payload.visibility.enableVisibleCulling)) return;
@@ -748,6 +755,7 @@ namespace Replanetizer.Renderer
             }
             shaderTable.animationShader.SetUniform1(UniformName.lightIndex, light);
             shaderTable.animationShader.SetUniform1(UniformName.objectBlendDistance, blendDistance);
+            shaderTable.animationShader.SetUniform1(UniformName.mobyAlpha, mobyAlpha);
 
             GLTexture.blueNoiseTexture.Bind(1);
 

--- a/Replanetizer/Renderer/MeshRenderer.cs
+++ b/Replanetizer/Renderer/MeshRenderer.cs
@@ -46,6 +46,7 @@ namespace Replanetizer.Renderer
 
         private bool selected;
         private float blendDistance = 0.0f;
+        private float mobyAlpha = 1.0f;
 
         private bool renderPrepared = false;
         private bool renderPerform = true;
@@ -449,6 +450,12 @@ namespace Replanetizer.Renderer
 
             UpdateVars();
 
+            mobyAlpha = 1.0f;
+            if (modelObject is Moby moby && moby.memory != null)
+            {
+                mobyAlpha = moby.memory.alpha / 128.0f;
+            }
+
             modelRender = modelObject?.model ?? modelStandalone;
 
             if (ComputeCulling(payload.camera, payload.visibility.enableDistanceCulling, payload.visibility.enableFrustumCulling, payload.visibility.enableVisibleCulling))
@@ -599,6 +606,8 @@ namespace Replanetizer.Renderer
             shaderTable.meshShader.SetUniform4(UniformName.staticColor, ambient);
             shaderTable.meshShader.SetUniform1(UniformName.lightIndex, light);
             shaderTable.meshShader.SetUniform1(UniformName.objectBlendDistance, blendDistance);
+            shaderTable.meshShader.SetUniform1(UniformName.mobyAlpha, mobyAlpha);
+
 
             GLTexture.blueNoiseTexture.Bind(1);
 

--- a/Replanetizer/Renderer/UniformName.cs
+++ b/Replanetizer/Renderer/UniformName.cs
@@ -49,7 +49,8 @@ namespace Replanetizer.Renderer
         useMetalShading,
         ssaaLevelLog,
         resolveTexture,
-        resolveSsaaLevel
+        resolveSsaaLevel,
+        mobyAlpha
     }
 
 }

--- a/Replanetizer/Shaders/animationfs.glsl
+++ b/Replanetizer/Shaders/animationfs.glsl
@@ -19,6 +19,7 @@ uniform int useTransparency;
 uniform int useTexture;
 uniform int useMetalShading;
 uniform int ssaaLevelLog;
+uniform float mobyAlpha;
 
 #define ONE_OVER_GOLDEN_RATIO (2654435769u) /* 0.61803398875f */
 
@@ -67,6 +68,8 @@ void main() {
     if (objectBlendDistance > 0.0f) {
         alpha *= 1.0f - objectBlendDistance;
     }
+
+    alpha *= mobyAlpha;
 
     if (useTransparency != 0) {
         alpha *= textureColor.w;

--- a/Replanetizer/Shaders/fs.glsl
+++ b/Replanetizer/Shaders/fs.glsl
@@ -20,6 +20,7 @@ uniform int useTransparency;
 uniform int useTexture;
 uniform int useMetalShading;
 uniform int ssaaLevelLog;
+uniform float mobyAlpha;
 
 #define ONE_OVER_GOLDEN_RATIO (2654435769u) /* 0.61803398875f */
 
@@ -83,6 +84,7 @@ void main() {
     if ((levelObjectType == 2 || levelObjectType == 4) && objectBlendDistance > 0.0f) {
         alpha *= 1.0f - objectBlendDistance;
     }
+    alpha *= mobyAlpha;
 
     if (useTransparency != 0) {
         alpha *= textureColor.w;


### PR DESCRIPTION
<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/9437eecf-8246-4414-82f6-a44daa9c802d" />
<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/90c407a6-dda6-483a-9e52-b7824f63c492" />

Explosions and the effect where multiple ratchets are spawned when using thruster pack now looks as it should