### PR TITLE
Sync spaceship textures and body swaps

### DIFF
--- a/LibReplanetizer/Headers/SpaceshipHeader.cs
+++ b/LibReplanetizer/Headers/SpaceshipHeader.cs
@@ -14,7 +14,7 @@ namespace LibReplanetizer.Headers
     public class SpaceshipHeader
     {
         private static readonly short[][] SPACESHIP_MODEL_PAIRS = { [530, 534], [531, 535], [532, 536], [533, 537] };
-        private static readonly short[] RAC23_SPACESHIP_MODEL_IDS = { 3412, 3413, 3414 };
+        public const short RAC23_SPACESHIP_OCLASS = 3412;
 
         public int shipModelPointer;
         public short shipModelID;
@@ -27,7 +27,7 @@ namespace LibReplanetizer.Headers
         {
             if (game == GameType.RaC2 || game == GameType.RaC3)
             {
-                shipModelID = RAC23_SPACESHIP_MODEL_IDS[spaceshipNum];
+                shipModelID = RAC23_SPACESHIP_OCLASS;
                 shipModelPointer = 0;
                 return;
             }

--- a/LibReplanetizer/Level.cs
+++ b/LibReplanetizer/Level.cs
@@ -36,6 +36,12 @@ namespace LibReplanetizer
         public List<Model> gadgetModels;
         public List<Model> armorModels;
         public List<MobyModel> spaceshipModels;
+
+        public int spaceshipTextureBaseIndex = -1;
+        public List<Model> spaceshipAttachmentModels = new List<Model>();
+        public MobyModel? spaceShipRc23Model;
+        public int spaceshipBodyVariant = -1;
+
         public Collision collisionEngine;
         public List<Collision> collisionChunks;
         public List<Texture> textures;
@@ -479,35 +485,145 @@ namespace LibReplanetizer
             // The texture IDs are local to their original file, so we need to transform them
             // to the level's texture ID space.
 
-            foreach (MobyModel model in spaceshipModels)
-            {
-                mobyModels.RemoveAll(x => x.id == model.id);
-            }
+            spaceshipTextureBaseIndex = textures.Count;
 
-            foreach (MobyModel model in spaceshipModels)
+            if (game == GameType.RaC1)
             {
-                foreach (TextureConfig conf in model.textureConfig)
-                    conf.id += textures.Count;
+                foreach (MobyModel model in spaceshipModels)
+                {
+                    mobyModels.RemoveAll(x => x.id == model.id);
+                }
+
+                foreach (MobyModel model in spaceshipModels)
+                {
+                    foreach (TextureConfig conf in model.textureConfig)
+                    {
+                        int variant = conf.id;
+                        if (variant < 0 || variant >= spaceshipTextures.Count)
+                            variant = 0;
+
+                        conf.id = spaceshipTextureBaseIndex + variant;
+                    }
+                }
+
+                mobyModels.AddRange(spaceshipModels);
+            }
+            else if (spaceshipModels.Count > 0)
+            {
+                foreach (MobyModel model in spaceshipModels)
+                {
+                    foreach (TextureConfig conf in model.textureConfig)
+                        conf.id = spaceshipTextureBaseIndex;
+                }
+
+                MobyModel defaultShipModel = spaceshipModels[0];
+
+                spaceShipRc23Model = (MobyModel?) mobyModels.Find(x => x.id == SpaceshipHeader.RAC23_SPACESHIP_OCLASS);
+
+                if (spaceShipRc23Model == null)
+                {
+                    spaceShipRc23Model = new MobyModel { id = SpaceshipHeader.RAC23_SPACESHIP_OCLASS };
+                    mobyModels.Add(spaceShipRc23Model);
+                }
+
+                spaceShipRc23Model.ReplaceMeshData(defaultShipModel);
+                spaceshipBodyVariant = 0;
             }
 
             List<short> spaceshipAttachmentModelIDs = SpaceshipParser.GetAllSpaceshipAttachmentModelIDs(game);
+            spaceshipAttachmentModels.Clear();
+
             foreach (short modelID in spaceshipAttachmentModelIDs)
             {
                 Model? model = mobyModels.Find(x => x.id == modelID);
 
                 if (model != null)
                 {
-                    // The texture IDs are negative. Since we don't know what that means, we just plain override the ID.
                     foreach (TextureConfig conf in model.textureConfig)
-                        conf.id = textures.Count;
+                        conf.id = spaceshipTextureBaseIndex;
+
+                    spaceshipAttachmentModels.Add(model);
                 }
             }
-
-            mobyModels.AddRange(spaceshipModels);
 
             textures.AddRange(spaceshipTextures);
 
             emplacedState = true;
+        }
+
+        public bool SetSpaceshipTextureVariant(Model shipModel, int variant)
+        {
+            if (!emplacedState) return false;
+            if (spaceshipTextureBaseIndex < 0) return false;
+            if (variant < 0 || variant >= spaceshipTextures.Count) return false;
+
+            bool isKnownModel = ReferenceEquals(shipModel, spaceShipRc23Model)
+                || spaceshipModels.Contains(shipModel)
+                || spaceshipAttachmentModels.Contains(shipModel);
+
+            if (!isKnownModel) return false;
+
+            int newId = spaceshipTextureBaseIndex + variant;
+            bool changed = false;
+
+            foreach (TextureConfig conf in shipModel.textureConfig)
+            {
+                if (conf.id != newId)
+                {
+                    conf.id = newId;
+                    changed = true;
+                }
+            }
+
+            return changed;
+        }
+        public bool SetSpaceshipTextureVariantForWholeShip(int variant)
+        {
+            IEnumerable<Model> targets;
+
+            if (spaceShipRc23Model != null)
+                targets = new[] { spaceShipRc23Model };
+            else
+                targets = spaceshipModels;
+
+            bool changed = false;
+            foreach (Model model in targets.Concat(spaceshipAttachmentModels))
+            {
+                changed |= SetSpaceshipTextureVariant(model, variant);
+            }
+
+            return changed;
+        }
+        public int GetSpaceshipTextureVariant(Model shipModel)
+        {
+            if (!emplacedState) return -1;
+            if (spaceshipTextureBaseIndex < 0) return -1;
+            if (shipModel.textureConfig.Count == 0) return -1;
+
+            int variant = shipModel.textureConfig[0].id - spaceshipTextureBaseIndex;
+            if (variant < 0 || variant >= spaceshipTextures.Count) return -1;
+
+            return variant;
+        }
+        public bool SetSpaceshipBodyVariant(int bodyVariant)
+        {
+            bool canApply = emplacedState
+                && spaceShipRc23Model != null
+                && bodyVariant >= 0 && bodyVariant < spaceshipModels.Count
+                && bodyVariant != spaceshipBodyVariant;
+
+            if (!canApply)
+                return false;
+
+            int currentTextureVariant = GetSpaceshipTextureVariant(spaceShipRc23Model!);
+
+            spaceShipRc23Model!.ReplaceMeshData(spaceshipModels[bodyVariant]);
+            spaceshipBodyVariant = bodyVariant;
+
+            if (currentTextureVariant >= 0)
+                SetSpaceshipTextureVariant(spaceShipRc23Model, currentTextureVariant);
+
+            return true;
         }
 
         public void Dispose()

--- a/LibReplanetizer/Parsers/SpaceshipParser.cs
+++ b/LibReplanetizer/Parsers/SpaceshipParser.cs
@@ -89,6 +89,7 @@ namespace LibReplanetizer.Parsers
                         models.Add(cockpitModel);
                         textures.AddRange(fileTextures);
                     }
+                    else shipModel.id = (short) (SpaceshipHeader.RAC23_SPACESHIP_OCLASS + models.Count);
                     models.Add(shipModel);
                 }
             }

--- a/Replanetizer/MemoryHook/MemoryAddresses.cs
+++ b/Replanetizer/MemoryHook/MemoryAddresses.cs
@@ -17,5 +17,7 @@ namespace Replanetizer.MemoryHook
         internal long skybox;
         internal long planetId;
         internal long levelFrames;
+        internal long spaceShipTexId;
+        internal long spaceShipBodyId;
     }
 }

--- a/Replanetizer/MemoryHook/MemoryHookHandle.cs
+++ b/Replanetizer/MemoryHook/MemoryHookHandle.cs
@@ -40,6 +40,8 @@ namespace Replanetizer.MemoryHook
             public int mobyCount;
             public int frameNumber;
             public int readerCount;
+            public int spaceshipTexId = -1;
+            public int spaceshipBodyId = -1;
         }
 
         private const int SNAPSHOT_COUNT = 3;
@@ -56,6 +58,8 @@ namespace Replanetizer.MemoryHook
         private readonly byte[] CUTSCENE_CAMERA_FRAME_BUFFER = new byte[CUTSCENE_CAMERA_FRAME_SIZE];
         private readonly byte[] MOBY_TABLE_DATA_BUFFER = new byte[MOBY_TABLE_DATA_SIZE];
         private readonly byte[] FRAME_DATA_BUFFER = new byte[sizeof(int)];
+        private readonly byte[] SPACESHIP_TEX_ID_BUFFER = new byte[sizeof(int)];
+        private readonly byte[] SPACESHIP_BODY_ID_BUFFER = new byte[sizeof(int)];
         private byte[] MOBY_DATA_BUFFER = Array.Empty<byte>();
         private Thread? SNAPSHOT_THREAD;
         private volatile bool STOP_SNAPSHOT_THREAD;
@@ -88,7 +92,9 @@ namespace Replanetizer.MemoryHook
                     {
                         moby = 0x3015927B0,
                         camera = 0x30146E3C0,
-                        levelFrames = 0x30156B070
+                        levelFrames = 0x30156B070,
+                        spaceShipTexId = 0x30147a220,
+                        spaceShipBodyId = 0x30147a208
                     };
                     break;
                 case 3:
@@ -96,7 +102,9 @@ namespace Replanetizer.MemoryHook
                     {
                         moby = 0x300F22260,
                         camera = 0x300D6B400,
-                        levelFrames = 0x301A70B30
+                        levelFrames = 0x301A70B30,
+                        spaceShipTexId = 0x300d990e0,
+                        spaceShipBodyId = 0x300d990c8
                     };
                     break;
                 default:
@@ -205,11 +213,37 @@ namespace Replanetizer.MemoryHook
             {
                 UpdateMobys(snapshot, level, renderer);
                 UpdateCamera(snapshot, camera);
+
+                UpdateSpaceShip(snapshot, level); 
             }
             finally
             {
                 ReleaseSnapshot(snapshot);
             }
+        }
+
+        private int lastAppliedSpaceshipTexId = -1;
+        private int lastAppliedSpaceshipBodyId = -1;
+
+        private int ApplyIfChanged(int newId, int lastApplied, int count, Action<int> apply)
+        {
+            if (newId < 0 || newId >= count || newId == lastApplied)
+                return lastApplied;
+
+            apply(newId);
+            return newId;
+        }
+
+        private void UpdateSpaceShip(MemorySnapshot snapshot, Level level)
+        {
+            if (ADDRESSES == null || !level.emplacedState)
+                return;
+
+            lastAppliedSpaceshipBodyId = ApplyIfChanged(snapshot.spaceshipBodyId, lastAppliedSpaceshipBodyId, level.spaceshipModels.Count,
+                id => level.SetSpaceshipBodyVariant(id));
+
+            lastAppliedSpaceshipTexId = ApplyIfChanged(snapshot.spaceshipTexId, lastAppliedSpaceshipTexId, level.spaceshipTextures.Count,
+                id => level.SetSpaceshipTextureVariantForWholeShip(id));
         }
 
         public int GetLevelFrameNumber()
@@ -432,6 +466,16 @@ namespace Replanetizer.MemoryHook
 
                 snapshot.camera.position = cameraPosition;
                 snapshot.camera.rotation = cameraRotation;
+
+                // Read spaceship vals
+                if (ADDRESSES.spaceShipTexId != 0 && ADDRESSES.spaceShipBodyId != 0)
+                {
+                    if (ReadProcessBytes(ADDRESSES.spaceShipTexId, SPACESHIP_TEX_ID_BUFFER))
+                        snapshot.spaceshipTexId = ReadInt(SPACESHIP_TEX_ID_BUFFER, 0);
+
+                    if (ReadProcessBytes(ADDRESSES.spaceShipBodyId, SPACESHIP_BODY_ID_BUFFER))
+                        snapshot.spaceshipBodyId = ReadInt(SPACESHIP_BODY_ID_BUFFER, 0);
+                }
 
                 while (snapshot.mobyMemory.Count < mobyCount)
                 {


### PR DESCRIPTION
This PR adds support for texture swapping and model swapping the spaceship in RaC2 and RaC3 when their states change ingame.
<img width="658" height="324" alt="image" src="https://github.com/user-attachments/assets/0b937b55-fbaa-48cc-b51d-7fc86d7cc90b" />
